### PR TITLE
Fix some typos in the docstrings

### DIFF
--- a/src/correlations.jl
+++ b/src/correlations.jl
@@ -23,8 +23,9 @@ ExponentialSeries(; tol = 1e-14, calc_steadystate = false) = ExponentialSeries(t
         c_ops::AbstractVector=[];
         kwargs...)
 
-Returns the two-times correlation function of three operators ``\hat{A}``, ``\hat{B}`` and ``\hat{C}``:
-``\expval{\hat{A}(t) \hat{B}(t + \tau) \hat{C}(t)}`` for a given initial state ``\ket{\psi_0}``.
+Returns the two-times correlation function of three operators ``\hat{A}``, ``\hat{B}`` and ``\hat{C}``: ``\expval{\hat{A}(t) \hat{B}(t + \tau) \hat{C}(t)}``
+
+for a given initial state ``\ket{\psi_0}``.
 """
 function correlation_3op_2t(
     H::QuantumObject{<:AbstractArray{T1},HOpType},
@@ -68,9 +69,10 @@ end
         reverse::Bool=false,
         kwargs...)
 
-Returns the two-times correlation function of two operators ``\hat{A}`` and ``\hat{B}``` 
-at different times ``\expval{\hat{A}(t + \tau) \hat{B}(t)}``.
-When ``reverse=true``, the correlation function is calculated as ``\expval{\hat{A}(t) \hat{B}(t + \tau)}``.
+Returns the two-times correlation function of two operators ``\hat{A}`` and ``\hat{B}`` 
+at different times: ``\expval{\hat{A}(t + \tau) \hat{B}(t)}``.
+
+When `reverse=true`, the correlation function is calculated as ``\expval{\hat{A}(t) \hat{B}(t + \tau)}``.
 """
 function correlation_2op_2t(
     H::QuantumObject{<:AbstractArray{T1},HOpType},
@@ -112,7 +114,7 @@ end
 
 Returns the one-time correlation function of two operators ``\hat{A}`` and ``\hat{B}`` 
 at different times ``\expval{\hat{A}(\tau) \hat{B}(0)}``.
-When ``reverse=true``, the correlation function is calculated as ``\expval{\hat{A}(0) \hat{B}(\tau)}``.
+When `reverse=true`, the correlation function is calculated as ``\expval{\hat{A}(0) \hat{B}(\tau)}``.
 """
 function correlation_2op_1t(
     H::QuantumObject{<:AbstractArray{T1},HOpType},
@@ -145,7 +147,11 @@ end
     solver::MySolver=ExponentialSeries(),
         kwargs...)
 
-Returns the emission spectrum ``S(\omega) = \int_{-\infty}^\infty \expval{\hat{A}(\tau) \hat{B}(0)} e^{-i \omega \tau} d \tau``.
+Returns the emission spectrum 
+
+```math
+S(\omega) = \int_{-\infty}^\infty \expval{\hat{A}(\tau) \hat{B}(0)} e^{-i \omega \tau} d \tau
+```
 """
 function spectrum(
     H::QuantumObject{MT1,HOpType},

--- a/src/qobj/arithmetic_and_attributes.jl
+++ b/src/qobj/arithmetic_and_attributes.jl
@@ -118,11 +118,11 @@ LinearAlgebra.:(/)(A::QuantumObject{<:AbstractArray{T}}, n::T1) where {T,T1<:Num
 @doc raw"""
     dot(A::QuantumObject, B::QuantumObject)
 
-Compute the dot product between two [`QuantumObject`]: ``\langle A | B \rangle``
+Compute the dot product between two [`QuantumObject`](@ref): ``\langle A | B \rangle``
 
 Note that `A` and `B` should be [`Ket`](@ref) or [`OperatorKet`](@ref)
 
-`A ⋅ B` (where `⋅` can be typed by tab-completing `\\cdot` in the REPL) is a synonym for `dot(A, B)`
+`A ⋅ B` (where `⋅` can be typed by tab-completing `\cdot` in the REPL) is a synonym for `dot(A, B)`
 """
 function LinearAlgebra.dot(
     A::QuantumObject{<:AbstractArray{T1},OpType},
@@ -217,7 +217,9 @@ LinearAlgebra.Hermitian(
 @doc raw"""
     tr(A::QuantumObject})
 
-Returns the trace of `A`.
+Returns the trace of [`QuantumObject`](@ref).
+
+Note that this function only supports for [`Operator`](@ref) and [`SuperOperator`](@ref)
 
 # Examples
 
@@ -252,8 +254,10 @@ LinearAlgebra.svdvals(A::QuantumObject{<:AbstractSparseMatrix}) = svdvals(sparse
 @doc raw"""
     norm(A::QuantumObject, p::Real)
 
-If `A` is either [`Ket`](@ref), [`Bra`](@ref), [`OperatorKet`](@ref), or [`OperatorBra`](@ref), returns the standard vector `p`-norm (default `p=2`) of `A`.
-If `A` is either [`Operator`](@ref) or [`SuperOperator`](@ref), returns [Schatten](https://en.wikipedia.org/wiki/Schatten_norm) `p`-norm (default `p=1`) of `A`.
+Return the standard vector `p`-norm or [Schatten](https://en.wikipedia.org/wiki/Schatten_norm) `p`-norm of a [`QuantumObject`](@ref) depending on the type of `A`:
+
+- If `A` is either [`Ket`](@ref), [`Bra`](@ref), [`OperatorKet`](@ref), or [`OperatorBra`](@ref), returns the standard vector `p`-norm (default `p=2`) of `A`.
+- If `A` is either [`Operator`](@ref) or [`SuperOperator`](@ref), returns [Schatten](https://en.wikipedia.org/wiki/Schatten_norm) `p`-norm (default `p=1`) of `A`.
 
 # Examples
 
@@ -590,7 +594,8 @@ tidyup(A::AbstractSparseMatrix{T}, tol::T2 = 1e-14) where {T,T2<:Real} = droptol
     tidyup!(A::QuantumObject, tol::Real=1e-14)
 
 Removes those elements of a QuantumObject `A` whose absolute value is less than `tol`.
-In-place version of [`tidyup`](@ref).
+
+Note that this function is an in-place version of [`tidyup`](@ref).
 """
 tidyup!(A::QuantumObject{<:AbstractArray{T}}, tol::T2 = 1e-14) where {T,T2<:Real} = (tidyup!(A.data, tol); A)
 tidyup!(A::AbstractArray{T}, tol::T2 = 1e-14) where {T,T2<:Real} = @. A = T(abs(A) > tol) * A
@@ -611,7 +616,7 @@ operator ``\hat{a}`` on the state ``\ket{\psi}``.
 
 It returns both ``\alpha`` and the state
 ``\ket{\delta_\psi} = \exp ( \bar{\alpha} \hat{a} - \alpha \hat{a}^\dagger )``. The
-latter corresponds to the quantum fulctuations around the coherent state ``\ket{\alpha}``.
+latter corresponds to the quantum fluctuations around the coherent state ``\ket{\alpha}``.
 """
 function get_coherence(
     ψ::QuantumObject{<:AbstractArray{T},StateOpType},

--- a/src/qobj/operators.jl
+++ b/src/qobj/operators.jl
@@ -25,43 +25,49 @@ commutator(
 ) where {T1,T2} = A * B - (-1)^anti * B * A
 
 @doc raw"""
-    spre(O::QuantumObject, Id_cache=I(size(O,1)))
+    spre(A::QuantumObject, Id_cache=I(size(A,1)))
 
-Returns the super-operator form of `O` acting on the left
-of the density matrix operator, ``\mathcal{O} \left(\hat{O}\right) \left[ \hat{\rho} \right] = \hat{O} \hat{\rho}``.
+Returns the [`SuperOperator`](@ref) form of `A` acting on the left of the density matrix operator: ``\mathcal{O} \left(\hat{A}\right) \left[ \hat{\rho} \right] = \hat{A} \hat{\rho}``.
 
-Since the density matrix is vectorized, this super-operator is always
-a matrix, obtained from ``\mathcal{O} \left(\hat{O}\right) \boldsymbol{\cdot} = \hat{\mathbb{1}} \otimes \hat{O}``.
+Since the density matrix is vectorized in [`OperatorKet`](@ref) form: ``|\hat{\rho}\rangle\rangle``, this [`SuperOperator`](@ref) is always a matrix ``\hat{\mathbb{1}} \otimes \hat{A}``, namely 
+
+```math
+\mathcal{O} \left(\hat{A}\right) \left[ \hat{\rho} \right] = \hat{\mathbb{1}} \otimes \hat{A} ~ |\hat{\rho}\rangle\rangle
+```
 
 The optional argument `Id_cache` can be used to pass a precomputed identity matrix. This can be useful when
 the same function is applied multiple times with a known Hilbert space dimension.
 """
-spre(O::QuantumObject{<:AbstractArray{T},OperatorQuantumObject}, Id_cache = I(size(O, 1))) where {T} =
-    QuantumObject(kron(Id_cache, O.data), SuperOperator, O.dims)
+spre(A::QuantumObject{<:AbstractArray{T},OperatorQuantumObject}, Id_cache = I(size(A, 1))) where {T} =
+    QuantumObject(kron(Id_cache, A.data), SuperOperator, A.dims)
 
 @doc raw"""
-    spost(O::QuantumObject)
+    spost(B::QuantumObject)
 
-Returns the super-operator form of `O` acting on the right
-of the density matrix operator, ``\mathcal{O} \left(\hat{O}\right) \left[ \hat{\rho} \right] = \hat{\rho} \hat{O}``.
+Returns the [`SuperOperator`](@ref) form of `B` acting on the right of the density matrix operator: ``\mathcal{O} \left(\hat{B}\right) \left[ \hat{\rho} \right] = \hat{\rho} \hat{B}``.
 
-Since the density matrix is vectorized, this super-operator is always
-a matrix, obtained from ``\mathcal{O} \left(\hat{O}\right) \boldsymbol{\cdot} = \hat{O}^T \otimes \hat{\mathbb{1}}``.
+Since the density matrix is vectorized in [`OperatorKet`](@ref) form: ``|\hat{\rho}\rangle\rangle``, this [`SuperOperator`](@ref) is always a matrix ``\hat{B}^T \otimes \hat{\mathbb{1}}``, namely
+
+```math
+\mathcal{O} \left(\hat{B}\right) \left[ \hat{\rho} \right] = \hat{B}^T \otimes \hat{\mathbb{1}} ~ |\hat{\rho}\rangle\rangle
+```
 
 The optional argument `Id_cache` can be used to pass a precomputed identity matrix. This can be useful when
 the same function is applied multiple times with a known Hilbert space dimension.
 """
-spost(O::QuantumObject{<:AbstractArray{T},OperatorQuantumObject}, Id_cache = I(size(O, 1))) where {T} =
-    QuantumObject(kron(sparse(transpose(sparse(O.data))), Id_cache), SuperOperator, O.dims) # TODO: fix the sparse conversion
+spost(B::QuantumObject{<:AbstractArray{T},OperatorQuantumObject}, Id_cache = I(size(B, 1))) where {T} =
+    QuantumObject(kron(sparse(transpose(sparse(B.data))), Id_cache), SuperOperator, B.dims) # TODO: fix the sparse conversion
 
 @doc raw"""
     sprepost(A::QuantumObject, B::QuantumObject)
 
-Returns the super-operator form of `A` and `B` acting on the left and the right
-of the density matrix operator respectively, ``\mathcal{O} \left( \hat{A}, \hat{B} \right) \left[ \hat{\rho} \right] = \hat{A} \hat{\rho} \hat{B}``.
+Returns the [`SuperOperator`](@ref) form of `A` and `B` acting on the left and right of the density matrix operator, respectively: ``\mathcal{O} \left( \hat{A}, \hat{B} \right) \left[ \hat{\rho} \right] = \hat{A} \hat{\rho} \hat{B}``.
 
-Since the density matrix is vectorized, this super-operator is always
-a matrix, obtained from ``\mathcal{O} \left(\hat{A}, \hat{B}\right) \boldsymbol{\cdot} = \text{spre}(A) * \text{spost}(B)``.
+Since the density matrix is vectorized in [`OperatorKet`](@ref) form: ``|\hat{\rho}\rangle\rangle``, this [`SuperOperator`](@ref) is always a matrix ``\hat{B}^T \otimes \hat{A}``, namely
+
+```math
+\mathcal{O} \left(\hat{A}, \hat{B}\right) \left[ \hat{\rho} \right] = \hat{B}^T \otimes \hat{A} ~ |\hat{\rho}\rangle\rangle = \textrm{spre}(A) * \textrm{spost}(B) ~ |\hat{\rho}\rangle\rangle
+```
 """
 sprepost(
     A::QuantumObject{<:AbstractArray{T1},OperatorQuantumObject},
@@ -71,12 +77,12 @@ sprepost(
 @doc raw"""
     lindblad_dissipator(O::QuantumObject, Id_cache=I(size(O,1))
 
-Returns the Lindblad super-operator defined as
-``
+Returns the Lindblad [`SuperOperator`](@ref) defined as
+
+```math
 \mathcal{D} \left( \hat{O} \right) \left[ \hat{\rho} \right] = \frac{1}{2} \left( 2 \hat{O} \hat{\rho} \hat{O}^\dagger - 
 \hat{O}^\dagger \hat{O} \hat{\rho} - \hat{\rho} \hat{O}^\dagger \hat{O} \right)
-``
-considering the density matrix ``\hat{\rho}`` in the vectorized form.
+```
 
 The optional argument `Id_cache` can be used to pass a precomputed identity matrix. This can be useful when
 the same function is applied multiple times with a known Hilbert space dimension.

--- a/src/qobj/quantum_object.jl
+++ b/src/qobj/quantum_object.jl
@@ -117,7 +117,7 @@ const OperatorKet = OperatorKetQuantumObject()
         dims::Vector{Int}
     end
 
-Julia struct representing any quantum operator.
+Julia struct representing any quantum objects.
 
 # Examples
 

--- a/src/qobj/quantum_object.jl
+++ b/src/qobj/quantum_object.jl
@@ -23,7 +23,7 @@ abstract type QuantumObjectType end
 @doc raw"""
     BraQuantumObject <: QuantumObjectType
 
-Constructor representing a bra state ``\bra{\psi}``.
+Constructor representing a bra state ``\langle\psi|``.
 """
 struct BraQuantumObject <: QuantumObjectType end
 Base.show(io::IO, ::BraQuantumObject) = print(io, "Bra")
@@ -31,14 +31,14 @@ Base.show(io::IO, ::BraQuantumObject) = print(io, "Bra")
 @doc raw"""
     const Bra = BraQuantumObject()
 
-A constant representing the type of [`BraQuantumObject`](@ref)
+A constant representing the type of [`BraQuantumObject`](@ref): a bra state ``\langle\psi|``
 """
 const Bra = BraQuantumObject()
 
 @doc raw"""
     KetQuantumObject <: QuantumObjectType
 
-Constructor representing a ket state ``\ket{\psi}``.
+Constructor representing a ket state ``|\psi\rangle``.
 """
 struct KetQuantumObject <: QuantumObjectType end
 Base.show(io::IO, ::KetQuantumObject) = print(io, "Ket")
@@ -46,7 +46,7 @@ Base.show(io::IO, ::KetQuantumObject) = print(io, "Ket")
 @doc raw"""
     const Ket = KetQuantumObject()
 
-A constant representing the type of [`KetQuantumObject`](@ref)
+A constant representing the type of [`KetQuantumObject`](@ref): a ket state ``|\psi\rangle``
 """
 const Ket = KetQuantumObject()
 
@@ -61,14 +61,14 @@ Base.show(io::IO, ::OperatorQuantumObject) = print(io, "Operator")
 @doc raw"""
     const Operator = OperatorQuantumObject()
 
-A constant representing the type of [`OperatorQuantumObject`](@ref)
+A constant representing the type of [`OperatorQuantumObject`](@ref): an operator ``\hat{O}``
 """
 const Operator = OperatorQuantumObject()
 
 @doc raw"""
     SuperOperatorQuantumObject <: QuantumObjectType
 
-Constructor representing a super-operator ``\hat{\mathcal{O}}``.
+Constructor representing a super-operator ``\hat{\mathcal{O}}`` acting on vectorized density operator matrices.
 """
 struct SuperOperatorQuantumObject <: QuantumObjectType end
 Base.show(io::IO, ::SuperOperatorQuantumObject) = print(io, "SuperOperator")
@@ -76,14 +76,14 @@ Base.show(io::IO, ::SuperOperatorQuantumObject) = print(io, "SuperOperator")
 @doc raw"""
     const SuperOperator = SuperOperatorQuantumObject()
 
-A constant representing the type of [`SuperOperatorQuantumObject`](@ref)
+A constant representing the type of [`SuperOperatorQuantumObject`](@ref): a super-operator ``\hat{\mathcal{O}}`` acting on vectorized density operator matrices
 """
 const SuperOperator = SuperOperatorQuantumObject()
 
 @doc raw"""
     OperatorBraQuantumObject <: QuantumObjectType
 
-Constructor representing a bra state in the super-operator formalism ``\langle\langle\rho|``.
+Constructor representing a bra state in the [`SuperOperator`](@ref) formalism ``\langle\langle\rho|``.
 """
 struct OperatorBraQuantumObject <: QuantumObjectType end
 Base.show(io::IO, ::OperatorBraQuantumObject) = print(io, "OperatorBra")
@@ -91,14 +91,14 @@ Base.show(io::IO, ::OperatorBraQuantumObject) = print(io, "OperatorBra")
 @doc raw"""
     const OperatorBra = OperatorBraQuantumObject()
 
-A constant representing the type of [`OperatorBraQuantumObject`](@ref)
+A constant representing the type of [`OperatorBraQuantumObject`](@ref): a bra state in the [`SuperOperator`](@ref) formalism ``\langle\langle\rho|``.
 """
 const OperatorBra = OperatorBraQuantumObject()
 
 @doc raw"""
     OperatorKetQuantumObject <: QuantumObjectType
 
-Constructor representing a ket state in the super-operator formalism ``|\rho\rangle\rangle``.
+Constructor representing a ket state in the [`SuperOperator`](@ref) formalism ``|\rho\rangle\rangle``.
 """
 struct OperatorKetQuantumObject <: QuantumObjectType end
 Base.show(io::IO, ::OperatorKetQuantumObject) = print(io, "OperatorKet")
@@ -106,7 +106,7 @@ Base.show(io::IO, ::OperatorKetQuantumObject) = print(io, "OperatorKet")
 @doc raw"""
     const OperatorKet = OperatorKetQuantumObject()
 
-A constant representing the type of [`OperatorKetQuantumObject`](@ref)
+A constant representing the type of [`OperatorKetQuantumObject`](@ref): a ket state in the [`SuperOperator`](@ref) formalism ``|\rho\rangle\rangle``
 """
 const OperatorKet = OperatorKetQuantumObject()
 

--- a/src/qobj/synonyms.jl
+++ b/src/qobj/synonyms.jl
@@ -11,7 +11,7 @@ export qeye
 @doc raw"""
     Qobj(A::AbstractArray; type::QuantumObjectType, dims::Vector{Int})
 
-Generate `QuantumObject`
+Generate [`QuantumObject`](@ref)
 
 Note that this functions is same as `QuantumObject(A; type=type, dims=dims)`
 """

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -241,9 +241,9 @@ end
 
 Calculates the steady state of a periodically driven system.
 Here `H_0` is the Hamiltonian or the Liouvillian of the undriven system.
-Considering a monochromatic drive at frequency ``\\omega_d``, we divide it into two parts,
+Considering a monochromatic drive at frequency ``\omega_d``, we divide it into two parts,
 `H_p` and `H_m`, where `H_p` oscillates
-as ``e^{i \\omega t}`` and `H_m` oscillates as ``e^{-i \\omega t}``.
+as ``e^{i \omega t}`` and `H_m` oscillates as ``e^{-i \omega t}``.
 There are two solvers available for this function:
 - `SSFloquetLinearSystem`: Solves the linear system of equations.
 - `SSFloquetEffectiveLiouvillian`: Solves the effective Liouvillian.
@@ -251,45 +251,53 @@ For both cases, `n_max` is the number of Fourier components to consider, and `to
 
 In the case of `SSFloquetLinearSystem`, the full linear system is solved at once:
 
-``( \mathcal{L}_0 - i n \omega_d ) \hat{\rho}_n + \mathcal{L}_1 \hat{\rho}\_{n-1} + \mathcal{L}\_{-1} \hat{\rho}\_{n+1} = 0``
+```math
+( \mathcal{L}_0 - i n \omega_d ) \hat{\rho}_n + \mathcal{L}_1 \hat{\rho}_{n-1} + \mathcal{L}_{-1} \hat{\rho}_{n+1} = 0
+```
 
 This is a tridiagonal linear system of the form
 
-``\mathbf{A} \cdot \mathbf{b} = 0``
+```math
+\mathbf{A} \cdot \mathbf{b} = 0
+```
 
 where
 
-``\mathbf{A} = \begin{pmatrix}
-\mathcal{L}\_0 - i (-n\_{\text{max}}) \omega\_{\textrm{d}} & \mathcal{L}\_{-1} & 0 & \cdots & 0 \\
-\mathcal{L}_1 & \mathcal{L}_0 - i (-n\_{\text{max}}+1) \omega\_{\textrm{d}} & \mathcal{L}\_{-1} & \cdots & 0 \\
-0 & \mathcal{L}\_1 & \mathcal{L}\_0 - i (-n\_{\text{max}}+2) \omega\_{\textrm{d}} & \cdots & 0 \\
+```math
+\mathbf{A} = \begin{pmatrix}
+\mathcal{L}_0 - i (-n_{\textrm{max}}) \omega_{\textrm{d}} & \mathcal{L}_{-1} & 0 & \cdots & 0 \\
+\mathcal{L}_1 & \mathcal{L}_0 - i (-n_{\textrm{max}}+1) \omega_{\textrm{d}} & \mathcal{L}_{-1} & \cdots & 0 \\
+0 & \mathcal{L}_1 & \mathcal{L}_0 - i (-n_{\textrm{max}}+2) \omega_{\textrm{d}} & \cdots & 0 \\
 \vdots & \vdots & \vdots & \ddots & \vdots \\
-0 & 0 & 0 & \cdots & \mathcal{L}_0 - i n\_{\text{max}} \omega\_{\textrm{d}}
-\end{pmatrix}``
+0 & 0 & 0 & \cdots & \mathcal{L}_0 - i n_{\textrm{max}} \omega_{\textrm{d}}
+\end{pmatrix}
+```
 
 and
 
-``\mathbf{b} = \begin{pmatrix}
-\hat{\rho}\_{-n_{\text{max}}} \\
-\hat{\rho}\_{-n_{\text{max}}+1} \\
+```math
+\mathbf{b} = \begin{pmatrix}
+\hat{\rho}_{-n_{\textrm{max}}} \\
+\hat{\rho}_{-n_{\textrm{max}}+1} \\
 \vdots \\
-\hat{\rho}\_{0} \\
+\hat{\rho}_{0} \\
 \vdots \\
-\hat{\rho}\_{n_{\text{max}}-1} \\
-\hat{\rho}\_{n_{\text{max}}}
-\end{pmatrix}``
+\hat{\rho}_{n_{\textrm{max}}-1} \\
+\hat{\rho}_{n_{\textrm{max}}}
+\end{pmatrix}
+```
 
 This will allow to simultaneously obtain all the ``\hat{\rho}_n``.
 
 In the case of `SSFloquetEffectiveLiouvillian`, instead, the effective Liouvillian is calculated using the matrix continued fraction method.
 
 !!! note "different return"
-    The two solvers returns different objects. The `SSFloquetLinearSystem` returns a list of `QuantumObject`, containing the density matrices for each Fourier component (`\hat{\rho}_{-n}`, with `n` from `0` to `n_max`), while the `SSFloquetEffectiveLiouvillian` returns only `\hat{\rho}_0`. 
+    The two solvers returns different objects. The `SSFloquetLinearSystem` returns a list of [`QuantumObject`](@ref), containing the density matrices for each Fourier component (``\hat{\rho}_{-n}``, with ``n`` from ``0`` to ``n_\textrm{max}``), while the `SSFloquetEffectiveLiouvillian` returns only ``\hat{\rho}_0``. 
 
 ## Arguments
 - `H_0::QuantumObject`: The Hamiltonian or the Liouvillian of the undriven system.
-- `H_p::QuantumObject`: The Hamiltonian or the Liouvillian of the part of the drive that oscillates as ``e^{i \\omega t}``.
-- `H_m::QuantumObject`: The Hamiltonian or the Liouvillian of the part of the drive that oscillates as ``e^{-i \\omega t}``.
+- `H_p::QuantumObject`: The Hamiltonian or the Liouvillian of the part of the drive that oscillates as ``e^{i \omega t}``.
+- `H_m::QuantumObject`: The Hamiltonian or the Liouvillian of the part of the drive that oscillates as ``e^{-i \omega t}``.
 - `ωd::Number`: The frequency of the drive.
 - `c_ops::AbstractVector = QuantumObject`: The optional collapse operators.
 - `n_max::Integer = 2`: The number of Fourier components to consider.

--- a/src/time_evolution/time_evolution.jl
+++ b/src/time_evolution/time_evolution.jl
@@ -118,9 +118,17 @@ end
 @doc raw"""
     liouvillian(H::QuantumObject, c_ops::AbstractVector, Id_cache=I(prod(H.dims))
 
-Construct the Liouvillian superoperator for a system Hamiltonian and a set of collapse operators:
-``\mathcal{L} \cdot = -i[\hat{H}, \cdot] + \sum_i \mathcal{D}[\hat{O}_i] \cdot``,
-where ``\mathcal{D}[\hat{O}_i] \cdot = \hat{O}_i \cdot \hat{O}_i^\dagger - \frac{1}{2} \hat{O}_i^\dagger \hat{O}_i \cdot - \frac{1}{2} \cdot \hat{O}_i^\dagger \hat{O}_i``.
+Construct the Liouvillian [`SuperOperator`](@ref) for a system Hamiltonian ``\hat{H}`` and a set of collapse operators ``\hat{O}_i``:
+
+```math
+\mathcal{L} [\cdot] = -i[\hat{H}, \cdot] + \sum_i \mathcal{D}(\hat{O}_i) [\cdot]
+```
+
+where 
+
+```math
+\mathcal{D}(\hat{O}_i) [\cdot] = \hat{O}_i [\cdot] \hat{O}_i^\dagger - \frac{1}{2} \hat{O}_i^\dagger \hat{O}_i [\cdot] - \frac{1}{2} [\cdot] \hat{O}_i^\dagger \hat{O}_i
+```
 
 The optional argument `Id_cache` can be used to pass a precomputed identity matrix. This can be useful when
 the same function is applied multiple times with a known Hilbert space dimension.


### PR DESCRIPTION
Found some typos in the function docstrings when I read through the document API page.

Also, there are some LaTeX formula that does not render correctly.