### PR TITLE
Avoid repeated print of progress_bar

### DIFF
--- a/src/progress_bar.jl
+++ b/src/progress_bar.jl
@@ -1,15 +1,18 @@
 export ProgressBar, next!
 
-mutable struct ProgressBar{CT,T1<:Integer,T2<:Real}
+mutable struct ProgressBar{CT,T1<:Integer,T2<:Real,T3<:Real}
     counter::CT
     max_counts::T1
     enable::Bool
     bar_width::T1
     start_time::T2
+    previous_time::T2
+    interval::T3
 end
 
-function ProgressBar(max_counts::Int; enable::Bool = true, bar_width::Int = 30)
-    return ProgressBar(Threads.Atomic{Int}(0), max_counts, enable, bar_width, time())
+function ProgressBar(max_counts::Int; enable::Bool = true, bar_width::Int = 30, interval = 1.0)
+    start_time = time()
+    return ProgressBar(Threads.Atomic{Int}(0), max_counts, enable, bar_width, start_time, start_time, interval)
 end
 
 function next!(p::ProgressBar, io::IO = stdout)
@@ -23,6 +26,12 @@ function next!(p::ProgressBar, io::IO = stdout)
     max_counts = p.max_counts
     bar_width = p.bar_width
     start_time = p.start_time
+    previous_time = p.previous_time
+    interval = p.interval
+
+    (time() - previous_time) < interval && return
+
+    p.previous_time = time()
 
     percentage = counter / max_counts
     percentage_100 = lpad(round(100 * percentage, digits = 1), 5, " ")

--- a/test/progress_bar.jl
+++ b/test/progress_bar.jl
@@ -1,8 +1,10 @@
 @testset "Progress Bar" begin
     bar_width = 30
     strLength = 67 + bar_width # including "\r" in the beginning of the string
-    prog = ProgressBar(bar_width, enable = true, bar_width = bar_width)
+    prog = ProgressBar(bar_width, enable = true, bar_width = bar_width, interval = 0.2)
     for p in 1:bar_width
+        sleep(0.3)
+
         output = sprint((t, s) -> next!(s, t), prog)
 
         if p < bar_width
@@ -10,5 +12,13 @@
         else # the last output has an extra "\n" in the end
             @test length(output) == strLength + 1
         end
+    end
+
+    prog = ProgressBar(bar_width, enable = true, bar_width = bar_width, interval = 0.2)
+    # No delay, so no output printed
+    for p in 1:bar_width
+        output = sprint((t, s) -> next!(s, t), prog)
+
+        @test length(output) == 0
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,21 +8,21 @@ const testdir = dirname(@__FILE__)
 
 # Put core tests in alphabetical order
 core_tests = [
-    # "correlations_and_spectrum.jl",
-    # "dynamical_fock_dimension_mesolve.jl",
-    # "dynamical-shifted-fock.jl",
-    # "eigenvalues_and_operators.jl",
-    # "entanglement.jl",
-    # "generalized_master_equation.jl",
-    # "low_rank_dynamics.jl",
-    # "negativity_and_partial_transpose.jl",
-    # "permutation.jl",
+    "correlations_and_spectrum.jl",
+    "dynamical_fock_dimension_mesolve.jl",
+    "dynamical-shifted-fock.jl",
+    "eigenvalues_and_operators.jl",
+    "entanglement.jl",
+    "generalized_master_equation.jl",
+    "low_rank_dynamics.jl",
+    "negativity_and_partial_transpose.jl",
+    "permutation.jl",
     "progress_bar.jl",
-    # "quantum_objects.jl",
-    # "states_and_operators.jl",
-    # "steady_state.jl",
-    # "time_evolution_and_partial_trace.jl",
-    # "wigner.jl",
+    "quantum_objects.jl",
+    "states_and_operators.jl",
+    "steady_state.jl",
+    "time_evolution_and_partial_trace.jl",
+    "wigner.jl",
 ]
 
 if ((GROUP == "All") || (GROUP == "Code-Quality")) && (VERSION >= v"1.9")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,21 +8,21 @@ const testdir = dirname(@__FILE__)
 
 # Put core tests in alphabetical order
 core_tests = [
-    "correlations_and_spectrum.jl",
-    "dynamical_fock_dimension_mesolve.jl",
-    "dynamical-shifted-fock.jl",
-    "eigenvalues_and_operators.jl",
-    "entanglement.jl",
-    "generalized_master_equation.jl",
-    "low_rank_dynamics.jl",
-    "negativity_and_partial_transpose.jl",
-    "permutation.jl",
+    # "correlations_and_spectrum.jl",
+    # "dynamical_fock_dimension_mesolve.jl",
+    # "dynamical-shifted-fock.jl",
+    # "eigenvalues_and_operators.jl",
+    # "entanglement.jl",
+    # "generalized_master_equation.jl",
+    # "low_rank_dynamics.jl",
+    # "negativity_and_partial_transpose.jl",
+    # "permutation.jl",
     "progress_bar.jl",
-    "quantum_objects.jl",
-    "states_and_operators.jl",
-    "steady_state.jl",
-    "time_evolution_and_partial_trace.jl",
-    "wigner.jl",
+    # "quantum_objects.jl",
+    # "states_and_operators.jl",
+    # "steady_state.jl",
+    # "time_evolution_and_partial_trace.jl",
+    # "wigner.jl",
 ]
 
 if ((GROUP == "All") || (GROUP == "Code-Quality")) && (VERSION >= v"1.9")


### PR DESCRIPTION
With the previous implementation, the `progress_bar` was printing the output independently on the frequency of the update.

Here, I introduced some minimum interval (one second by default), such that, updates more frequent than one second are not printed, avoiding to print thousands of lines in some cases.