### PR TITLE
Introduce `commutator`, `fcreate`, and `fdestroy`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -95,6 +95,8 @@ sigmay
 sigmaz
 destroy
 create
+fdestroy
+fcreate
 eye
 qeye
 projection

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -98,6 +98,7 @@ create
 eye
 qeye
 projection
+commutator
 spre
 spost
 sprepost

--- a/src/qobj/operators.jl
+++ b/src/qobj/operators.jl
@@ -4,7 +4,19 @@ Functions for generating (common) quantum operators.
 
 export sigmam, sigmap, sigmax, sigmay, sigmaz
 export destroy, create, eye, qeye, projection
+export commutator
 export spre, spost, sprepost, lindblad_dissipator
+
+@doc raw"""
+    commutator(A::QuantumObject, B::QuantumObject; anti::Bool=false)
+
+Return the commutator (or `anti`-commutator) of the two [`QuantumObject`](@ref):
+- commutator (`anti=false`): ``AB-BA``
+- anticommutator (`anti=true`): ``AB+BA``
+
+Note that `A` and `B` must be [`Operator`](@ref)
+"""
+commutator(A::QuantumObject{<:AbstractArray{T1},OperatorQuantumObject}, B::QuantumObject{<:AbstractArray{T2},OperatorQuantumObject}; anti::Bool=false) = A * B - (-1)^anti * B * A
 
 @doc raw"""
     spre(O::QuantumObject, Id_cache=I(size(O,1)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,7 @@ core_tests = [
     "permutation.jl",
     "progress_bar.jl",
     "quantum_objects.jl",
+    "states_and_operators.jl",
     "steady_state.jl",
     "time_evolution_and_partial_trace.jl",
     "wigner.jl",

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -1,0 +1,27 @@
+@testset "States and Operators" begin
+    # test commutation relations for fermionic creation and annihilation operators
+    sites = 4
+    SIZE = 2^sites
+    dims = fill(2, sites)
+    Q_iden = Qobj(sparse(ComplexF64, LinearAlgebra.I, SIZE, SIZE); dims = dims)
+    Q_zero = Qobj(spzeros(ComplexF64, SIZE, SIZE); dims = dims)
+    for i in 0:(sites-1)
+        d_i = fdestroy(sites, i)
+        @test d_i' ≈ fcreate(sites, i)
+
+        for j in 0:(sites-1)
+            d_j = fdestroy(sites, j)
+
+            if i == j
+                @test commutator(d_i, d_j'; anti = true) ≈ Q_iden
+            else
+                @test commutator(d_i, d_j'; anti = true) ≈ Q_zero
+            end
+            @test commutator(d_i', d_j'; anti = true) ≈ Q_zero
+            @test commutator(d_i, d_j; anti = true) ≈ Q_zero
+        end
+    end
+    @test_throws ArgumentError fdestroy(0, 0)
+    @test_throws ArgumentError fdestroy(sites, -1)
+    @test_throws ArgumentError fdestroy(sites, sites)
+end


### PR DESCRIPTION
This PR introduces three functions that is list supported in Python `qutip`:

- `commutator(A, B; anti=false)`: calculate the commutator (or anti-commutator) for `A` and `B`
- `fcreate`: the fermionic creation operator (using Jordan-Wigner transformation)
- `fdestroy`: the fermionic annihilation operator (using Jordan-Wigner transformation)