### PR TITLE
Introduce `show` for `TimeEvolutionSol` and `TimeEvolutionMCSol`, also, adjust return `states` and `expect` from `sesolve`, `mesolve`, and `mcsolve`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -161,6 +161,7 @@ qeye
 
 ```@docs
 TimeEvolutionSol
+TimeEvolutionMCSol
 sesolveProblem
 mesolveProblem
 lr_mesolveProblem

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -160,6 +160,7 @@ qeye
 ## [Time evolution](@id doc-API:Time-evolution)
 
 ```@docs
+TimeEvolutionSol
 sesolveProblem
 mesolveProblem
 lr_mesolveProblem

--- a/src/correlations.jl
+++ b/src/correlations.jl
@@ -112,8 +112,8 @@ end
         reverse::Bool=false,
         kwargs...)
 
-Returns the one-time correlation function of two operators ``\hat{A}`` and ``\hat{B}`` 
-at different times ``\expval{\hat{A}(\tau) \hat{B}(0)}``.
+Returns the one-time correlation function of two operators ``\hat{A}`` and ``\hat{B}`` at different times ``\expval{\hat{A}(\tau) \hat{B}(0)}``.
+
 When `reverse=true`, the correlation function is calculated as ``\expval{\hat{A}(0) \hat{B}(\tau)}``.
 """
 function correlation_2op_1t(
@@ -140,11 +140,11 @@ end
 
 @doc raw"""
     spectrum(H::QuantumObject,
-    ω_list::AbstractVector,
-    A::QuantumObject{<:AbstractArray{T2},OperatorQuantumObject},
-    B::QuantumObject{<:AbstractArray{T3},OperatorQuantumObject},
-    c_ops::AbstractVector=[];
-    solver::MySolver=ExponentialSeries(),
+        ω_list::AbstractVector,
+        A::QuantumObject{<:AbstractArray{T2},OperatorQuantumObject},
+        B::QuantumObject{<:AbstractArray{T3},OperatorQuantumObject},
+        c_ops::AbstractVector=[];
+        solver::MySolver=ExponentialSeries(),
         kwargs...)
 
 Returns the emission spectrum 

--- a/src/time_evolution/lr_mesolve.jl
+++ b/src/time_evolution/lr_mesolve.jl
@@ -58,7 +58,7 @@ end
 
 select(x::Real, xarr::AbstractArray, retval = false) = retval ? xarr[argmin(abs.(x .- xarr))] : argmin(abs.(x .- xarr))
 
-"""
+@doc raw"""
     _pinv!(A, T1, T2; atol::Real=0.0, rtol::Real=(eps(real(float(oneunit(T))))*min(size(A)...))*iszero(atol)) where T
     Computes the pseudo-inverse of a matrix A, and stores it in T1. If T2 is provided, it is used as a temporary matrix. 
     The algorithm is based on the SVD decomposition of A, and is taken from the Julia package LinearAlgebra.
