### PR TITLE
Functions for generating common quantum states

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,17 @@ using Documenter
 
 DocMeta.setdocmeta!(QuantumToolbox, :DocTestSetup, :(using QuantumToolbox); recursive = true)
 
+const MathEngine = MathJax3(
+    Dict(
+        :loader => Dict("load" => ["[tex]/physics"]),
+        :tex => Dict(
+            "inlineMath" => [["\$", "\$"], ["\\(", "\\)"]],
+            "tags" => "ams",
+            "packages" => ["base", "ams", "autoload", "physics"],
+        ),
+    )
+)
+
 const PAGES = [
     "Getting Started" => [
         "Introduction" => "index.md",
@@ -53,16 +64,8 @@ makedocs(;
         canonical = "https://qutip.github.io/QuantumToolbox.jl",
         edit_link = "main",
         assets = ["assets/favicon.ico"],
-        mathengine = MathJax3(
-            Dict(
-                :loader => Dict("load" => ["[tex]/physics"]),
-                :tex => Dict(
-                    "inlineMath" => [["\$", "\$"], ["\\(", "\\)"]],
-                    "tags" => "ams",
-                    "packages" => ["base", "ams", "autoload", "physics"],
-                ),
-            ),
-        ),
+        mathengine = MathEngine,
+        size_threshold_ignore = ["api.md"],
     )
 )
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -108,6 +108,9 @@ maximally_mixed_dm
 rand_dm
 spin_state
 spin_coherent
+bell_state
+singlet_state
+triplet_states
 sigmap
 sigmam
 sigmax

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -101,6 +101,7 @@ zero_ket
 fock
 basis
 coherent
+fock_dm
 rand_dm
 sigmap
 sigmam

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -102,6 +102,7 @@ fock
 basis
 coherent
 fock_dm
+coherent_dm
 rand_dm
 sigmap
 sigmam

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -111,6 +111,8 @@ spin_coherent
 bell_state
 singlet_state
 triplet_states
+w_state
+ghz_state
 sigmap
 sigmam
 sigmax

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -106,6 +106,7 @@ coherent_dm
 thermal_dm
 maximally_mixed_dm
 rand_dm
+spin_state
 sigmap
 sigmam
 sigmax

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -107,6 +107,7 @@ thermal_dm
 maximally_mixed_dm
 rand_dm
 spin_state
+spin_coherent
 sigmap
 sigmam
 sigmax

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -103,6 +103,7 @@ basis
 coherent
 fock_dm
 coherent_dm
+thermal_dm
 rand_dm
 sigmap
 sigmam

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -97,6 +97,7 @@ mat2vec
 ## [Generate states and operators](@id doc-API:Generate-states-and-operators)
 
 ```@docs
+zero_ket
 fock
 basis
 coherent

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -104,6 +104,7 @@ coherent
 fock_dm
 coherent_dm
 thermal_dm
+maximally_mixed_dm
 rand_dm
 sigmap
 sigmam

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -38,11 +38,11 @@ julia> entropy_vn(ρ, base=2)
 
 Mixed state:
 ```
-julia> ρ = 1 / 2 * ( ket2dm(fock(2,0)) + ket2dm(fock(2,1)) )
+julia> ρ = maximally_mixed_dm(2)
 Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=true
-2×2 Matrix{ComplexF64}:
- 0.5+0.0im  0.0+0.0im
- 0.0+0.0im  0.5+0.0im
+2×2 Diagonal{ComplexF64, Vector{ComplexF64}}:
+ 0.5-0.0im      ⋅    
+     ⋅      0.5-0.0im
 
 julia> entropy_vn(ρ, base=2)
 1.0

--- a/src/negativity.jl
+++ b/src/negativity.jl
@@ -18,7 +18,7 @@ and ``\Vert X \Vert_1=\textrm{Tr}\sqrt{X^\dagger X}`` is the trace norm.
 # Examples
 
 ```
-julia> Ψ = bell_state("00")
+julia> Ψ = bell_state(0, 0)
 Quantum Object:   type=Ket   dims=[2, 2]   size=(4,)
 4-element Vector{ComplexF64}:
  0.7071067811865475 + 0.0im

--- a/src/negativity.jl
+++ b/src/negativity.jl
@@ -18,7 +18,7 @@ and ``\Vert X \Vert_1=\textrm{Tr}\sqrt{X^\dagger X}`` is the trace norm.
 # Examples
 
 ```
-julia> Ψ = 1 / √2 * ( basis(2,0) ⊗ basis(2,0) + basis(2,1) ⊗ basis(2,1) )
+julia> Ψ = bell_state("00")
 Quantum Object:   type=Ket   dims=[2, 2]   size=(4,)
 4-element Vector{ComplexF64}:
  0.7071067811865475 + 0.0im

--- a/src/qobj/operators.jl
+++ b/src/qobj/operators.jl
@@ -178,41 +178,41 @@ Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=false
 jmat(j::Real, which::Symbol) = jmat(j, Val(which))
 jmat(j::Real) = (jmat(j, Val(:x)), jmat(j, Val(:y)), jmat(j, Val(:z)))
 function jmat(j::Real, ::Val{:x})
-    N = 2 * j
-    ((floor(N) != (N)) || (j < 0)) &&
-        throw(ArgumentError("The spin quantum number (j) j must be a non-negative integer or half-integer."))
+    J = 2 * j + 1
+    ((floor(J) != J) || (j < 0)) &&
+        throw(ArgumentError("The spin quantum number (j) must be a non-negative integer or half-integer."))
 
     σ = _jm(j)
-    return QuantumObject((σ' + σ) / 2, Operator, [Int(N + 1)])
+    return QuantumObject((σ' + σ) / 2, Operator, [Int(J)])
 end
 function jmat(j::Real, ::Val{:y})
-    N = 2 * j
-    ((floor(N) != (N)) || (j < 0)) &&
-        throw(ArgumentError("The spin quantum number (j) j must be a non-negative integer or half-integer."))
+    J = 2 * j + 1
+    ((floor(J) != J) || (j < 0)) &&
+        throw(ArgumentError("The spin quantum number (j) must be a non-negative integer or half-integer."))
 
     σ = _jm(j)
-    return QuantumObject((σ' - σ) / 2im, Operator, [Int(N + 1)])
+    return QuantumObject((σ' - σ) / 2im, Operator, [Int(J)])
 end
 function jmat(j::Real, ::Val{:z})
-    N = 2 * j
-    ((floor(N) != (N)) || (j < 0)) &&
-        throw(ArgumentError("The spin quantum number (j) j must be a non-negative integer or half-integer."))
+    J = 2 * j + 1
+    ((floor(J) != J) || (j < 0)) &&
+        throw(ArgumentError("The spin quantum number (j) must be a non-negative integer or half-integer."))
 
-    return QuantumObject(_jz(j), Operator, [Int(N + 1)])
+    return QuantumObject(_jz(j), Operator, [Int(J)])
 end
 function jmat(j::Real, ::Val{:+})
-    N = 2 * j
-    ((floor(N) != (N)) || (j < 0)) &&
-        throw(ArgumentError("The spin quantum number (j) j must be a non-negative integer or half-integer."))
+    J = 2 * j + 1
+    ((floor(J) != J) || (j < 0)) &&
+        throw(ArgumentError("The spin quantum number (j) must be a non-negative integer or half-integer."))
 
-    return QuantumObject(adjoint(_jm(j)), Operator, [Int(N + 1)])
+    return QuantumObject(adjoint(_jm(j)), Operator, [Int(J)])
 end
 function jmat(j::Real, ::Val{:-})
-    N = 2 * j
-    ((floor(N) != (N)) || (j < 0)) &&
-        throw(ArgumentError("The spin quantum number (j) j must be a non-negative integer or half-integer."))
+    J = 2 * j + 1
+    ((floor(J) != J) || (j < 0)) &&
+        throw(ArgumentError("The spin quantum number (j) must be a non-negative integer or half-integer."))
 
-    return QuantumObject(_jm(j), Operator, [Int(N + 1)])
+    return QuantumObject(_jm(j), Operator, [Int(J)])
 end
 jmat(j::Real, ::Val{T}) where {T} = throw(ArgumentError("Invalid spin operator: $(T)"))
 

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -3,7 +3,7 @@ Functions for generating (common) quantum states.
 =#
 
 export zero_ket, fock, basis, coherent
-export rand_dm
+export fock_dm, rand_dm
 
 @doc raw"""
     zero_ket(dimensions)
@@ -51,6 +51,18 @@ Generates a coherent state ``\ket{\alpha}``, which is defined as an eigenvector 
 function coherent(N::Real, α::T) where {T<:Number}
     a = destroy(N)
     return exp(α * a' - α' * a) * fock(N, 0)
+end
+
+@doc raw"""
+    fock_dm(N::Int, pos::Int=0; dims::Vector{Int}=[N], sparse::Bool=false)
+
+Density matrix representation of a Fock state.
+
+Constructed via outer product of [`fock`](@ref).
+"""
+function fock_dm(N::Int, pos::Int = 0; dims::Vector{Int} = [N], sparse::Bool = false)
+    ψ = fock(N, pos; dims = dims, sparse = sparse)
+    return ψ * ψ'
 end
 
 @doc raw"""

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -2,8 +2,20 @@
 Functions for generating (common) quantum states.
 =#
 
-export fock, basis, coherent
+export zero_ket, fock, basis, coherent
 export rand_dm
+
+@doc raw"""
+    zero_ket(dimensions)
+
+Returns a zero [`Ket`](@ref) vector with given argument `dimensions`.
+
+The `dimensions` can be either the following types:
+- `dimensions::Int`: Number of basis states in the Hilbert space.
+- `dimensions::Vector{Int}`: list of dimensions representing the each number of basis in the subsystems.
+"""
+zero_ket(dimensions::Int) = QuantumObject(zeros(dimensions), Ket, [dimensions])
+zero_ket(dimensions::Vector{Int}) = QuantumObject(zeros(prod(dimensions)), Ket, dimensions)
 
 @doc raw"""
     fock(N::Int, pos::Int=0; dims::Vector{Int}=[N], sparse::Bool=false)

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -44,11 +44,11 @@ It is also possible to specify the list of dimensions `dims` if different subsys
 basis(N::Int, pos::Int = 0; dims::Vector{Int} = [N]) = fock(N, pos, dims = dims)
 
 @doc raw"""
-    coherent(N::Real, α::Number)
+    coherent(N::Int, α::Number)
 
 Generates a coherent state ``\ket{\alpha}``, which is defined as an eigenvector of the bosonic annihilation operator ``\hat{a} \ket{\alpha} = \alpha \ket{\alpha}``.
 """
-function coherent(N::Real, α::T) where {T<:Number}
+function coherent(N::Int, α::T) where {T<:Number}
     a = destroy(N)
     return exp(α * a' - α' * a) * fock(N, 0)
 end
@@ -62,6 +62,18 @@ Constructed via outer product of [`fock`](@ref).
 """
 function fock_dm(N::Int, pos::Int = 0; dims::Vector{Int} = [N], sparse::Bool = false)
     ψ = fock(N, pos; dims = dims, sparse = sparse)
+    return ψ * ψ'
+end
+
+@doc raw"""
+    coherent_dm(N::Int, α::Number)
+
+Density matrix representation of a coherent state.
+
+Constructed via outer product of [`coherent`](@ref).
+"""
+function coherent(N::Int, α::T) where {T<:Number}
+    ψ = coherent(N, α)
     return ψ * ψ'
 end
 

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -80,17 +80,21 @@ function coherent_dm(N::Int, α::T) where {T<:Number}
 end
 
 @doc raw"""
-    thermal_dm(N::Int, n::Real)
+    thermal_dm(N::Int, n::Real; sparse::Bool=false)
 
 Density matrix for a thermal state (generating thermal state probabilities) with the following arguments:
 - `N::Int`: Number of basis states in the Hilbert space
 - `n::Real`: Expectation value for number of particles in the thermal state.
 """
-function thermal_dm(N::Int, n::Real)
+function thermal_dm(N::Int, n::Real; sparse::Bool = false)
     β = log(1.0 / n + 1.0)
     N_list = Array{Float64}(0:N-1)
     data = exp.(-β .* N_list)
-    return QuantumObject(spdiagm(0 => data ./ sum(data)), Operator, [N])
+    if sparse
+        return QuantumObject(spdiagm(0 => data ./ sum(data)), Operator, [N])
+    else
+        return QuantumObject(diagm(0 => data ./ sum(data)), Operator, [N])
+    end
 end
 
 @doc raw"""
@@ -102,10 +106,10 @@ The `dimensions` can be either the following types:
 - `dimensions::Int`: Number of basis states in the Hilbert space.
 - `dimensions::Vector{Int}`: list of dimensions representing the each number of basis in the subsystems.
 """
-maximally_mixed_dm(dimensions::Int) = QuantumObject(ones(dimensions, dimensions) / dimensions, Operator, [dimensions])
+maximally_mixed_dm(dimensions::Int) = QuantumObject(I(dimensions) / complex(dimensions), Operator, [dimensions])
 function maximally_mixed_dm(dimensions::Vector{Int})
     N = prod(dimensions)
-    return QuantumObject(ones(N, N) / N, Operator, dimensions)
+    return QuantumObject(I(N) / complex(N), Operator, dimensions)
 end
 
 @doc raw"""

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -100,10 +100,10 @@ The `dimensions` can be either the following types:
 - `dimensions::Int`: Number of basis states in the Hilbert space.
 - `dimensions::Vector{Int}`: list of dimensions representing the each number of basis in the subsystems.
 """
-maximally_mixed_dm(dimensions::Int) = QuantumObject(ones(dimensions) / dimensions, Operator, [dimensions])
+maximally_mixed_dm(dimensions::Int) = QuantumObject(ones(dimensions, dimensions) / dimensions, Operator, [dimensions])
 function maximally_mixed_dm(dimensions::Vector{Int})
     N = prod(dimensions)
-    return QuantumObject(ones(N) / N, Operator, dimensions)
+    return QuantumObject(ones(N, N) / N, Operator, dimensions)
 end
 
 @doc raw"""

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -3,7 +3,7 @@ Functions for generating (common) quantum states.
 =#
 
 export zero_ket, fock, basis, coherent
-export fock_dm, rand_dm
+export fock_dm, coherent_dm, rand_dm
 
 @doc raw"""
     zero_ket(dimensions)

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -5,6 +5,7 @@ Functions for generating (common) quantum states.
 export zero_ket, fock, basis, coherent
 export fock_dm, coherent_dm, thermal_dm, maximally_mixed_dm, rand_dm
 export spin_state, spin_coherent
+export bell_state, singlet_state, triplet_states
 
 @doc raw"""
     zero_ket(dimensions)
@@ -171,4 +172,68 @@ See also [`jmat`](@ref) and [`spin_state`](@ref).
 function spin_coherent(j::Real, θ::Real, ϕ::Real)
     Sm = jmat(j, Val(:-))
     return exp(0.5 * θ * (Sm * exp(1im * ϕ) - Sm' * exp(-1im * ϕ))) * spin_state(j, j)
+end
+
+@doc raw"""
+    bell_state(state::String="00")
+
+Return the corresponding Bell state:
+- `"00"`: ``( |00\rangle + |11\rangle ) / \sqrt{2}``
+- `"01"`: ``( |00\rangle - |11\rangle ) / \sqrt{2}``
+- `"10"`: ``( |01\rangle + |10\rangle ) / \sqrt{2}``
+- `"11"`: ``( |01\rangle - |10\rangle ) / \sqrt{2}``
+
+# Example
+
+```
+julia> bell_state("00")
+Quantum Object:   type=Ket   dims=[2, 2]   size=(4,)
+4-element Vector{ComplexF64}:
+ 0.7071067811865475 + 0.0im
+                0.0 + 0.0im
+                0.0 + 0.0im
+ 0.7071067811865475 + 0.0im
+```
+"""
+function bell_state(state::String = "00")
+    if state == "00"
+        data = ComplexF64[1, 0, 0, 1]
+
+    elseif state == "01"
+        data = ComplexF64[1, 0, 0, -1]
+
+    elseif state == "10"
+        data = ComplexF64[0, 1, 1, 0]
+
+    elseif state == "11"
+        data = ComplexF64[0, 1, -1, 0]
+    else
+        throw(ArgumentError("Invalid state: $(state)"))
+    end
+
+    return QuantumObject(data / sqrt(2), Ket, [2, 2])
+end
+
+@doc raw"""
+    singlet_state()
+
+Return the two particle singlet state: ``\frac{1}{\sqrt{2}} ( |01\rangle - |10\rangle )``
+"""
+singlet_state() = QuantumObject(ComplexF64[0, 1, -1, 0] / sqrt(2), Ket, [2, 2])
+
+@doc raw"""
+    triplet_states()
+
+Return a list of the two particle triplet states: 
+
+- ``|11\rangle``
+- ``( |01\rangle + |10\rangle ) / \sqrt{2}``
+- ``|00\rangle``
+"""
+function triplet_states()
+    return QuantumObject[
+        QuantumObject(ComplexF64[0, 0, 0, 1], Ket, [2, 2]),
+        QuantumObject(ComplexF64[0, 1, 1, 0] / sqrt(2), Ket, [2, 2]),
+        QuantumObject(ComplexF64[1, 0, 0, 0], Ket, [2, 2]),
+    ]
 end

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -4,7 +4,7 @@ Functions for generating (common) quantum states.
 
 export zero_ket, fock, basis, coherent
 export fock_dm, coherent_dm, thermal_dm, maximally_mixed_dm, rand_dm
-export spin_state
+export spin_state, spin_coherent
 
 @doc raw"""
     zero_ket(dimensions)
@@ -141,4 +141,34 @@ function spin_state(j::Real, m::Real)
     (m < (-j)) && throw(ArgumentError("Invalid eigenvalue m, must satisfy: -j ≤ m ≤ j"))
 
     return basis(Int(J), Int(Δ))
+end
+
+@doc raw"""
+    spin_coherent(j::Real, θ::Real, ϕ::Real)
+
+Generate the coherent spin state (rotation of the ``|j, j\rangle`` state), namely
+
+```math
+|\theta, \phi \rangle = R(\theta, \phi) |j, j\rangle
+```
+
+where the rotation operator is defined as
+
+```math
+R(\theta, \phi) = \exp \left( \frac{\theta}{2} (S_- e^{i\phi} - S_+ e^{-i\phi}) \right)
+```
+
+# Arguments
+- `j::Real`: The spin quantum number and can be a non-negative integer or half-integer
+- `θ::Real`: rotation angle from z-axis
+- `ϕ::Real`: rotation angle from x-axis
+
+See also [`jmat`](@ref) and [`spin_state`](@ref).
+
+# Reference
+- [Robert Jones, Spin Coherent States and Statistical Physics](https://web.mit.edu/8.334/www/grades/projects/projects19/JonesRobert.pdf)
+"""
+function spin_coherent(j::Real, θ::Real, ϕ::Real)
+    Sm = jmat(j, Val(:-))
+    return exp(0.5 * θ * (Sm * exp(1im * ϕ) - Sm' * exp(-1im * ϕ))) * spin_state(j, j)
 end

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -3,7 +3,7 @@ Functions for generating (common) quantum states.
 =#
 
 export zero_ket, fock, basis, coherent
-export fock_dm, coherent_dm, rand_dm
+export fock_dm, coherent_dm, thermal_dm, rand_dm
 
 @doc raw"""
     zero_ket(dimensions)
@@ -75,6 +75,20 @@ Constructed via outer product of [`coherent`](@ref).
 function coherent_dm(N::Int, α::T) where {T<:Number}
     ψ = coherent(N, α)
     return ψ * ψ'
+end
+
+@doc raw"""
+    thermal_dm(N::Int, n::Real)
+
+Density matrix for a thermal state (generating thermal state probabilities) with the following arguments:
+- `N::Int`: Number of basis states in the Hilbert space
+- `n::Real`: Expectation value for number of particles in the thermal state.
+"""
+function thermal_dm(N::Int, n::Real)
+    β = log(1.0 / n + 1.0)
+    N_list = Array{Float64}(0:N-1)
+    data = exp.(-β .* N_list)
+    return QuantumObject(spdiagm(0 => data ./ sum(data)), Operator, [N])
 end
 
 @doc raw"""

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -5,7 +5,7 @@ Functions for generating (common) quantum states.
 export zero_ket, fock, basis, coherent
 export fock_dm, coherent_dm, thermal_dm, maximally_mixed_dm, rand_dm
 export spin_state, spin_coherent
-export bell_state, singlet_state, triplet_states
+export bell_state, singlet_state, triplet_states, w_state, ghz_state
 
 @doc raw"""
     zero_ket(dimensions)
@@ -236,4 +236,36 @@ function triplet_states()
         QuantumObject(ComplexF64[0, 1, 1, 0] / sqrt(2), Ket, [2, 2]),
         QuantumObject(ComplexF64[1, 0, 0, 0], Ket, [2, 2]),
     ]
+end
+
+@doc raw"""
+    w_state(n::Int)
+
+Returns the `n`-qubit [W-state](https://en.wikipedia.org/wiki/W_state):
+
+```math
+\frac{1}{\sqrt{n}} \left( |100...0\rangle + |010...0\rangle + \cdots + |00...01\rangle \right)
+```
+"""
+function w_state(n::Int)
+    nzind = 2 .^ (0:(n-1)) .+ 1
+    nzval = fill(ComplexF64(1 / sqrt(n)), n)
+    return QuantumObject(SparseVector(2^n, nzind, nzval), Ket, fill(2, n))
+end
+
+@doc raw"""
+    ghz_state(n::Int; d::Int=2)
+
+Returns the generalized `n`-qudit [Greenberger–Horne–Zeilinger (GHZ) state](https://en.wikipedia.org/wiki/Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state):
+
+```math
+\frac{1}{\sqrt{d}} \sum_{i=0}^{d-1} | i \rangle \otimes \cdots \otimes | i \rangle
+```
+
+Here, `d` specifies the dimension of each qudit. Default to `d=2` (qubit).
+"""
+function ghz_state(n::Int; d::Int = 2)
+    nzind = collect((0:(d-1)) .* Int((d^n - 1) / (d - 1)) .+ 1)
+    nzval = ones(ComplexF64, d) / sqrt(d)
+    return QuantumObject(SparseVector(d^n, nzind, nzval), Ket, fill(d, n))
 end

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -4,6 +4,7 @@ Functions for generating (common) quantum states.
 
 export zero_ket, fock, basis, coherent
 export fock_dm, coherent_dm, thermal_dm, maximally_mixed_dm, rand_dm
+export spin_state
 
 @doc raw"""
     zero_ket(dimensions)
@@ -118,4 +119,26 @@ function rand_dm(N::Integer; dims::Vector{Int} = [N])
     ρ *= ρ'
     ρ /= tr(ρ)
     return QuantumObject(ρ; type = Operator, dims = dims)
+end
+
+@doc raw"""
+    spin_state(j::Real, m::Real)
+
+Generate the spin state: ``|j, m\rangle``
+
+The eigenstate of the Spin-`j` ``S_z`` operator with eigenvalue `m`, where where `j` is the spin quantum number and can be a non-negative integer or half-integer
+
+See also [`jmat`](@ref).
+"""
+function spin_state(j::Real, m::Real)
+    J = 2 * j + 1
+    ((floor(J) != J) || (j < 0)) &&
+        throw(ArgumentError("The spin quantum number (j) must be a non-negative integer or half-integer."))
+
+    Δ = j - m
+    ((floor(Δ) != Δ) || (Δ < 0)) &&
+        throw(ArgumentError("Invalid eigenvalue m: (j - m) must be a non-negative integer."))
+    (m < (-j)) && throw(ArgumentError("Invalid eigenvalue m, must satisfy: -j ≤ m ≤ j"))
+
+    return basis(Int(J), Int(Δ))
 end

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -175,18 +175,20 @@ function spin_coherent(j::Real, θ::Real, ϕ::Real)
 end
 
 @doc raw"""
-    bell_state(state::String="00")
+    bell_state(x::Int, z::Int)
 
-Return the corresponding Bell state:
-- `"00"`: ``( |00\rangle + |11\rangle ) / \sqrt{2}``
-- `"01"`: ``( |00\rangle - |11\rangle ) / \sqrt{2}``
-- `"10"`: ``( |01\rangle + |10\rangle ) / \sqrt{2}``
-- `"11"`: ``( |01\rangle - |10\rangle ) / \sqrt{2}``
+Return the [Bell state](https://en.wikipedia.org/wiki/Bell_state) depending on the arguments `(x, z)`:
+- `(0, 0)`: ``| \Phi^+ \rangle = ( |00\rangle + |11\rangle ) / \sqrt{2}``
+- `(0, 1)`: ``| \Phi^- \rangle = ( |00\rangle - |11\rangle ) / \sqrt{2}``
+- `(1, 0)`: ``| \Psi^+ \rangle = ( |01\rangle + |10\rangle ) / \sqrt{2}``
+- `(1, 1)`: ``| \Psi^- \rangle = ( |01\rangle - |10\rangle ) / \sqrt{2}``
+
+Here, `x = 1` (`z = 1`) means applying Pauli-``X`` ( Pauli-``Z``) unitary transformation on ``| \Phi^+ \rangle``.
 
 # Example
 
 ```
-julia> bell_state("00")
+julia> bell_state(0, 0)
 Quantum Object:   type=Ket   dims=[2, 2]   size=(4,)
 4-element Vector{ComplexF64}:
  0.7071067811865475 + 0.0im
@@ -195,24 +197,12 @@ Quantum Object:   type=Ket   dims=[2, 2]   size=(4,)
  0.7071067811865475 + 0.0im
 ```
 """
-function bell_state(state::String = "00")
-    if state == "00"
-        data = ComplexF64[1, 0, 0, 1]
-
-    elseif state == "01"
-        data = ComplexF64[1, 0, 0, -1]
-
-    elseif state == "10"
-        data = ComplexF64[0, 1, 1, 0]
-
-    elseif state == "11"
-        data = ComplexF64[0, 1, -1, 0]
-    else
-        throw(ArgumentError("Invalid state: $(state)"))
-    end
-
-    return QuantumObject(data / sqrt(2), Ket, [2, 2])
-end
+bell_state(x::Int, z::Int) = bell_state(Val(x), Val(z))
+bell_state(::Val{0}, ::Val{0}) = QuantumObject(ComplexF64[1, 0, 0, 1] / sqrt(2), Ket, [2, 2])
+bell_state(::Val{0}, ::Val{1}) = QuantumObject(ComplexF64[1, 0, 0, -1] / sqrt(2), Ket, [2, 2])
+bell_state(::Val{1}, ::Val{0}) = QuantumObject(ComplexF64[0, 1, 1, 0] / sqrt(2), Ket, [2, 2])
+bell_state(::Val{1}, ::Val{1}) = QuantumObject(ComplexF64[0, 1, -1, 0] / sqrt(2), Ket, [2, 2])
+bell_state(::Val{T1}, ::Val{T2}) where {T1,T2} = throw(ArgumentError("Invalid Bell state: $(T1), $(T2)"))
 
 @doc raw"""
     singlet_state()

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -72,7 +72,7 @@ Density matrix representation of a coherent state.
 
 Constructed via outer product of [`coherent`](@ref).
 """
-function coherent(N::Int, α::T) where {T<:Number}
+function coherent_dm(N::Int, α::T) where {T<:Number}
     ψ = coherent(N, α)
     return ψ * ψ'
 end

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -3,7 +3,7 @@ Functions for generating (common) quantum states.
 =#
 
 export zero_ket, fock, basis, coherent
-export fock_dm, coherent_dm, thermal_dm, rand_dm
+export fock_dm, coherent_dm, thermal_dm, maximally_mixed_dm, rand_dm
 
 @doc raw"""
     zero_ket(dimensions)
@@ -89,6 +89,21 @@ function thermal_dm(N::Int, n::Real)
     N_list = Array{Float64}(0:N-1)
     data = exp.(-β .* N_list)
     return QuantumObject(spdiagm(0 => data ./ sum(data)), Operator, [N])
+end
+
+@doc raw"""
+    maximally_mixed_dm(dimensions)
+
+Returns the maximally mixed density matrix with given argument `dimensions`.
+
+The `dimensions` can be either the following types:
+- `dimensions::Int`: Number of basis states in the Hilbert space.
+- `dimensions::Vector{Int}`: list of dimensions representing the each number of basis in the subsystems.
+"""
+maximally_mixed_dm(dimensions::Int) = QuantumObject(ones(dimensions) / dimensions, Operator, [dimensions])
+function maximally_mixed_dm(dimensions::Vector{Int})
+    N = prod(dimensions)
+    return QuantumObject(ones(N) / N, Operator, dimensions)
 end
 
 @doc raw"""

--- a/test/quantum_objects.jl
+++ b/test/quantum_objects.jl
@@ -364,9 +364,9 @@
     @test ket_bdca.dims == correct_dims
     @test bra_bdca.dims == correct_dims
     @test op_bdca.dims == correct_dims
-    @test typeof(ket_bdca.type) <: KetQuantumObject
-    @test typeof(bra_bdca.type) <: BraQuantumObject
-    @test typeof(op_bdca.type) <: OperatorQuantumObject
+    @test isket(ket_bdca)
+    @test isbra(bra_bdca)
+    @test isoper(op_bdca)
     @test_throws ArgumentError permute(ket_bdca, wrong_order1)
     @test_throws ArgumentError permute(ket_bdca, wrong_order2)
     @test_throws ArgumentError permute(bra_bdca, wrong_order1)

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -68,6 +68,25 @@
     @test all(eigenenergies(ρ_B) .>= 0)
     @test_throws DimensionMismatch rand_dm(4, dims = [2])
 
+    # bell_state, singlet_state, triplet_states
+    e0 = basis(2, 0)
+    e1 = basis(2, 1)
+    B00 = (e0 ⊗ e0 + e1 ⊗ e1) / √2
+    B01 = (e0 ⊗ e0 - e1 ⊗ e1) / √2
+    B10 = (e0 ⊗ e1 + e1 ⊗ e0) / √2
+    B11 = (e0 ⊗ e1 - e1 ⊗ e0) / √2
+    S = singlet_state()
+    T = triplet_states()
+    @test bell_state("00") == B00
+    @test bell_state("01") == B01
+    @test bell_state("10") == B10 == T[2]
+    @test bell_state("11") == B11 == S
+    @test T[1] == e1 ⊗ e1
+    @test T[3] == e0 ⊗ e0
+    @test_throws ArgumentError bell_state("")
+    @test_throws ArgumentError bell_state("0")
+    @test_throws ArgumentError bell_state("1")
+
     # Pauli matrices and general Spin-j operators
     J0 = Qobj(spdiagm(0 => [0.0im]))
     Jx, Jy, Jz = spin_J_set(0.5)

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -1,4 +1,16 @@
 @testset "States and Operators" begin
+    # zero_ket
+    v1 = zero_ket(4)
+    v2 = zero_ket([2, 2])
+    @test size(v1) == (4,)
+    @test size(v2) == (4,)
+    @test v1.data == v2.data
+    @test v1 != v2
+    @test isket(v1)
+    @test isket(v2)
+    @test v1.dims == [4]
+    @test v2.dims == [2, 2]
+
     # fock, basis
     @test fock(4; dims = [2, 2], sparse = true) ≈ basis(4; dims = [2, 2])
     @test_throws DimensionMismatch fock(4; dims = [2])

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -110,6 +110,28 @@
     @test_throws ArgumentError spin_state(2.5, 3.5)
     @test_throws ArgumentError spin_state(2.5, -3.5)
 
+    # spin_coherent
+    ## spin-half (state in Bloch sphere)
+    s = 0.5
+    θ = π * rand()
+    ϕ = 2 * π * rand()
+    @test spin_coherent(s, θ, ϕ) ≈ cos(θ / 2) * basis(2, 0) + exp(1im * ϕ) * sin(θ / 2) * basis(2, 1)
+
+    ## also verify the equation in: 
+    ## Robert Jones, Spin Coherent States and Statistical Physics, page 3
+    s = 3.5
+    θ1 = π * rand()
+    θ2 = π * rand()
+    ϕ1 = 2 * π * rand()
+    ϕ2 = 2 * π * rand()
+    γ = rand()
+    Sz = spin_Jz(s)
+    n1 = spin_coherent(s, θ1, ϕ1)
+    n2 = spin_coherent(s, θ2, ϕ2)
+    @test dot(n1, n2) ≈ (cos(θ1 / 2) * cos(θ2 / 2) + exp(1im * (ϕ2 - ϕ1)) * sin(θ1 / 2) * sin(θ2 / 2))^(2 * s)
+    @test dot(n1, exp(-γ * Sz), n2) ≈
+          (exp(-γ / 2) * cos(θ1 / 2) * cos(θ2 / 2) + exp(1im * (ϕ2 - ϕ1) + γ / 2) * sin(θ1 / 2) * sin(θ2 / 2))^(2 * s)
+
     # test commutation relations for fermionic creation and annihilation operators
     sites = 4
     SIZE = 2^sites

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -11,8 +11,8 @@
     @test v1.dims == [4]
     @test v2.dims == [2, 2]
 
-    # fock, basis
-    @test fock(4; dims = [2, 2], sparse = true) ≈ basis(4; dims = [2, 2])
+    # fock, basis, fock_dm
+    @test fock_dm(4; dims = [2, 2], sparse = true) ≈ ket2dm(basis(4; dims = [2, 2]))
     @test_throws DimensionMismatch fock(4; dims = [2])
 
     # rand_dm

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -24,6 +24,20 @@
     @test isoper(ρα)
     @test ket2dm(ψα) ≈ ρα
 
+    # thermal_dm
+    ρT = thermal_dm(5, 0.123)
+    @test isoper(ρT)
+    @test ρT.dims == [5]
+    @test ρT.data ≈ spdiagm(
+        0 => Float64[
+            0.8904859864731106,
+            0.09753319353178326,
+            0.010682620484781245,
+            0.0011700465891612583,
+            0.00012815292116369966,
+        ],
+    )
+
     # rand_dm
     ρ_AB = rand_dm(4, dims = [2, 2])
     ρ_A = ptrace(ρ_AB, 1)

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -97,6 +97,19 @@
     @test commutator(Jy, Jx) ≈ -1im * Jz
     @test commutator(Jz, Jy) ≈ -1im * Jx
 
+    # spin_state
+    j = 3.5
+    Jz = spin_Jz(j)
+    for m in (-j):1:j
+        ψm = spin_state(j, m)
+        @test Jz * ψm ≈ m * ψm  # check eigenvalue
+    end
+    @test_throws ArgumentError spin_state(8.7, 8.7)
+    @test_throws ArgumentError spin_state(-1, 0)
+    @test_throws ArgumentError spin_state(2.5, 2)
+    @test_throws ArgumentError spin_state(2.5, 3.5)
+    @test_throws ArgumentError spin_state(2.5, -3.5)
+
     # test commutation relations for fermionic creation and annihilation operators
     sites = 4
     SIZE = 2^sites

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -38,6 +38,18 @@
         ],
     )
 
+    # maximally_mixed_dm
+    ρ1 = maximally_mixed_dm(4)
+    ρ2 = maximally_mixed_dm([2, 2])
+    @test size(ρ1) == (4, 4)
+    @test size(ρ2) == (4, 4)
+    @test ρ1.data == ρ2.data
+    @test ρ1 != ρ2
+    @test isoper(ρ1)
+    @test isoper(ρ2)
+    @test ρ1.dims == [4]
+    @test ρ2.dims == [2, 2]
+
     # rand_dm
     ρ_AB = rand_dm(4, dims = [2, 2])
     ρ_A = ptrace(ρ_AB, 1)

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -68,21 +68,27 @@
     @test all(eigenenergies(ρ_B) .>= 0)
     @test_throws DimensionMismatch rand_dm(4, dims = [2])
 
-    # bell_state, singlet_state, triplet_states
+    # bell_state, singlet_state, triplet_states, w_state, ghz_state
     e0 = basis(2, 0)
     e1 = basis(2, 1)
+    d0 = basis(3, 0)
+    d1 = basis(3, 1)
+    d2 = basis(3, 2)
     B00 = (e0 ⊗ e0 + e1 ⊗ e1) / √2
     B01 = (e0 ⊗ e0 - e1 ⊗ e1) / √2
     B10 = (e0 ⊗ e1 + e1 ⊗ e0) / √2
     B11 = (e0 ⊗ e1 - e1 ⊗ e0) / √2
     S = singlet_state()
     T = triplet_states()
-    @test bell_state("00") == B00
+    @test bell_state("00") == B00 == ghz_state(2)
     @test bell_state("01") == B01
-    @test bell_state("10") == B10 == T[2]
+    @test bell_state("10") == B10 == T[2] == w_state(2)
     @test bell_state("11") == B11 == S
     @test T[1] == e1 ⊗ e1
     @test T[3] == e0 ⊗ e0
+    @test w_state(3) == (e0 ⊗ e0 ⊗ e1 + e0 ⊗ e1 ⊗ e0 + e1 ⊗ e0 ⊗ e0) / √3
+    @test ghz_state(3) == (e0 ⊗ e0 ⊗ e0 + e1 ⊗ e1 ⊗ e1) / √2
+    @test ghz_state(3; d = 3) == (d0 ⊗ d0 ⊗ d0 + d1 ⊗ d1 ⊗ d1 + d2 ⊗ d2 ⊗ d2) / √3
     @test_throws ArgumentError bell_state("")
     @test_throws ArgumentError bell_state("0")
     @test_throws ArgumentError bell_state("1")

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -80,18 +80,18 @@
     B11 = (e0 ⊗ e1 - e1 ⊗ e0) / √2
     S = singlet_state()
     T = triplet_states()
-    @test bell_state("00") == B00 == ghz_state(2)
-    @test bell_state("01") == B01
-    @test bell_state("10") == B10 == T[2] == w_state(2)
-    @test bell_state("11") == B11 == S
+    @test bell_state(0, 0) == B00 == ghz_state(2)
+    @test bell_state(0, 1) == B01
+    @test bell_state(1, 0) == B10 == T[2] == w_state(2)
+    @test bell_state(1, 1) == B11 == S
     @test T[1] == e1 ⊗ e1
     @test T[3] == e0 ⊗ e0
     @test w_state(3) == (e0 ⊗ e0 ⊗ e1 + e0 ⊗ e1 ⊗ e0 + e1 ⊗ e0 ⊗ e0) / √3
     @test ghz_state(3) == (e0 ⊗ e0 ⊗ e0 + e1 ⊗ e1 ⊗ e1) / √2
     @test ghz_state(3; d = 3) == (d0 ⊗ d0 ⊗ d0 + d1 ⊗ d1 ⊗ d1 + d2 ⊗ d2 ⊗ d2) / √3
-    @test_throws ArgumentError bell_state("")
-    @test_throws ArgumentError bell_state("0")
-    @test_throws ArgumentError bell_state("1")
+    @test_throws ArgumentError bell_state(0, 2)
+    @test_throws ArgumentError bell_state(3, 1)
+    @test_throws ArgumentError bell_state(2, 3)
 
     # Pauli matrices and general Spin-j operators
     J0 = Qobj(spdiagm(0 => [0.0im]))

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -26,11 +26,12 @@
     @test tr(ρα) ≈ 1.0
 
     # thermal_dm
-    ρT = thermal_dm(5, 0.123)
-    @test isoper(ρT)
-    @test ρT.dims == [5]
-    @test tr(ρT) ≈ 1.0
-    @test ρT.data ≈ spdiagm(
+    ρTd = thermal_dm(5, 0.123)
+    ρTs = thermal_dm(5, 0.123; sparse = true)
+    @test isoper(ρTd)
+    @test ρTd.dims == [5]
+    @test tr(ρTd) ≈ 1.0
+    @test ρTd.data ≈ spdiagm(
         0 => Float64[
             0.8904859864731106,
             0.09753319353178326,
@@ -39,6 +40,8 @@
             0.00012815292116369966,
         ],
     )
+    @test typeof(ρTs.data) <: AbstractSparseMatrix
+    @test ρTd ≈ ρTs
 
     # maximally_mixed_dm
     ρ1 = maximally_mixed_dm(4)
@@ -52,6 +55,7 @@
     @test isoper(ρ2)
     @test ρ1.dims == [4]
     @test ρ2.dims == [2, 2]
+    @test entropy_vn(ρ1, base = 2) ≈ log(2, 4)
 
     # rand_dm
     ρ_AB = rand_dm(4, dims = [2, 2])

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -23,11 +23,13 @@
     @test isket(ψα)
     @test isoper(ρα)
     @test ket2dm(ψα) ≈ ρα
+    @test tr(ρα) ≈ 1.0
 
     # thermal_dm
     ρT = thermal_dm(5, 0.123)
     @test isoper(ρT)
     @test ρT.dims == [5]
+    @test tr(ρT) ≈ 1.0
     @test ρT.data ≈ spdiagm(
         0 => Float64[
             0.8904859864731106,
@@ -43,6 +45,7 @@
     ρ2 = maximally_mixed_dm([2, 2])
     @test size(ρ1) == (4, 4)
     @test size(ρ2) == (4, 4)
+    @test tr(ρ1) ≈ 1.0
     @test ρ1.data == ρ2.data
     @test ρ1 != ρ2
     @test isoper(ρ1)

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -15,6 +15,15 @@
     @test fock_dm(4; dims = [2, 2], sparse = true) ≈ ket2dm(basis(4; dims = [2, 2]))
     @test_throws DimensionMismatch fock(4; dims = [2])
 
+    # coherent, coherent_dm
+    N = 4
+    α = 0.25im
+    ψα = coherent(N, α)
+    ρα = coherent_dm(N, α)
+    @test isket(ψα)
+    @test isoper(ρα)
+    @test ket2dm(ψα) ≈ ρα
+
     # rand_dm
     ρ_AB = rand_dm(4, dims = [2, 2])
     ρ_A = ptrace(ρ_AB, 1)


### PR DESCRIPTION
close #146 

Summarize of this PR:
- Introduce `zero_ket`
- Introduce `fock_dm`
- Introduce `coherent_dm`
- Introduce `thermal_dm`
- Introduce `maximally_mixed_dm`
- minor changes in `jmat`
- Introduce `spin_state`
- Introduce `spin_coherent`
- Introduce `bell_state`
- Introduce `singlet_state`
- Introduce `triplet_states`
- Introduce `w_state`
- Introduce `ghz_state`
- ignore size threshold for document API page: `size_threshold_ignore = ["api.md"]`