### PR TITLE
Fix incorrect inputs for functions that generate states

### DIFF
--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -13,12 +13,12 @@ to specify the list of dimensions `dims` if different subsystems are present.
 """
 function fock(N::Int, pos::Int = 0; dims::Vector{Int} = [N], sparse::Bool = false)
     if sparse
-        return QuantumObject(sparsevec([pos + 1], [1.0 + 0im], N), Ket, dims)
+        array = sparsevec([pos + 1], [1.0 + 0im], N)
     else
         array = zeros(ComplexF64, N)
         array[pos+1] = 1
-        return QuantumObject(array, Ket, dims)
     end
+    return QuantumObject(array; type = Ket, dims = dims)
 end
 
 """

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -8,8 +8,9 @@ export rand_dm
 @doc raw"""
     fock(N::Int, pos::Int=0; dims::Vector{Int}=[N], sparse::Bool=false)
 
-Generates a fock state ``\ket{\psi}`` of dimension `N`. It is also possible
-to specify the list of dimensions `dims` if different subsystems are present.
+Generates a fock state ``\ket{\psi}`` of dimension `N`. 
+
+It is also possible to specify the list of dimensions `dims` if different subsystems are present.
 """
 function fock(N::Int, pos::Int = 0; dims::Vector{Int} = [N], sparse::Bool = false)
     if sparse
@@ -21,7 +22,7 @@ function fock(N::Int, pos::Int = 0; dims::Vector{Int} = [N], sparse::Bool = fals
     return QuantumObject(array; type = Ket, dims = dims)
 end
 
-"""
+@doc raw"""
     basis(N::Int, pos::Int = 0; dims::Vector{Int}=[N])
 
 Generates a fock state like [`fock`](@ref).

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -26,14 +26,15 @@ end
     basis(N::Int, pos::Int = 0; dims::Vector{Int}=[N])
 
 Generates a fock state like [`fock`](@ref).
+
+It is also possible to specify the list of dimensions `dims` if different subsystems are present.
 """
 basis(N::Int, pos::Int = 0; dims::Vector{Int} = [N]) = fock(N, pos, dims = dims)
 
 @doc raw"""
     coherent(N::Real, α::Number)
 
-Generates a coherent state ``\ket{\alpha}``, which is defined as an eigenvector of the
-bosonic annihilation operator ``\hat{a} \ket{\alpha} = \alpha \ket{\alpha}``.
+Generates a coherent state ``\ket{\alpha}``, which is defined as an eigenvector of the bosonic annihilation operator ``\hat{a} \ket{\alpha} = \alpha \ket{\alpha}``.
 """
 function coherent(N::Real, α::T) where {T<:Number}
     a = destroy(N)

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -47,7 +47,7 @@ Generates a random density matrix ``\hat{\rho}``, with the property to be positi
 
 It is also possible to specify the list of dimensions `dims` if different subsystems are present.
 """
-function rand_dm(N::Integer; dims::Vector{Int}=[N])
+function rand_dm(N::Integer; dims::Vector{Int} = [N])
     ρ = rand(ComplexF64, N, N)
     ρ *= ρ'
     ρ /= tr(ρ)

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -41,14 +41,15 @@ function coherent(N::Real, α::T) where {T<:Number}
 end
 
 @doc raw"""
-    rand_dm(N::Integer; kwargs...)
+    rand_dm(N::Integer; dims::Vector{Int}=[N])
 
-Generates a random density matrix ``\hat{\rho}``, with the property to be positive definite,
-and that ``\Tr \left[ \hat{\rho} \right] = 1``.
+Generates a random density matrix ``\hat{\rho}``, with the property to be positive semi-definite and ``\textrm{Tr} \left[ \hat{\rho} \right] = 1``.
+
+It is also possible to specify the list of dimensions `dims` if different subsystems are present.
 """
-function rand_dm(N::Integer; kwargs...)
+function rand_dm(N::Integer; dims::Vector{Int}=[N])
     ρ = rand(ComplexF64, N, N)
     ρ *= ρ'
     ρ /= tr(ρ)
-    return QuantumObject(ρ; kwargs...)
+    return QuantumObject(ρ; type = Operator, dims = dims)
 end

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -29,7 +29,7 @@ Generates a fock state like [`fock`](@ref).
 basis(N::Int, pos::Int = 0; dims::Vector{Int} = [N]) = fock(N, pos, dims = dims)
 
 @doc raw"""
-    coherent(N::Real, α::T)
+    coherent(N::Real, α::Number)
 
 Generates a coherent state ``\ket{\alpha}``, which is defined as an eigenvector of the
 bosonic annihilation operator ``\hat{a} \ket{\alpha} = \alpha \ket{\alpha}``.

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -1,4 +1,23 @@
 @testset "States and Operators" begin
+    # fock, basis
+    @test fock(4; dims = [2, 2], sparse = true) ≈ basis(4; dims = [2, 2])
+    @test_throws DimensionMismatch fock(4; dims = [2])
+
+    # rand_dm
+    ρ_AB = rand_dm(4, dims = [2, 2])
+    ρ_A = ptrace(ρ_AB, 1)
+    ρ_B = ptrace(ρ_AB, 2)
+    @test tr(ρ_AB) ≈ 1.0
+    @test tr(ρ_A) ≈ 1.0
+    @test tr(ρ_B) ≈ 1.0
+    @test ishermitian(ρ_AB) == true
+    @test ishermitian(ρ_A) == true
+    @test ishermitian(ρ_B) == true
+    @test all(eigenenergies(ρ_AB) .>= 0)
+    @test all(eigenenergies(ρ_A) .>= 0)
+    @test all(eigenenergies(ρ_B) .>= 0)
+    @test_throws DimensionMismatch rand_dm(4, dims = [2])
+
     # test commutation relations for fermionic creation and annihilation operators
     sites = 4
     SIZE = 2^sites


### PR DESCRIPTION
close #154

Summary for this PR:

- `fock` can only return `Ket`
- `basis` can only return `Ket`
- `rand_dm` can only return `Operator`
- users can specify the keyword argument `dims` for all the functions above, and will check whether the arguments are correct by directly passing them to `QuantumObject(A; type = type, dims = dims)`