### PR TITLE
Improve runtest CI config

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,7 +73,8 @@ jobs:
         with:
           directories: src,ext
       - uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,17 +42,13 @@ jobs:
 
         include:
           # for core tests on macOS
-          - version: '1.7'      # oldest
-            os: 'macOS-latest'  # M-series chip
-            arch: 'arm64'
-            group: 'Core'
-          - version: '1'        # latest
-            os: 'macOS-latest'  # M-series chip
-            arch: 'arm64'
-            group: 'Core'
-          - version: '1'        # latest
+          - version: '1.7'      # oldest (julia v1.7 does not support M-series chip)
             os: 'macOS-13'      # Intel chip
             arch: 'x64'
+            group: 'Core'
+          - version: '1'        # latest
+            os: 'macOS-latest'  # M-series chip
+            arch: 'arm64'
             group: 'Core'
 
           # for core tests (intermediate versions)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,11 +30,11 @@ jobs:
       matrix:
         # for core tests (latest and oldest supported versions)
         version:
-          - '1.7'
-          - '1.10'
+          - '1.7'  # oldest
+          - '1'    # latest
         os:
           - ubuntu-latest
-          - macOS-latest
+          - macOS-latest-large # intel chip
           - windows-latest
         arch:
           - x64
@@ -50,6 +50,12 @@ jobs:
           - version: '1.9'
             os: 'ubuntu-latest'
             arch: 'x64'
+            group: 'Core'
+
+          # for core tests on macOS M-series chip
+          - version: '1'
+            os: 'macOS-latest-xlarge'
+            arch: 'arm64'
             group: 'Core'
 
           # for code quality tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,6 @@ jobs:
           - '1'    # latest
         os:
           - ubuntu-latest
-          - macOS-13 # intel chip
           - windows-latest
         arch:
           - x64
@@ -42,6 +41,20 @@ jobs:
           - Core
 
         include:
+          # for core tests on macOS
+          - version: '1.7'      # oldest
+            os: 'macOS-latest'  # M-series chip
+            arch: 'arm64'
+            group: 'Core'
+          - version: '1'        # latest
+            os: 'macOS-latest'  # M-series chip
+            arch: 'arm64'
+            group: 'Core'
+          - version: '1'        # latest
+            os: 'macOS-13'      # Intel chip
+            arch: 'x64'
+            group: 'Core'
+
           # for core tests (intermediate versions)
           - version: '1.8'
             os: 'ubuntu-latest'
@@ -50,12 +63,6 @@ jobs:
           - version: '1.9'
             os: 'ubuntu-latest'
             arch: 'x64'
-            group: 'Core'
-
-          # for core tests on macOS M-series chip
-          - version: '1'
-            os: 'macOS-latest'
-            arch: 'arm64'
             group: 'Core'
 
           # for code quality tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
           - '1'    # latest
         os:
           - ubuntu-latest
-          - macOS-latest-large # intel chip
+          - macOS-13 # intel chip
           - windows-latest
         arch:
           - x64
@@ -54,7 +54,7 @@ jobs:
 
           # for core tests on macOS M-series chip
           - version: '1'
-            os: 'macOS-latest-xlarge'
+            os: 'macOS-latest'
             arch: 'arm64'
             group: 'Core'
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,4 +86,4 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: lcov.info
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
Two things we want to address here:

- [x] [set `fail_ci_if_error` to `false`
- [x] runtest for different macOS architecture
  - for intel chip: use `os: macOS-13` and `arch: x64` (`macOS-latest` will ***virtually*** support `x64` by `Rosetta`)
  - for Apple M-series chip: use `os: macOS-latest` and  `arch: arm64`