### PR TITLE
Implement steady state solver using LinearSolve.jl and eigen

### DIFF
--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -1,26 +1,92 @@
 export steadystate, steadystate_floquet
-export SteadyStateSolver, SteadyStateDirectSolver
+export SteadyStateSolver, SteadyStateLinearSolver, SteadyStateEigenSolver, SteadyStateDirectSolver
 
 abstract type SteadyStateSolver end
 
 struct SteadyStateDirectSolver <: SteadyStateSolver end
+struct SteadyStateEigenSolver <: SteadyStateSolver end
+Base.@kwdef struct SteadyStateLinearSolver{MT<:Union{LinearSolve.SciMLLinearSolveAlgorithm, Nothing}} <: SteadyStateSolver 
+    alg::MT = nothing
+    Pl::Union{Function, Nothing} = nothing
+    Pr::Union{Function, Nothing} = nothing
+end
 
 function steadystate(
     L::QuantumObject{<:AbstractArray{T},SuperOperatorQuantumObject};
-    solver::SteadyStateSolver = SteadyStateDirectSolver(),
+    solver::SteadyStateSolver = SteadyStateLinearSolver(),
+    kwargs...,
 ) where {T}
-    return _steadystate(L, solver)
+    return _steadystate(L, solver; kwargs...)
 end
 
 function steadystate(
     H::QuantumObject{<:AbstractArray{T},OpType},
-    c_ops::Vector,
-    solver::SteadyStateSolver = SteadyStateDirectSolver(),
+    c_ops::AbstractVector;
+    solver::SteadyStateSolver = SteadyStateLinearSolver(),
+    kwargs...,
 ) where {T,OpType<:Union{OperatorQuantumObject,SuperOperatorQuantumObject}}
     L = liouvillian(H, c_ops)
 
-    return steadystate(L, solver = solver)
+    return steadystate(L; solver = solver, kwargs...)
 end