@@ -98,7 +98,7 @@ function _pinv!(
     return mul!(T1, SVD.Vt', T2)
 end
 
-"""
+@doc raw"""
     _calculate_expectation!(p,z,B,idx) where T
     Calculates the expectation values and function values of the operators and functions in p.e_ops and p.f_ops, respectively, and stores them in p.expvals and p.funvals.
     The function is called by the callback _save_affect_lr_mesolve!.
@@ -169,7 +169,7 @@ end
 #                CALLBACK FUNCTIONS
 #=======================================================#
 
-"""
+@doc raw"""
     _adjM_condition_ratio(u, t, integrator) where T
     Condition for the dynamical rank adjustment based on the ratio between the smallest and largest eigenvalues of the density matrix.
     The spectrum of the density matrix is calculated efficiently using the properties of the SVD decomposition of the matrix.
@@ -200,7 +200,7 @@ function _adjM_condition_ratio(u, t, integrator)
     return (err >= opt.err_max && M < N && M < opt.M_max)
 end
 
-"""
+@doc raw"""
     _adjM_condition_variational(u, t, integrator) where T
     Condition for the dynamical rank adjustment based on the leakage out of the low-rank manifold.
 
@@ -222,7 +222,7 @@ function _adjM_condition_variational(u, t, integrator)
     return (err >= opt.err_max && M < N && M < opt.M_max)
 end
 
-"""
+@doc raw"""
     _adjM_affect!(integrator)
     Affect function for the dynamical rank adjustment. It increases the rank of the low-rank manifold by one, and updates the matrices accordingly.
     If Δt>0, it rewinds the integrator to the previous time step.
@@ -286,7 +286,7 @@ end
 #            DYNAMICAL EVOLUTION EQUATIONS
 #=======================================================#
 
-"""
+@doc raw"""
     dBdz!(du, u, p, t) where T
     Dynamical evolution equations for the low-rank manifold. The function is called by the ODEProblem.
 
@@ -364,7 +364,7 @@ end
 #                   PROBLEM FORMULATION
 #=======================================================#
 
-"""
+@doc raw"""
     lr_mesolveProblem(H, z, B, t_l, c_ops; e_ops=(), f_ops=(), opt=LRMesolveOptions(), kwargs...) where T
     Formulates the ODEproblem for the low-rank time evolution of the system. The function is called by lr_mesolve.
 
@@ -510,7 +510,7 @@ get_z(u::AbstractArray{T}, N::Integer, M::Integer) where {T} = reshape(view(u, 1
 
 get_B(u::AbstractArray{T}, N::Integer, M::Integer) where {T} = reshape(view(u, (M*N+1):length(u)), M, M)
 
-"""
+@doc raw"""
     lr_mesolve(prob::ODEProblem; kwargs...)
     Solves the ODEProblem formulated by lr_mesolveProblem. The function is called by lr_mesolve.
 

--- a/src/time_evolution/lr_mesolve.jl
+++ b/src/time_evolution/lr_mesolve.jl
@@ -529,7 +529,7 @@ function lr_mesolve(prob::ODEProblem; kwargs...)
     Ll = length.(sol.u)
     Ml = @. Int((sqrt(N^2 + 4 * Ll) - N) / 2)
 
-    if !haskey(kwargs, :save_idxs)
+    if !haskey(kwargs, :saveat)
         Bt = map(x -> get_B(x[1], N, x[2]), zip(sol.u, Ml))
         zt = map(x -> get_z(x[1], N, x[2]), zip(sol.u, Ml))
     else

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -181,6 +181,11 @@ function mcsolveProblem(
     jump_callback::TJC = ContinuousLindbladJumpCallback(),
     kwargs...,
 ) where {MT1<:AbstractMatrix,T2,Tc<:AbstractMatrix,Te<:AbstractMatrix,TJC<:LindbladJumpCallbackType}
+
+    H.dims != ψ0.dims && throw(DimensionMismatch("The two quantum objects are not of the same Hilbert dimension."))
+
+    haskey(kwargs, :save_idxs) && throw(ArgumentError("The keyword argument \"save_idxs\" is not supported in QuantumToolbox."))
+
     H_eff = H - T2(0.5im) * mapreduce(op -> op' * op, +, c_ops)
 
     is_empty_e_ops_mc = isempty(e_ops)

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -89,7 +89,7 @@ end
 function _mcsolve_generate_statistics(sol, i, times, states, expvals_all, jump_times, jump_which)
     sol_i = sol[:, i]
     sol_u =
-        haskey(sol_i.prob.kwargs, :save_idxs) ? sol_i.u :
+        isempty(sol_i.prob.kwargs[:saveat]) ? sol_i.u :
         [QuantumObject(sol_i.u[i], dims = sol_i.prob.p.Hdims) for i in 1:length(sol_i.u)]
 
     copyto!(view(expvals_all, i, :, :), sol_i.prob.p.expvals)
@@ -403,7 +403,7 @@ function mcsolve(
     expvals_all = Array{ComplexF64}(undef, length(sol), size(sol[:, 1].prob.p.expvals)...)
     times = Vector{Vector{Float64}}(undef, length(sol))
     states =
-        haskey(sol[:, 1].prob.kwargs, :save_idxs) ? Vector{Vector{eltype(sol[:, 1].u[1])}}(undef, length(sol)) :
+        isempty(sol[:, 1].prob.kwargs[:saveat]) ? Vector{Vector{eltype(sol[:, 1].u[1])}}(undef, length(sol)) :
         Vector{Vector{QuantumObject}}(undef, length(sol))
     jump_times = Vector{Vector{Float64}}(undef, length(sol))
     jump_which = Vector{Vector{Int16}}(undef, length(sol))

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -127,9 +127,10 @@ Generates the ODEProblem for a single trajectory of the Monte Carlo wave functio
 - `jump_callback::LindbladJumpCallbackType`: The Jump Callback type: Discrete or Continuous.
 - `kwargs...`: Additional keyword arguments to pass to the solver.
 
-Note that the default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+# Notes
 
-For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
+- The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+- For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
 
@@ -263,9 +264,10 @@ Generates the ODEProblem for an ensemble of trajectories of the Monte Carlo wave
 - `output_func::Function`: Function to use for generating the output of a single trajectory.
 - `kwargs...`: Additional keyword arguments to pass to the solver.
 
-Note that the default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+# Notes
 
-For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
+- The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+- For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
 
@@ -339,11 +341,11 @@ Time evolution of an open quantum system using quantum trajectories.
 - `output_func::Function`: Function to use for generating the output of a single trajectory.
 - `kwargs...`: Additional keyword arguments to pass to the solver.
 
-Note that `ensemble_method` can be one of `EnsembleThreads()`, `EnsembleSerial()`, `EnsembleDistributed()`.
+# Notes
 
-The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
-
-For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
+- `ensemble_method` can be one of `EnsembleThreads()`, `EnsembleSerial()`, `EnsembleDistributed()`
+- The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+- For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
 

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -181,10 +181,10 @@ function mcsolveProblem(
     jump_callback::TJC = ContinuousLindbladJumpCallback(),
     kwargs...,
 ) where {MT1<:AbstractMatrix,T2,Tc<:AbstractMatrix,Te<:AbstractMatrix,TJC<:LindbladJumpCallbackType}
-
     H.dims != ψ0.dims && throw(DimensionMismatch("The two quantum objects are not of the same Hilbert dimension."))
 
-    haskey(kwargs, :save_idxs) && throw(ArgumentError("The keyword argument \"save_idxs\" is not supported in QuantumToolbox."))
+    haskey(kwargs, :save_idxs) &&
+        throw(ArgumentError("The keyword argument \"save_idxs\" is not supported in QuantumToolbox."))
 
     H_eff = H - T2(0.5im) * mapreduce(op -> op' * op, +, c_ops)
 

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -111,26 +111,29 @@ end
         jump_callback::TJC=ContinuousLindbladJumpCallback(),
         kwargs...)
 
-Generates the ODEProblem for a single trajectory of the Monte Carlo wave function
-time evolution of an open quantum system.
+Generates the ODEProblem for a single trajectory of the Monte Carlo wave function time evolution of an open quantum system.
 
 # Arguments
 
-  - `H::QuantumObject`: Hamiltonian of the system.
-  - `ψ0::QuantumObject`: Initial state of the system.
-  - `t_l::AbstractVector`: List of times at which to save the state of the system.
-  - `c_ops::Vector`: List of collapse operators.
-  - `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm`: Algorithm to use for the time evolution.
-  - `e_ops::Vector`: List of operators for which to calculate expectation values.
-  - `H_t::Union{Nothing,Function,TimeDependentOperatorSum}`: Time-dependent part of the Hamiltonian.
-  - `params::NamedTuple`: Dictionary of parameters to pass to the solver.
-  - `seeds::Union{Nothing, Vector{Int}}`: List of seeds for the random number generator. Length must be equal to the number of trajectories provided.
-  - `jump_callback::LindbladJumpCallbackType`: The Jump Callback type: Discrete or Continuous.
-  - `kwargs...`: Additional keyword arguments to pass to the solver.
+- `H::QuantumObject`: Hamiltonian of the system.
+- `ψ0::QuantumObject`: Initial state of the system.
+- `t_l::AbstractVector`: List of times at which to save the state of the system.
+- `c_ops::Vector`: List of collapse operators.
+- `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm`: Algorithm to use for the time evolution.
+- `e_ops::Vector`: List of operators for which to calculate expectation values.
+- `H_t::Union{Nothing,Function,TimeDependentOperatorSum}`: Time-dependent part of the Hamiltonian.
+- `params::NamedTuple`: Dictionary of parameters to pass to the solver.
+- `seeds::Union{Nothing, Vector{Int}}`: List of seeds for the random number generator. Length must be equal to the number of trajectories provided.
+- `jump_callback::LindbladJumpCallbackType`: The Jump Callback type: Discrete or Continuous.
+- `kwargs...`: Additional keyword arguments to pass to the solver.
+
+Note that the default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+
+For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
 
-  - `prob::ODEProblem`: The ODEProblem for the Monte Carlo wave function time evolution.
+- `prob::ODEProblem`: The ODEProblem for the Monte Carlo wave function time evolution.
 """
 function mcsolveProblem(
     H::QuantumObject{MT1,OperatorQuantumObject},
@@ -228,7 +231,7 @@ function mcsolveProblem(
     return sesolveProblem(H_eff, ψ0, t_l; alg = alg, H_t = H_t, params = params, kwargs2...)
 end
 
-"""
+@doc raw"""
     mcsolveEnsembleProblem(H::QuantumObject{<:AbstractArray{T1},OperatorQuantumObject},
         ψ0::QuantumObject{<:AbstractArray{T2},KetQuantumObject},
         t_l::AbstractVector,
@@ -242,29 +245,31 @@ end
         output_func::Function=_mcsolve_output_func,
         kwargs...)
 
-Generates the ODEProblem for an ensemble of trajectories of the Monte Carlo wave function
-time evolution of an open quantum system.
+Generates the ODEProblem for an ensemble of trajectories of the Monte Carlo wave function time evolution of an open quantum system.
 
 # Arguments
 
-  - `H::QuantumObject`: Hamiltonian of the system.
-  - `ψ0::QuantumObject`: Initial state of the system.
-  - `t_l::AbstractVector`: List of times at which to save the state of the system.
-  - `c_ops::Vector`: List of collapse operators.
-  - `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm`: Algorithm to use for the time evolution.
-  - `e_ops::Vector`: List of operators for which to calculate expectation values.
-  - `H_t::Union{Nothing,Function,TimeDependentOperatorSum}`: Time-dependent part of the Hamiltonian.
-  - `params::NamedTuple`: Dictionary of parameters to pass to the solver.
-  - `seeds::Union{Nothing, Vector{Int}}`: List of seeds for the random number generator. Length must be equal to the number of trajectories provided.
-  - `jump_callback::LindbladJumpCallbackType`: The Jump Callback type: Discrete or Continuous.
-  - `prob_func::Function`: Function to use for generating the ODEProblem.
-  - `output_func::Function`: Function to use for generating the output of a single trajectory.
-  - `kwargs...`: Additional keyword arguments to pass to the solver.
+- `H::QuantumObject`: Hamiltonian of the system.
+- `ψ0::QuantumObject`: Initial state of the system.
+- `t_l::AbstractVector`: List of times at which to save the state of the system.
+- `c_ops::Vector`: List of collapse operators.
+- `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm`: Algorithm to use for the time evolution.
+- `e_ops::Vector`: List of operators for which to calculate expectation values.
+- `H_t::Union{Nothing,Function,TimeDependentOperatorSum}`: Time-dependent part of the Hamiltonian.
+- `params::NamedTuple`: Dictionary of parameters to pass to the solver.
+- `seeds::Union{Nothing, Vector{Int}}`: List of seeds for the random number generator. Length must be equal to the number of trajectories provided.
+- `jump_callback::LindbladJumpCallbackType`: The Jump Callback type: Discrete or Continuous.
+- `prob_func::Function`: Function to use for generating the ODEProblem.
+- `output_func::Function`: Function to use for generating the output of a single trajectory.
+- `kwargs...`: Additional keyword arguments to pass to the solver.
+
+Note that the default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+
+For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
 
-  - `prob::EnsembleProblem with ODEProblem`: The Ensemble ODEProblem for the Monte Carlo
-    wave function time evolution.
+- `prob::EnsembleProblem with ODEProblem`: The Ensemble ODEProblem for the Monte Carlo wave function time evolution.
 """
 function mcsolveEnsembleProblem(
     H::QuantumObject{MT1,OperatorQuantumObject},
@@ -300,7 +305,7 @@ function mcsolveEnsembleProblem(
     return ensemble_prob
 end
 
-"""
+@doc raw"""
     mcsolve(H::QuantumObject{<:AbstractArray{T1},OperatorQuantumObject},
         ψ0::QuantumObject{<:AbstractArray{T2},KetQuantumObject},
         t_l::AbstractVector,
@@ -318,29 +323,31 @@ Time evolution of an open quantum system using quantum trajectories.
 
 # Arguments
 
-  - `H::QuantumObject`: Hamiltonian of the system.
-  - `ψ0::QuantumObject`: Initial state of the system.
-  - `t_l::AbstractVector`: List of times at which to save the state of the system.
-  - `c_ops::Vector`: List of collapse operators.
-  - `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm`: Algorithm to use for the time evolution.
-  - `e_ops::Vector`: List of operators for which to calculate expectation values.
-  - `H_t::Union{Nothing,Function,TimeDependentOperatorSum}`: Time-dependent part of the Hamiltonian.
-  - `params::NamedTuple`: Dictionary of parameters to pass to the solver.
-  - `seeds::Union{Nothing, Vector{Int}}`: List of seeds for the random number generator. Length must be equal to the number of trajectories provided.
-  - `n_traj::Int`: Number of trajectories to use.
-  - `ensemble_method`: Ensemble method to use.
-  - `jump_callback::LindbladJumpCallbackType`: The Jump Callback type: Discrete or Continuous.
-  - `prob_func::Function`: Function to use for generating the ODEProblem.
-  - `output_func::Function`: Function to use for generating the output of a single trajectory.
-  - `kwargs...`: Additional keyword arguments to pass to the solver.
+- `H::QuantumObject`: Hamiltonian of the system.
+- `ψ0::QuantumObject`: Initial state of the system.
+- `t_l::AbstractVector`: List of times at which to save the state of the system.
+- `c_ops::Vector`: List of collapse operators.
+- `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm`: Algorithm to use for the time evolution.
+- `e_ops::Vector`: List of operators for which to calculate expectation values.
+- `H_t::Union{Nothing,Function,TimeDependentOperatorSum}`: Time-dependent part of the Hamiltonian.
+- `params::NamedTuple`: Dictionary of parameters to pass to the solver.
+- `seeds::Union{Nothing, Vector{Int}}`: List of seeds for the random number generator. Length must be equal to the number of trajectories provided.
+- `n_traj::Int`: Number of trajectories to use.
+- `ensemble_method`: Ensemble method to use.
+- `jump_callback::LindbladJumpCallbackType`: The Jump Callback type: Discrete or Continuous.
+- `prob_func::Function`: Function to use for generating the ODEProblem.
+- `output_func::Function`: Function to use for generating the output of a single trajectory.
+- `kwargs...`: Additional keyword arguments to pass to the solver.
+
+Note that `ensemble_method` can be one of `EnsembleThreads()`, `EnsembleSerial()`, `EnsembleDistributed()`.
+
+The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+
+For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
 
-  - `sol::TimeEvolutionMCSol`: The solution of the time evolution.
-
-# Notes
-
-`ensemble_method` can be one of `EnsembleThreads()`, `EnsembleSerial()`, `EnsembleDistributed()`.
+- `sol::TimeEvolutionMCSol`: The solution of the time evolution.
 """
 function mcsolve(
     H::QuantumObject{MT1,OperatorQuantumObject},

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -99,7 +99,7 @@ function _mcsolve_generate_statistics(sol, i, times, states, expvals_all, jump_t
     return jump_which[i] = sol_i.prob.p.jump_which
 end
 
-"""
+@doc raw"""
     mcsolveProblem(H::QuantumObject{<:AbstractArray{T1},OperatorQuantumObject},
         ψ0::QuantumObject{<:AbstractArray{T2},KetQuantumObject},
         t_l::AbstractVector,

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -52,9 +52,12 @@ Generates the ODEProblem for the master equation time evolution of an open quant
 - `progress_bar::Bool=true`: Whether to show the progress bar.
 - `kwargs...`: The keyword arguments for the ODEProblem.
 
-Note that the default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+# Notes
 
-For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
+- The states will be saved depend on the keyword argument `saveat` in `kwargs`.
+- If `e_ops` is specified, the default value of `saveat=[t_l[end]]` (only save the final state), otherwise, `saveat=t_l` (saving the states corresponding to `t_l`). You can also specify `e_ops` and `saveat` separately.
+- The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+- For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
 
@@ -177,13 +180,16 @@ where
 - `progress_bar::Bool`: Whether to show the progress bar.
 - `kwargs...`: Additional keyword arguments to pass to the solver.
 
-Note that the default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+# Notes
 
-For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
+- The states will be saved depend on the keyword argument `saveat` in `kwargs`.
+- If `e_ops` is specified, the default value of `saveat=[t_l[end]]` (only save the final state), otherwise, `saveat=t_l` (saving the states corresponding to `t_l`). You can also specify `e_ops` and `saveat` separately.
+- The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+- For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
 
-- `sol::TimeEvolutionSol`: The solution of the time evolution.
+- `sol::TimeEvolutionSol`: The solution of the time evolution. See also [`TimeEvolutionSol`](@ref)
 """
 function mesolve(
     H::QuantumObject{MT1,HOpType},
@@ -225,7 +231,7 @@ function mesolve(prob::ODEProblem, alg::OrdinaryDiffEqAlgorithm = Tsit5())
     sol = solve(prob, alg)
     ρt =
         isempty(sol.prob.kwargs[:saveat]) ? QuantumObject[] :
-        map(ϕ -> QuantumObject(vec2mat(ϕ), dims = sol.prob.p.Hdims), sol.u)
+        map(ϕ -> QuantumObject(vec2mat(ϕ), type = Operator, dims = sol.prob.p.Hdims), sol.u)
 
     return TimeEvolutionSol(
         sol.t,

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -26,7 +26,7 @@ function mesolve_td_dudt!(du, u, p, t)
     return mul!(du, L_t, u, 1, 1)
 end
 
-"""
+@doc raw"""
     mesolveProblem(H::QuantumObject,
         ψ0::QuantumObject,
         t_l::AbstractVector, c_ops::AbstractVector=[];
@@ -41,20 +41,24 @@ Generates the ODEProblem for the master equation time evolution of an open quant
 
 # Arguments
 
-  - `H::QuantumObject`: The Hamiltonian or the Liouvillian of the system.
-  - `ψ0::QuantumObject`: The initial state of the system.
-  - `t_l::AbstractVector`: The time list of the evolution.
-  - `c_ops::AbstractVector=[]`: The list of the collapse operators.
-  - `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm=Tsit5()`: The algorithm used for the time evolution.
-  - `e_ops::AbstractVector=[]`: The list of the operators for which the expectation values are calculated.
-  - `H_t::Union{Nothing,Function,TimeDependentOperatorSum}=nothing`: The time-dependent Hamiltonian or Liouvillian.
-  - `params::NamedTuple=NamedTuple()`: The parameters of the time evolution.
-  - `progress_bar::Bool=true`: Whether to show the progress bar.
-  - `kwargs...`: The keyword arguments for the ODEProblem.
+- `H::QuantumObject`: The Hamiltonian or the Liouvillian of the system.
+- `ψ0::QuantumObject`: The initial state of the system.
+- `t_l::AbstractVector`: The time list of the evolution.
+- `c_ops::AbstractVector=[]`: The list of the collapse operators.
+- `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm=Tsit5()`: The algorithm used for the time evolution.
+- `e_ops::AbstractVector=[]`: The list of the operators for which the expectation values are calculated.
+- `H_t::Union{Nothing,Function,TimeDependentOperatorSum}=nothing`: The time-dependent Hamiltonian or Liouvillian.
+- `params::NamedTuple=NamedTuple()`: The parameters of the time evolution.
+- `progress_bar::Bool=true`: Whether to show the progress bar.
+- `kwargs...`: The keyword arguments for the ODEProblem.
+
+Note that the default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+
+For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
 
-  - `prob::ODEProblem`: The ODEProblem for the master equation time evolution.
+- `prob::ODEProblem`: The ODEProblem for the master equation time evolution.
 """
 function mesolveProblem(
     H::QuantumObject{MT1,HOpType},
@@ -135,7 +139,7 @@ function _mesolveProblem(
     return ODEProblem{true,SciMLBase.FullSpecialize}(mesolve_td_dudt!, ρ0, tspan, p; kwargs...)
 end
 
-"""
+@doc raw"""
     mesolve(H::QuantumObject,
         ψ0::QuantumObject,
         t_l::AbstractVector, c_ops::AbstractVector=[];
@@ -146,24 +150,38 @@ end
         progress_bar::Bool=true,
         kwargs...)
 
-Time evolution of an open quantum system using master equation.
+Time evolution of an open quantum system using Lindblad master equation:
+
+```math
+\frac{\partial \rho(t)}{\partial t} = -i[\hat{H}, \rho(t)] + \sum_i \mathcal{D}(\hat{O}_i) [\rho(t)]
+```
+
+where 
+
+```math
+\mathcal{D}(\hat{O}_i) [\rho(t)] = \hat{O}_i \rho(t) \hat{O}_i^\dagger - \frac{1}{2} \hat{O}_i^\dagger \hat{O}_i \rho(t) - \frac{1}{2} \rho(t) \hat{O}_i^\dagger \hat{O}_i
+```
 
 # Arguments
 
-  - `H::QuantumObject`: Hamiltonian of Liouvillian of the system.
-  - `ψ0::QuantumObject`: Initial state of the system.
-  - `t_l::AbstractVector`: List of times at which to save the state of the system.
-  - `c_ops::AbstractVector`: List of collapse operators.
-  - `alg::OrdinaryDiffEqAlgorithm`: Algorithm to use for the time evolution.
-  - `e_ops::AbstractVector`: List of operators for which to calculate expectation values.
-  - `H_t::Union{Nothing,Function,TimeDependentOperatorSum}`: Time-dependent part of the Hamiltonian.
-  - `params::NamedTuple`: Named Tuple of parameters to pass to the solver.
-  - `progress_bar::Bool`: Whether to show the progress bar.
-  - `kwargs...`: Additional keyword arguments to pass to the solver.
+- `H::QuantumObject`: Hamiltonian ``\hat{H}`` or Liouvillian of the system.
+- `ψ0::QuantumObject`: Initial state of the system.
+- `t_l::AbstractVector`: List of times at which to save the state of the system.
+- `c_ops::AbstractVector`: List of collapse operators ``\{\hat{O}_i\}_i``.
+- `alg::OrdinaryDiffEqAlgorithm`: Algorithm to use for the time evolution.
+- `e_ops::AbstractVector`: List of operators for which to calculate expectation values.
+- `H_t::Union{Nothing,Function,TimeDependentOperatorSum}`: Time-dependent part of the Hamiltonian.
+- `params::NamedTuple`: Named Tuple of parameters to pass to the solver.
+- `progress_bar::Bool`: Whether to show the progress bar.
+- `kwargs...`: Additional keyword arguments to pass to the solver.
+
+Note that the default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+
+For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
 
-  - `sol::TimeEvolutionSol`: The solution of the time evolution.
+- `sol::TimeEvolutionSol`: The solution of the time evolution.
 """
 function mesolve(
     H::QuantumObject{MT1,HOpType},

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -96,7 +96,8 @@ function mesolveProblem(
 }
     H.dims != ψ0.dims && throw(DimensionMismatch("The two quantum objects are not of the same Hilbert dimension."))
 
-    haskey(kwargs, :save_idxs) && throw(ArgumentError("The keyword argument \"save_idxs\" is not supported in QuantumToolbox."))
+    haskey(kwargs, :save_idxs) &&
+        throw(ArgumentError("The keyword argument \"save_idxs\" is not supported in QuantumToolbox."))
 
     is_time_dependent = !(H_t === nothing)
 

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -41,13 +41,13 @@ end
 Generates the ODEProblem for the master equation time evolution of an open quantum system:
 
 ```math
-\frac{\partial \rho(t)}{\partial t} = -i[\hat{H}, \rho(t)] + \sum_i \mathcal{D}(\hat{O}_i) [\rho(t)]
+\frac{\partial \rho(t)}{\partial t} = -i[\hat{H}, \rho(t)] + \sum_n \mathcal{D}(\hat{C}_n) [\rho(t)]
 ```
 
 where 
 
 ```math
-\mathcal{D}(\hat{O}_i) [\rho(t)] = \hat{O}_i \rho(t) \hat{O}_i^\dagger - \frac{1}{2} \hat{O}_i^\dagger \hat{O}_i \rho(t) - \frac{1}{2} \rho(t) \hat{O}_i^\dagger \hat{O}_i
+\mathcal{D}(\hat{C}_n) [\rho(t)] = \hat{C}_n \rho(t) \hat{C}_n^\dagger - \frac{1}{2} \hat{C}_n^\dagger \hat{C}_n \rho(t) - \frac{1}{2} \rho(t) \hat{C}_n^\dagger \hat{C}_n
 ```
 
 # Arguments
@@ -55,7 +55,7 @@ where
 - `H::QuantumObject`: The Hamiltonian ``\hat{H}`` or the Liouvillian of the system.
 - `ψ0::QuantumObject`: The initial state of the system.
 - `t_l::AbstractVector`: The time list of the evolution.
-- `c_ops::AbstractVector=[]`: The list of the collapse operators ``\{\hat{O}_i\}_i``.
+- `c_ops::AbstractVector=[]`: The list of the collapse operators ``\{\hat{C}_n\}_n``.
 - `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm=Tsit5()`: The algorithm used for the time evolution.
 - `e_ops::AbstractVector=[]`: The list of the operators for which the expectation values are calculated.
 - `H_t::Union{Nothing,Function,TimeDependentOperatorSum}=nothing`: The time-dependent Hamiltonian or Liouvillian.
@@ -170,21 +170,21 @@ end
 Time evolution of an open quantum system using Lindblad master equation:
 
 ```math
-\frac{\partial \rho(t)}{\partial t} = -i[\hat{H}, \rho(t)] + \sum_i \mathcal{D}(\hat{O}_i) [\rho(t)]
+\frac{\partial \rho(t)}{\partial t} = -i[\hat{H}, \rho(t)] + \sum_n \mathcal{D}(\hat{C}_n) [\rho(t)]
 ```
 
 where 
 
 ```math
-\mathcal{D}(\hat{O}_i) [\rho(t)] = \hat{O}_i \rho(t) \hat{O}_i^\dagger - \frac{1}{2} \hat{O}_i^\dagger \hat{O}_i \rho(t) - \frac{1}{2} \rho(t) \hat{O}_i^\dagger \hat{O}_i
+\mathcal{D}(\hat{C}_n) [\rho(t)] = \hat{C}_n \rho(t) \hat{C}_n^\dagger - \frac{1}{2} \hat{C}_n^\dagger \hat{C}_n \rho(t) - \frac{1}{2} \rho(t) \hat{C}_n^\dagger \hat{C}_n
 ```
 
 # Arguments
 
-- `H::QuantumObject`: Hamiltonian ``\hat{H}`` or Liouvillian of the system.
-- `ψ0::QuantumObject`: Initial state of the system.
-- `t_l::AbstractVector`: List of times at which to save the state of the system.
-- `c_ops::AbstractVector`: List of collapse operators ``\{\hat{O}_i\}_i``.
+- `H::QuantumObject`: The Hamiltonian ``\hat{H}`` or the Liouvillian of the system.
+- `ψ0::QuantumObject`: The initial state of the system.
+- `t_l::AbstractVector`: The time list of the evolution.
+- `c_ops::AbstractVector=[]`: The list of the collapse operators ``\{\hat{C}_n\}_n``.
 - `alg::OrdinaryDiffEqAlgorithm`: Algorithm to use for the time evolution.
 - `e_ops::AbstractVector`: List of operators for which to calculate expectation values.
 - `H_t::Union{Nothing,Function,TimeDependentOperatorSum}`: Time-dependent part of the Hamiltonian.

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -103,7 +103,7 @@ function mesolveProblem(
         params...,
     )
 
-    saveat = is_empty_e_ops ? t_l : []
+    saveat = is_empty_e_ops ? t_l : [t_l[end]]
     default_values = (abstol = 1e-7, reltol = 1e-5, saveat = saveat)
     kwargs2 = merge(default_values, kwargs)
     if !isempty(e_ops) || progress_bar

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -29,7 +29,8 @@ end
 @doc raw"""
     mesolveProblem(H::QuantumObject,
         ψ0::QuantumObject,
-        t_l::AbstractVector, c_ops::AbstractVector=[];
+        t_l::AbstractVector, 
+        c_ops::AbstractVector=[];
         alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm=Tsit5(),
         e_ops::AbstractVector=[],
         H_t::Union{Nothing,Function,TimeDependentOperatorSum}=nothing,
@@ -37,14 +38,24 @@ end
         progress_bar::Bool=true,
         kwargs...)
 
-Generates the ODEProblem for the master equation time evolution of an open quantum system.
+Generates the ODEProblem for the master equation time evolution of an open quantum system:
+
+```math
+\frac{\partial \rho(t)}{\partial t} = -i[\hat{H}, \rho(t)] + \sum_i \mathcal{D}(\hat{O}_i) [\rho(t)]
+```
+
+where 
+
+```math
+\mathcal{D}(\hat{O}_i) [\rho(t)] = \hat{O}_i \rho(t) \hat{O}_i^\dagger - \frac{1}{2} \hat{O}_i^\dagger \hat{O}_i \rho(t) - \frac{1}{2} \rho(t) \hat{O}_i^\dagger \hat{O}_i
+```
 
 # Arguments
 
-- `H::QuantumObject`: The Hamiltonian or the Liouvillian of the system.
+- `H::QuantumObject`: The Hamiltonian ``\hat{H}`` or the Liouvillian of the system.
 - `ψ0::QuantumObject`: The initial state of the system.
 - `t_l::AbstractVector`: The time list of the evolution.
-- `c_ops::AbstractVector=[]`: The list of the collapse operators.
+- `c_ops::AbstractVector=[]`: The list of the collapse operators ``\{\hat{O}_i\}_i``.
 - `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm=Tsit5()`: The algorithm used for the time evolution.
 - `e_ops::AbstractVector=[]`: The list of the operators for which the expectation values are calculated.
 - `H_t::Union{Nothing,Function,TimeDependentOperatorSum}=nothing`: The time-dependent Hamiltonian or Liouvillian.
@@ -147,7 +158,8 @@ end
 @doc raw"""
     mesolve(H::QuantumObject,
         ψ0::QuantumObject,
-        t_l::AbstractVector, c_ops::AbstractVector=[];
+        t_l::AbstractVector, 
+        c_ops::AbstractVector=[];
         alg::OrdinaryDiffEqAlgorithm=Tsit5(),
         e_ops::AbstractVector=[],
         H_t::Union{Nothing,Function,TimeDependentOperatorSum}=nothing,

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -96,6 +96,8 @@ function mesolveProblem(
 }
     H.dims != ψ0.dims && throw(DimensionMismatch("The two quantum objects are not of the same Hilbert dimension."))
 
+    haskey(kwargs, :save_idxs) && throw(ArgumentError("The keyword argument \"save_idxs\" is not supported in QuantumToolbox."))
+
     is_time_dependent = !(H_t === nothing)
 
     ρ0 = mat2vec(ket2dm(ψ0).data)

--- a/src/time_evolution/sesolve.jl
+++ b/src/time_evolution/sesolve.jl
@@ -38,19 +38,23 @@ Generates the ODEProblem for the Schrödinger time evolution of a quantum system
 
 # Arguments
 
-  - `H::QuantumObject`: The Hamiltonian of the system.
-  - `ψ0::QuantumObject`: The initial state of the system.
-  - `t_l::AbstractVector`: The time list of the evolution.
-  - `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm`: The algorithm used for the time evolution.
-  - `e_ops::AbstractVector`: The list of operators to be evaluated during the evolution.
-  - `H_t::Union{Nothing,Function,TimeDependentOperatorSum}`: The time-dependent Hamiltonian of the system. If `nothing`, the Hamiltonian is time-independent.
-  - `params::NamedTuple`: The parameters of the system.
-  - `progress_bar::Bool`: Whether to show the progress bar.
-  - `kwargs...`: The keyword arguments passed to the `ODEProblem` constructor.
+- `H::QuantumObject`: The Hamiltonian of the system.
+- `ψ0::QuantumObject`: The initial state of the system.
+- `t_l::AbstractVector`: The time list of the evolution.
+- `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm`: The algorithm used for the time evolution.
+- `e_ops::AbstractVector`: The list of operators to be evaluated during the evolution.
+- `H_t::Union{Nothing,Function,TimeDependentOperatorSum}`: The time-dependent Hamiltonian of the system. If `nothing`, the Hamiltonian is time-independent.
+- `params::NamedTuple`: The parameters of the system.
+- `progress_bar::Bool`: Whether to show the progress bar.
+- `kwargs...`: The keyword arguments passed to the `ODEProblem` constructor.
+
+Note that the default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+
+For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
 
-  - `prob`: The `ODEProblem` for the Schrödinger time evolution of the system.
+- `prob`: The `ODEProblem` for the Schrödinger time evolution of the system.
 """
 function sesolveProblem(
     H::QuantumObject{MT1,OperatorQuantumObject},
@@ -122,7 +126,7 @@ function _sesolveProblem(
     return ODEProblem{true,SciMLBase.FullSpecialize}(sesolve_td_dudt!, ϕ0, tspan, p; kwargs...)
 end
 
-"""
+@doc raw"""
     sesolve(H::QuantumObject,
         ψ0::QuantumObject,
         t_l::AbstractVector;
@@ -133,22 +137,31 @@ end
         progress_bar::Bool=true,
         kwargs...)
 
-Time evolution of a closed quantum system using the Schrödinger equation.
+Time evolution of a closed quantum system using the Schrödinger equation:
+
+```math
+\frac{\partial \psi(t)}{\partial t}=-i H \psi(t)
+```
 
 # Arguments
 
-  - `H::QuantumObject`: Hamiltonian of the system.
+- `H::QuantumObject`: Hamiltonian of the system.
+- `ψ0::QuantumObject`: Initial state of the system.
+- `t_l::AbstractVector`: List of times at which to save the state of the system.
+- `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm`: Algorithm to use for the time evolution.
+- `e_ops::AbstractVector`: List of operators for which to calculate expectation values.
+- `H_t::Union{Nothing,Function,TimeDependentOperatorSum}`: Time-dependent part of the Hamiltonian.
+- `params::NamedTuple`: Dictionary of parameters to pass to the solver.
+- `progress_bar::Bool`: Whether to show the progress bar.
+- `kwargs...`: Additional keyword arguments to pass to the solver.
 
-  - `ψ0::QuantumObject`: Initial state of the system.
-  - `t_l::AbstractVector`: List of times at which to save the state of the system.
-  - `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm`: Algorithm to use for the time evolution.
-  - `e_ops::AbstractVector`: List of operators for which to calculate expectation values.
-  - `H_t::Union{Nothing,Function,TimeDependentOperatorSum}`: Time-dependent part of the Hamiltonian.
-  - `params::NamedTuple`: Dictionary of parameters to pass to the solver.
-  - `progress_bar::Bool`: Whether to show the progress bar.
-  - `kwargs...`: Additional keyword arguments to pass to the solver.
-  - Returns
-  - `sol::TimeEvolutionSol`: The solution of the time evolution.
+Note that the default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+
+For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
+
+Returns
+
+- `sol::TimeEvolutionSol`: The solution of the time evolution.
 """
 function sesolve(
     H::QuantumObject{MT1,OperatorQuantumObject},

--- a/src/time_evolution/sesolve.jl
+++ b/src/time_evolution/sesolve.jl
@@ -34,12 +34,16 @@ end
         progress_bar::Bool=true,
         kwargs...)
 
-Generates the ODEProblem for the Schrödinger time evolution of a quantum system.
+Generates the ODEProblem for the Schrödinger time evolution of a quantum system:
+
+```math
+\frac{\partial}{\partial t} |\psi(t)\rangle = -i \hat{H} |\psi(t)\rangle
+```
 
 # Arguments
 
-- `H::QuantumObject`: The Hamiltonian of the system.
-- `ψ0::QuantumObject`: The initial state of the system.
+- `H::QuantumObject`: The Hamiltonian of the system ``\hat{H}``.
+- `ψ0::QuantumObject`: The initial state of the system ``|\psi(0)\rangle``.
 - `t_l::AbstractVector`: The time list of the evolution.
 - `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm`: The algorithm used for the time evolution.
 - `e_ops::AbstractVector`: The list of operators to be evaluated during the evolution.
@@ -145,13 +149,13 @@ end
 Time evolution of a closed quantum system using the Schrödinger equation:
 
 ```math
-\frac{\partial \psi(t)}{\partial t}=-i H \psi(t)
+\frac{\partial}{\partial t} |\psi(t)\rangle = -i \hat{H} |\psi(t)\rangle
 ```
 
 # Arguments
 
-- `H::QuantumObject`: Hamiltonian of the system.
-- `ψ0::QuantumObject`: Initial state of the system.
+- `H::QuantumObject`: The Hamiltonian of the system ``\hat{H}``.
+- `ψ0::QuantumObject`: The initial state of the system ``|\psi(0)\rangle``.
 - `t_l::AbstractVector`: List of times at which to save the state of the system.
 - `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm`: Algorithm to use for the time evolution.
 - `e_ops::AbstractVector`: List of operators for which to calculate expectation values.

--- a/src/time_evolution/sesolve.jl
+++ b/src/time_evolution/sesolve.jl
@@ -23,7 +23,7 @@ function sesolve_td_dudt!(du, u, p, t)
     return mul!(du, H_t, u, -1im, 1)
 end
 
-"""
+@doc raw"""
     sesolveProblem(H::QuantumObject,
         ψ0::QuantumObject,
         t_l::AbstractVector;
@@ -38,15 +38,15 @@ Generates the ODEProblem for the Schrödinger time evolution of a quantum system
 
 # Arguments
 
-  - `H::QuantumObject`: The Hamiltonian of the system.
-  - `ψ0::QuantumObject`: The initial state of the system.
-  - `t_l::AbstractVector`: The time list of the evolution.
-  - `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm`: The algorithm used for the time evolution.
-  - `e_ops::AbstractVector`: The list of operators to be evaluated during the evolution.
-  - `H_t::Union{Nothing,Function,TimeDependentOperatorSum}`: The time-dependent Hamiltonian of the system. If `nothing`, the Hamiltonian is time-independent.
-  - `params::NamedTuple`: The parameters of the system.
-  - `progress_bar::Bool`: Whether to show the progress bar.
-  - `kwargs...`: The keyword arguments passed to the `ODEProblem` constructor.
+- `H::QuantumObject`: The Hamiltonian of the system.
+- `ψ0::QuantumObject`: The initial state of the system.
+- `t_l::AbstractVector`: The time list of the evolution.
+- `alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm`: The algorithm used for the time evolution.
+- `e_ops::AbstractVector`: The list of operators to be evaluated during the evolution.
+- `H_t::Union{Nothing,Function,TimeDependentOperatorSum}`: The time-dependent Hamiltonian of the system. If `nothing`, the Hamiltonian is time-independent.
+- `params::NamedTuple`: The parameters of the system.
+- `progress_bar::Bool`: Whether to show the progress bar.
+- `kwargs...`: The keyword arguments passed to the `ODEProblem` constructor.
 
 Note that the default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
 
@@ -54,7 +54,7 @@ For more details about `alg` and extra `kwargs`, please refer to [`DifferentialE
 
 # Returns
 
-  - `prob`: The `ODEProblem` for the Schrödinger time evolution of the system.
+- `prob`: The `ODEProblem` for the Schrödinger time evolution of the system.
 """
 function sesolveProblem(
     H::QuantumObject{MT1,OperatorQuantumObject},
@@ -90,7 +90,7 @@ function sesolveProblem(
         params...,
     )
 
-    saveat = is_empty_e_ops ? t_l : []
+    saveat = is_empty_e_ops ? t_l : [t_l[end]]
     default_values = (abstol = 1e-7, reltol = 1e-5, saveat = saveat)
     kwargs2 = merge(default_values, kwargs)
     if !isempty(e_ops) || progress_bar

--- a/src/time_evolution/sesolve.jl
+++ b/src/time_evolution/sesolve.jl
@@ -48,9 +48,12 @@ Generates the ODEProblem for the Schrödinger time evolution of a quantum system
 - `progress_bar::Bool`: Whether to show the progress bar.
 - `kwargs...`: The keyword arguments passed to the `ODEProblem` constructor.
 
-Note that the default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+# Notes
 
-For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
+- The states will be saved depend on the keyword argument `saveat` in `kwargs`.
+- If `e_ops` is specified, the default value of `saveat=[t_l[end]]` (only save the final state), otherwise, `saveat=t_l` (saving the states corresponding to `t_l`). You can also specify `e_ops` and `saveat` separately.
+- The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+- For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
 
@@ -157,13 +160,16 @@ Time evolution of a closed quantum system using the Schrödinger equation:
 - `progress_bar::Bool`: Whether to show the progress bar.
 - `kwargs...`: Additional keyword arguments to pass to the solver.
 
-Note that the default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+# Notes
 
-For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
+- The states will be saved depend on the keyword argument `saveat` in `kwargs`.
+- If `e_ops` is specified, the default value of `saveat=[t_l[end]]` (only save the final state), otherwise, `saveat=t_l` (saving the states corresponding to `t_l`). You can also specify `e_ops` and `saveat` separately.
+- The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+- For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
-Returns
+# Returns
 
-- `sol::TimeEvolutionSol`: The solution of the time evolution.
+- `sol::TimeEvolutionSol`: The solution of the time evolution. See also [`TimeEvolutionSol`](@ref)
 """
 function sesolve(
     H::QuantumObject{MT1,OperatorQuantumObject},
@@ -194,7 +200,8 @@ end
 function sesolve(prob::ODEProblem, alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm = Tsit5())
     sol = solve(prob, alg)
     ψt =
-        isempty(sol.prob.kwargs[:saveat]) ? QuantumObject[] : map(ϕ -> QuantumObject(ϕ, dims = sol.prob.p.Hdims), sol.u)
+        isempty(sol.prob.kwargs[:saveat]) ? QuantumObject[] :
+        map(ϕ -> QuantumObject(ϕ, type = Ket, dims = sol.prob.p.Hdims), sol.u)
 
     return TimeEvolutionSol(
         sol.t,

--- a/src/time_evolution/sesolve.jl
+++ b/src/time_evolution/sesolve.jl
@@ -75,6 +75,8 @@ function sesolveProblem(
     kwargs...,
 ) where {MT1<:AbstractMatrix,T2,MT2<:AbstractMatrix}
     H.dims != ψ0.dims && throw(DimensionMismatch("The two quantum objects are not of the same Hilbert dimension."))
+    
+    haskey(kwargs, :save_idxs) && throw(ArgumentError("The keyword argument \"save_idxs\" is not supported in QuantumToolbox."))
 
     is_time_dependent = !(H_t === nothing)
 

--- a/src/time_evolution/sesolve.jl
+++ b/src/time_evolution/sesolve.jl
@@ -75,8 +75,9 @@ function sesolveProblem(
     kwargs...,
 ) where {MT1<:AbstractMatrix,T2,MT2<:AbstractMatrix}
     H.dims != ψ0.dims && throw(DimensionMismatch("The two quantum objects are not of the same Hilbert dimension."))
-    
-    haskey(kwargs, :save_idxs) && throw(ArgumentError("The keyword argument \"save_idxs\" is not supported in QuantumToolbox."))
+
+    haskey(kwargs, :save_idxs) &&
+        throw(ArgumentError("The keyword argument \"save_idxs\" is not supported in QuantumToolbox."))
 
     is_time_dependent = !(H_t === nothing)
 

--- a/src/time_evolution/time_evolution.jl
+++ b/src/time_evolution/time_evolution.jl
@@ -3,6 +3,21 @@ export TimeEvolutionSol, TimeEvolutionMCSol
 
 export liouvillian, liouvillian_floquet, liouvillian_generalized
 
+@doc raw"""
+    struct TimeEvolutionSol
+
+A structure storing the results and some information from solving time evolution.
+
+# Fields (Attributes)
+
+- `times::AbstractVector`: The time list of the evolution.
+- `states::Vector{QuantumObject}`: The list of result states.
+- `expect::Matrix`: The expectation values corresponding each time points in `times`.
+- `retcode`: The return code from the solver.
+- `alg`: The algorithm which is used during the solving process.
+- `abstol::Real`: The absolute tolerance which is used during the solving process.
+- `reltol::Real`: The relative tolerance which is used during the solving process.
+"""
 struct TimeEvolutionSol{TT<:Vector{<:Real},TS<:AbstractVector,TE<:Matrix{ComplexF64}}
     times::TT
     states::TS

--- a/src/time_evolution/time_evolution.jl
+++ b/src/time_evolution/time_evolution.jl
@@ -7,6 +7,22 @@ struct TimeEvolutionSol{TT<:Vector{<:Real},TS<:AbstractVector,TE<:Matrix{Complex
     times::TT
     states::TS
     expect::TE
+    retcode::Enum
+    alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm
+    abstol::Real
+    reltol::Real
+end
+
+function Base.show(io::IO, sol::TimeEvolutionSol)
+    print(io, "Solution of time evolution\n")
+    print(io, "(return code: $(sol.retcode))\n")
+    print(io, "--------------------------\n")
+    print(io, "num_states = $(length(sol.states))\n")
+    print(io, "num_expect = $(size(sol.expect, 1))\n")
+    print(io, "ODE alg.: $(sol.alg)\n")
+    print(io, "abstol = $(sol.abstol)\n")
+    print(io, "reltol = $(sol.reltol)\n")
+    return nothing
 end
 
 struct TimeEvolutionMCSol{

--- a/src/time_evolution/time_evolution.jl
+++ b/src/time_evolution/time_evolution.jl
@@ -12,7 +12,7 @@ A structure storing the results and some information from solving time evolution
 
 - `times::AbstractVector`: The time list of the evolution.
 - `states::Vector{QuantumObject}`: The list of result states.
-- `expect::Matrix`: The expectation values corresponding each time points in `times`.
+- `expect::Matrix`: The expectation values corresponding to each time point in `times`.
 - `retcode`: The return code from the solver.
 - `alg`: The algorithm which is used during the solving process.
 - `abstol::Real`: The absolute tolerance which is used during the solving process.
@@ -40,6 +40,25 @@ function Base.show(io::IO, sol::TimeEvolutionSol)
     return nothing
 end
 
+@doc raw"""
+    struct TimeEvolutionMCSol
+
+A structure storing the results and some information from solving quantum trajectories of the Monte Carlo wave function time evolution.
+
+# Fields (Attributes)
+
+- `n_traj::Int`: Number of trajectories
+- `times::AbstractVector`: The time list of the evolution in each trajectory.
+- `states::Vector{Vector{QuantumObject}}`: The list of result states in each trajectory.
+- `expect::Matrix`: The expectation values (averaging all trajectories) corresponding to each time point in `times`.
+- `expect_all::Array`: The expectation values corresponding to each trajectory and each time point in `times`
+- `jump_times::Vector{Vector{Real}}`: The time records of every quantum jump happened in each trajectory.
+- `jump_which::Vector{Vector{Int}}`: The indices of the jump operators in `c_ops` that describe the corresponding quantum jumps happened in each trajectory.
+- `converged::Bool`: Whether the solution is converged or not.
+- `alg`: The algorithm which is used during the solving process.
+- `abstol::Real`: The absolute tolerance which is used during the solving process.
+- `reltol::Real`: The relative tolerance which is used during the solving process.
+"""
 struct TimeEvolutionMCSol{
     TT<:Vector{<:Vector{<:Real}},
     TS<:AbstractVector,
@@ -48,12 +67,30 @@ struct TimeEvolutionMCSol{
     TJT<:Vector{<:Vector{<:Real}},
     TJW<:Vector{<:Vector{<:Integer}},
 }
+    n_traj::Int
     times::TT
     states::TS
     expect::TE
     expect_all::TEA
     jump_times::TJT
     jump_which::TJW
+    converged::Bool
+    alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm
+    abstol::Real
+    reltol::Real
+end
+
+function Base.show(io::IO, sol::TimeEvolutionMCSol)
+    print(io, "Solution of quantum trajectories\n")
+    print(io, "(converged: $(sol.converged))\n")
+    print(io, "--------------------------------\n")
+    print(io, "num_trajectories = $(sol.n_traj)\n")
+    print(io, "num_states = $(length(sol.states[1]))\n")
+    print(io, "num_expect = $(size(sol.expect, 1))\n")
+    print(io, "ODE alg.: $(sol.alg)\n")
+    print(io, "abstol = $(sol.abstol)\n")
+    print(io, "reltol = $(sol.reltol)\n")
+    return nothing
 end
 
 abstract type LindbladJumpCallbackType end

--- a/src/time_evolution/time_evolution.jl
+++ b/src/time_evolution/time_evolution.jl
@@ -52,8 +52,8 @@ A structure storing the results and some information from solving quantum trajec
 - `states::Vector{Vector{QuantumObject}}`: The list of result states in each trajectory.
 - `expect::Matrix`: The expectation values (averaging all trajectories) corresponding to each time point in `times`.
 - `expect_all::Array`: The expectation values corresponding to each trajectory and each time point in `times`
-- `jump_times::Vector{Vector{Real}}`: The time records of every quantum jump happened in each trajectory.
-- `jump_which::Vector{Vector{Int}}`: The indices of the jump operators in `c_ops` that describe the corresponding quantum jumps happened in each trajectory.
+- `jump_times::Vector{Vector{Real}}`: The time records of every quantum jump occurred in each trajectory.
+- `jump_which::Vector{Vector{Int}}`: The indices of the jump operators in `c_ops` that describe the corresponding quantum jumps occurred in each trajectory.
 - `converged::Bool`: Whether the solution is converged or not.
 - `alg`: The algorithm which is used during the solving process.
 - `abstol::Real`: The absolute tolerance which is used during the solving process.
@@ -186,16 +186,16 @@ end
 @doc raw"""
     liouvillian(H::QuantumObject, c_ops::AbstractVector, Id_cache=I(prod(H.dims)))
 
-Construct the Liouvillian [`SuperOperator`](@ref) for a system Hamiltonian ``\hat{H}`` and a set of collapse operators ``\hat{O}_i``:
+Construct the Liouvillian [`SuperOperator`](@ref) for a system Hamiltonian ``\hat{H}`` and a set of collapse operators ``\{\hat{C}_n\}_n``:
 
 ```math
-\mathcal{L} [\cdot] = -i[\hat{H}, \cdot] + \sum_i \mathcal{D}(\hat{O}_i) [\cdot]
+\mathcal{L} [\cdot] = -i[\hat{H}, \cdot] + \sum_n \mathcal{D}(\hat{C}_n) [\cdot]
 ```
 
 where 
 
 ```math
-\mathcal{D}(\hat{O}_i) [\cdot] = \hat{O}_i [\cdot] \hat{O}_i^\dagger - \frac{1}{2} \hat{O}_i^\dagger \hat{O}_i [\cdot] - \frac{1}{2} [\cdot] \hat{O}_i^\dagger \hat{O}_i
+\mathcal{D}(\hat{C}_n) [\cdot] = \hat{C}_n [\cdot] \hat{C}_n^\dagger - \frac{1}{2} \hat{C}_n^\dagger \hat{C}_n [\cdot] - \frac{1}{2} [\cdot] \hat{C}_n^\dagger \hat{C}_n
 ```
 
 The optional argument `Id_cache` can be used to pass a precomputed identity matrix. This can be useful when the same function is applied multiple times with a known Hilbert space dimension.

--- a/src/time_evolution/time_evolution_dynamical.jl
+++ b/src/time_evolution/time_evolution_dynamical.jl
@@ -242,7 +242,15 @@ function dfd_mesolve(
         eachindex(sol.t),
     )
 
-    return TimeEvolutionSol(sol.t, ρt, sol.prob.p.expvals)
+    return TimeEvolutionSol(
+        sol.t,
+        ρt,
+        sol.prob.p.expvals,
+        sol.retcode,
+        sol.alg,
+        sol.prob.kwargs[:abstol],
+        sol.prob.kwargs[:reltol],
+    )
 end
 
 # Dynamical Shifted Fock mesolve
@@ -443,7 +451,7 @@ function dsf_mesolve(
         kwargs...,
     )
 
-    return mesolve(dsf_prob; alg = alg, kwargs...)
+    return mesolve(dsf_prob, alg)
 end
 
 function dsf_mesolve(

--- a/src/time_evolution/time_evolution_dynamical.jl
+++ b/src/time_evolution/time_evolution_dynamical.jl
@@ -191,7 +191,7 @@ function dfd_mesolveProblem(
 end
 
 @doc raw"""
-    function dfd_mesolve(H::Function, ψ0::QuantumObject,
+    dfd_mesolve(H::Function, ψ0::QuantumObject,
         t_l::AbstractVector, c_ops::Function, maxdims::AbstractVector,
         dfd_params::NamedTuple=NamedTuple();
         alg::OrdinaryDiffEq.OrdinaryDiffEqAlgorithm=Tsit5(),
@@ -402,7 +402,7 @@ function dsf_mesolveProblem(
 end
 
 @doc raw"""
-    function dsf_mesolve(H::Function,
+    dsf_mesolve(H::Function,
         ψ0::QuantumObject,
         t_l::AbstractVector, c_ops::Function,
         op_list::Vector{TOl},
@@ -667,7 +667,7 @@ function dsf_mcsolveEnsembleProblem(
 end
 
 @doc raw"""
-    function dsf_mcsolve(H::Function,
+    dsf_mcsolve(H::Function,
         ψ0::QuantumObject,
         t_l::AbstractVector, c_ops::Function,
         op_list::Vector{TOl},
@@ -723,5 +723,5 @@ function dsf_mcsolve(
         kwargs...,
     )
 
-    return mcsolve(ens_prob_mc; alg = alg, n_traj = n_traj, ensemble_method = ensemble_method, kwargs...)
+    return mcsolve(ens_prob_mc; alg = alg, n_traj = n_traj, ensemble_method = ensemble_method)
 end

--- a/src/time_evolution/time_evolution_dynamical.jl
+++ b/src/time_evolution/time_evolution_dynamical.jl
@@ -190,7 +190,7 @@ function dfd_mesolveProblem(
     return mesolveProblem(H₀, ψ0, t_l, c_ops₀; e_ops = e_ops₀, alg = alg, H_t = H_t, params = params2, kwargs2...)
 end
 
-"""
+@doc raw"""
     function dfd_mesolve(H::Function, ψ0::QuantumObject,
         t_l::AbstractVector, c_ops::Function, maxdims::AbstractVector,
         dfd_params::NamedTuple=NamedTuple();
@@ -393,7 +393,7 @@ function dsf_mesolveProblem(
     return mesolveProblem(H₀, ψ0, t_l, c_ops₀; e_ops = e_ops₀, alg = alg, H_t = H_t, params = params2, kwargs2...)
 end
 
-"""
+@doc raw"""
     function dsf_mesolve(H::Function,
         ψ0::QuantumObject,
         t_l::AbstractVector, c_ops::Function,
@@ -658,7 +658,7 @@ function dsf_mcsolveEnsembleProblem(
     )
 end
 
-"""
+@doc raw"""
     function dsf_mcsolve(H::Function,
         ψ0::QuantumObject,
         t_l::AbstractVector, c_ops::Function,
@@ -676,8 +676,7 @@ end
         krylov_dim::Int=min(5,cld(length(ψ0.data), 3)),
         kwargs...)
 
-Time evolution of a quantum system using the Monte Carlo wave function method
-and the Dynamical Shifted Fock algorithm.
+Time evolution of a quantum system using the Monte Carlo wave function method and the Dynamical Shifted Fock algorithm.
 """
 function dsf_mcsolve(
     H::Function,

--- a/test/time_evolution_and_partial_trace.jl
+++ b/test/time_evolution_and_partial_trace.jl
@@ -1,4 +1,5 @@
 @testset "Time Evolution and Partial Trace" begin
+    # sesolve
     N = 10
     a_d = kron(create(N), qeye(2))
     a = a_d'
@@ -25,6 +26,7 @@
           "abstol = $(sol.abstol)\n" *
           "reltol = $(sol.reltol)\n"
 
+    # mesolve and mcsolve
     a = destroy(N)
     a_d = a'
     H = a_d * a
@@ -56,6 +58,15 @@
           "ODE alg.: $(sol_mc.alg)\n" *
           "abstol = $(sol_mc.abstol)\n" *
           "reltol = $(sol_mc.reltol)\n"
+
+    # exceptions
+    psi_wrong = basis(N - 1, 3)
+    @test_throws DimensionMismatch sesolve(H, psi_wrong, t_l)
+    @test_throws DimensionMismatch mesolve(H, psi_wrong, t_l)
+    @test_throws DimensionMismatch mcsolve(H, psi_wrong, t_l)
+    @test_throws ArgumentError sesolve(H, psi0, t_l, save_idxs = [1, 2])
+    @test_throws ArgumentError mesolve(H, psi0, t_l, save_idxs = [1, 2])
+    @test_throws ArgumentError mcsolve(H, psi0, t_l, save_idxs = [1, 2])
 
     sp1 = kron(sigmap(), qeye(2))
     sm1 = sp1'

--- a/test/time_evolution_and_partial_trace.jl
+++ b/test/time_evolution_and_partial_trace.jl
@@ -11,9 +11,19 @@
     t_l = LinRange(0, 1000, 1000)
     e_ops = [a_d * a]
     sol = sesolve(H, psi0, t_l, e_ops = e_ops, alg = Vern7(), progress_bar = false)
+    sol_string = sprint((t, s) -> show(t, "text/plain", s), sol)
     @test sum(abs.(sol.expect[1, :] .- sin.(η * t_l) .^ 2)) / length(t_l) < 0.1
     @test ptrace(sol.states[end], 1) ≈ ptrace(ket2dm(sol.states[end]), 1)
     @test ptrace(sol.states[end]', 1) ≈ ptrace(sol.states[end], 1)
+    @test sol_string ==
+          "Solution of time evolution\n" *
+          "(return code: $(sol.retcode))\n" *
+          "--------------------------\n" *
+          "num_states = $(length(sol.states))\n" *
+          "num_expect = $(size(sol.expect, 1))\n" *
+          "ODE alg.: $(sol.alg)\n" *
+          "abstol = $(sol.abstol)\n" *
+          "reltol = $(sol.reltol)\n"
 
     a = destroy(N)
     a_d = a'
@@ -24,7 +34,17 @@
     t_l = LinRange(0, 100, 1000)
     sol_me = mesolve(H, psi0, t_l, c_ops, e_ops = e_ops, alg = Vern7(), progress_bar = false)
     sol_mc = mcsolve(H, psi0, t_l, c_ops, n_traj = 500, e_ops = e_ops, progress_bar = false)
+    sol_me_string = sprint((t, s) -> show(t, "text/plain", s), sol_me)
     @test sum(abs.(sol_mc.expect .- sol_me.expect)) / length(t_l) < 0.1
+    @test sol_me_string ==
+          "Solution of time evolution\n" *
+          "(return code: $(sol_me.retcode))\n" *
+          "--------------------------\n" *
+          "num_states = $(length(sol_me.states))\n" *
+          "num_expect = $(size(sol_me.expect, 1))\n" *
+          "ODE alg.: $(sol_me.alg)\n" *
+          "abstol = $(sol_me.abstol)\n" *
+          "reltol = $(sol_me.reltol)\n"
 
     sp1 = kron(sigmap(), qeye(2))
     sm1 = sp1'

--- a/test/time_evolution_and_partial_trace.jl
+++ b/test/time_evolution_and_partial_trace.jl
@@ -35,6 +35,7 @@
     sol_me = mesolve(H, psi0, t_l, c_ops, e_ops = e_ops, alg = Vern7(), progress_bar = false)
     sol_mc = mcsolve(H, psi0, t_l, c_ops, n_traj = 500, e_ops = e_ops, progress_bar = false)
     sol_me_string = sprint((t, s) -> show(t, "text/plain", s), sol_me)
+    sol_mc_string = sprint((t, s) -> show(t, "text/plain", s), sol_mc)
     @test sum(abs.(sol_mc.expect .- sol_me.expect)) / length(t_l) < 0.1
     @test sol_me_string ==
           "Solution of time evolution\n" *
@@ -45,6 +46,16 @@
           "ODE alg.: $(sol_me.alg)\n" *
           "abstol = $(sol_me.abstol)\n" *
           "reltol = $(sol_me.reltol)\n"
+    @test sol_mc_string ==
+          "Solution of quantum trajectories\n" *
+          "(converged: $(sol_mc.converged))\n" *
+          "--------------------------------\n" *
+          "num_trajectories = $(sol_mc.n_traj)\n" *
+          "num_states = $(length(sol_mc.states[1]))\n" *
+          "num_expect = $(size(sol_mc.expect, 1))\n" *
+          "ODE alg.: $(sol_mc.alg)\n" *
+          "abstol = $(sol_mc.abstol)\n" *
+          "reltol = $(sol_mc.reltol)\n"
 
     sp1 = kron(sigmap(), qeye(2))
     sm1 = sp1'


### PR DESCRIPTION
close #143 

Summary of this PR:
1. Adjust many docstrings for time evolution functions (add `@doc raw`, LaTeX formula, and some minor changes)
2. Introduce `show` for `TimeEvolutionSol` and `TimeEvolutionMCSol`: take the brief example in README, here is the output if we `show` (or `print`) `sol` directly:
```
julia> sol = mesolve(H, ψ0, tlist, c_ops, e_ops = e_ops)
Solution of time evolution
(return code: Success)
--------------------------
num_states = 1
num_expect = 1
ODE alg.: Tsit5(; stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!, thread = static(false),)
abstol = 1.0e-7
reltol = 1.0e-5
```
3. Adjust the return data for `sesolve`, `mesolve`, and `mcsolve`

For the current implementation, the users will only get a final state if they doesn't specify `e_ops`, which cause some ambiguity about the argument `t_l`. In this PR, the `expect` will be decide by the argument `e_ops`, and the `states` will be decide by the argument `saveat`:
- if the user specifies only `e_ops`: `saveat = [t_l[end]]`, thus, return expectation values and the final state (which is same as current implementation)
- if the user doesn't specifies `e_ops`: `saveat = t_l`, thus, return all the states corresponding to `t_l`
- if the user specifies `e_ops` and `saveat` at the same time: `expect` will depend on `e_ops`, and `states` will depend on `saveat`.

Again, take the brief example in README:

if user doesn't specify `e_ops`:
```
julia> sol = mesolve(H, ψ0, tlist, c_ops)
Solution of time evolution
(return code: Success)
--------------------------
num_states = 100
num_expect = 0
ODE alg.: Tsit5(; stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!, thread = static(false),)
abstol = 1.0e-7
reltol = 1.0e-5
```

if user specifies both `e_ops` and `saveat`:
```
julia> sol = mesolve(H, ψ0, tlist, c_ops, e_ops = e_ops, saveat = tlist)
Solution of time evolution
(return code: Success)
--------------------------
num_states = 100
num_expect = 1
ODE alg.: Tsit5(; stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!, thread = static(false),)
abstol = 1.0e-7
reltol = 1.0e-5
```
```
julia> sol = mesolve(H, ψ0, tlist, c_ops, e_ops = e_ops, saveat = [])
Solution of time evolution
(return code: Success)
--------------------------
num_states = 0
num_expect = 1
ODE alg.: Tsit5(; stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!, thread = static(false),)
abstol = 1.0e-7
reltol = 1.0e-5
```