+
+function _steadystate(
+    L::QuantumObject{<:AbstractArray{T},SuperOperatorQuantumObject},
+    solver::SteadyStateLinearSolver;
+    kwargs...,
+) where {T}
+    L_tmp = L.data
+    N = prod(L.dims)
+    weight = norm(L_tmp, 1) / length(L_tmp)
+
+    v0 = _get_dense_similar(L_tmp, N^2)
+    fill!(v0, 0)
+    allowed_setindex!(v0, weight, 1) # Because scalar indexing is not allowed on GPU arrays
+
+    idx_range = collect(1:N)
+    rows = _get_dense_similar(L_tmp, N)
+    cols = _get_dense_similar(L_tmp, N)
+    datas = _get_dense_similar(L_tmp, N)
+    fill!(rows, 1)
+    copyto!(cols, N .* (idx_range .- 1) .+ idx_range)
+    fill!(datas, weight)
+    Tn = sparse(rows, cols, datas, N^2, N^2)
+    L_tmp = L_tmp + Tn
+    
+    (haskey(kwargs, :Pl) || haskey(kwargs, :Pr)) && error("The use of preconditioners must be defined in the solver.")
+    if !isnothing(solver.Pl)
+        kwargs = merge((; kwargs...), (Pl = solver.Pl(L_tmp),))
+    elseif isa(L_tmp, SparseMatrixCSC)
+        kwargs = merge((; kwargs...), (Pl = ilu(L_tmp, τ=0.01),))
+    end
+    !isnothing(solver.Pr) && (kwargs = merge((; kwargs...), (Pr = solver.Pr(L_tmp),)))
+
+
+    prob = LinearProblem(L_tmp, v0)
+    ρss_vec = solve(prob, solver.alg; kwargs...).u
+
+    ρss = reshape(ρss_vec, N, N)
+    ρss = (ρss + ρss') / 2 # Hermitianize
+    return QuantumObject(ρss, Operator, L.dims)
+end
+
+
+function _steadystate(
+    L::QuantumObject{<:AbstractArray{T},SuperOperatorQuantumObject},
+    solver::SteadyStateEigenSolver;
+    kwargs...,
+) where {T}    
+    N = prod(L.dims)
+
+    kwargs = merge((sigma = 1e-8, k=1), (; kwargs...))
+
+    ρss_vec = eigsolve(L; kwargs...).vectors[:, 1] 
+    ρss = reshape(ρss_vec, N, N)
+    ρss /= tr(ρss)
+    ρss = (ρss + ρss') / 2 # Hermitianize
+    return QuantumObject(ρss, Operator, L.dims)
+end
+
 
 function _steadystate(
     L::QuantumObject{<:AbstractArray{T},SuperOperatorQuantumObject},

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -13,7 +13,7 @@ end
 
 function steadystate(
     L::QuantumObject{<:AbstractArray{T},SuperOperatorQuantumObject};
-    solver::SteadyStateSolver = SteadyStateLinearSolver(),
+    solver::SteadyStateSolver = SteadyStateDirectSolver(),
     kwargs...,
 ) where {T}
     return _steadystate(L, solver; kwargs...)
@@ -22,7 +22,7 @@ end
 function steadystate(
     H::QuantumObject{<:AbstractArray{T},OpType},
     c_ops::AbstractVector;
-    solver::SteadyStateSolver = SteadyStateLinearSolver(),
+    solver::SteadyStateSolver = SteadyStateDirectSolver(),
     kwargs...,
 ) where {T,OpType<:Union{OperatorQuantumObject,SuperOperatorQuantumObject}}
     L = liouvillian(H, c_ops)

--- a/test/steady_state.jl
+++ b/test/steady_state.jl
@@ -8,8 +8,23 @@
     psi0 = fock(N, 3)
     t_l = LinRange(0, 200, 1000)
     sol_me = mesolve(H, psi0, t_l, c_ops, e_ops = e_ops, progress_bar = false)
-    ρ_ss = steadystate(H, c_ops)
-    @test abs(sol_me.expect[1, end] - expect(e_ops[1], ρ_ss)) < 1e-3
+    rho_me = sol_me.states[end]
+
+    solver = SteadyStateDirectSolver()
+    ρ_ss = steadystate(H, c_ops, solver = solver)
+    @test tracedist(rho_me, ρ_ss) < 1e-4
+
+    solver = SteadyStateLinearSolver()
+    ρ_ss = steadystate(H, c_ops, solver = solver)
+    @test tracedist(rho_me, ρ_ss) < 1e-4
+
+    solver = SteadyStateLinearSolver(alg=KrylovJL_GMRES())
+    ρ_ss = steadystate(H, c_ops, solver = solver)
+    @test tracedist(rho_me, ρ_ss) < 1e-4
+
+    solver = SteadyStateEigenSolver()
+    ρ_ss = steadystate(H, c_ops, solver = solver)
+    @test tracedist(rho_me, ρ_ss) < 1e-4
 
     H = a_d * a
     H_t = 0.1 * (a + a_d)

--- a/test/steady_state.jl
+++ b/test/steady_state.jl
@@ -18,7 +18,7 @@
     ρ_ss = steadystate(H, c_ops, solver = solver)
     @test tracedist(rho_me, ρ_ss) < 1e-4
 
-    solver = SteadyStateLinearSolver(alg=KrylovJL_GMRES())
+    solver = SteadyStateLinearSolver(alg = KrylovJL_GMRES())
     ρ_ss = steadystate(H, c_ops, solver = solver)
     @test tracedist(rho_me, ρ_ss) < 1e-4
 


### PR DESCRIPTION
The goal of this pull request is to make a step forward in the direction of fixing issue #81

## General description

In issue #81 it has been asked to implement, along with the `SteadyStateDirectSolver` already present within the library, an iterative solver using LinearSolve.jl and an eigen solver using the already implemented `eigsolve` function.

I aimed to make the code as agnostic as possible and compatible with both dense and sparse matrices on CPU and GPU. I haven't been able to make some combinations of method-device work yet, but I think this might be a good starting point.

## Summary of the changes

I introduced, along with the already implemented `SteadyStateDirectSolver`, two new structs: `SteadyStateEigenSolver` and `SteadyStateLinearSolver`. While the first two don't require any argument when created, the latter allows specifying optional parameters (see below).

### Direct solver

No changes have been made on this side, and the code remains as originally implemented in the library. 

From a few tests, this method seems to work on sparse and dense CPU matrices and dense GPU ones, but not on sparse GPU matrices. It seems that the left-division operation on GPU matrices results in an indexing of the array, which is disabled by `CUDA.allowscalar(false)` for efficiency reasons.

### Linear solver

The `SteadyStateLinearSolver` accepts three optional keyword arguments, allowing the specification of the solving algorithm from the LinearSolve.jl package, and the left- and right- preconditioners. Since the preconditioners are applied to a matrix `L_tmp` analogous to that defined within the direct solver (see [here](https://github.com/qutip/QuantumToolbox.jl/blob/9786ddf796fa29a23766a5cba0ed6397ad34ead7/src/steadystate.jl#L45)), they are defined as functions. For example, `SteadyStateLinearSolver(alg=KrylovJL_GMRES(), Pl=L_tmp -> ilu(L_tmp, τ = 0.01))` creates a `SteadyStateLinearSolver` which uses the `KrylovJL_GMRES` algorithm defined in LinearSolve.jl and performs a preconditioning with the `ilu` method from the IncompleteLU.jl package. If no algorithm is specified, LinearSolve.jl uses a direct method analogous to our DirectSolver. Moreover, additional parameters can be given to the `solve` function of LinearSolve.jl by passing them as keyword arguments to the call to `steadystate`.

When used as a direct solver, it seems that this method only fails for sparse GPU arrays. I think the reason might be the call to `SparseMatrixCSC()` in [LinearSolve.jl](https://github.com/SciML/LinearSolve.jl/blob/270b56d864e91c2873d27c71b78115a04b824e23/src/factorization.jl#L1359C1-L1360C1), which is not implemented when the parameters are GPU arrays

When used with an iterative method (e.g., `KrylovJL_GMRES`), this solver works for all the combinations of sparse-dense matrices and both on CPU and GPU. Yet, the application to sparse GPU matrices is very slow compared to that on CPU, because no preconditioner is applied. From the [preconditioners page](https://docs.sciml.ai/LinearSolve/stable/basics/Preconditioners/) of LinearSolve.jl's docs, the only GPU-ready preconditioners are defined in KrylovPreconditioners.jl. However, taking for example the `kp_ilu0` method, this seems to be only defined for real CSC matrices ([see here](https://github.com/JuliaSmoothOptimizers/KrylovPreconditioners.jl/blob/09af6873d27e425f8a757e4c08ae5faa0fd9b664/ext/CUDA/ilu0.jl#L97)) while it would be implemented for complex ones as well if they were CSR ([here](https://github.com/JuliaSmoothOptimizers/KrylovPreconditioners.jl/blob/09af6873d27e425f8a757e4c08ae5faa0fd9b664/ext/CUDA/ilu0.jl#L83)).

### EigenSolver

The EigenSolver is nothing but an interface to the already implemented `eigsolve` function. Any keyword arguments specified in the call to the `steadystate` function will be passed to `eigsolve`.

This method seems to work only for CPU matrices, as I consistently get a _scalar indexing_ error from the `arnoldi_init` function for GPU matrices.

---

I hope this can be a good starting point to improve the support of different solving methods within the `steadystate` function. Please let me know what you think and if there is anything I could improve already. Thank you!