### PR TITLE
Change default tolerance for ODE-based solvers

### DIFF
--- a/src/time_evolution/lr_mesolve.jl
+++ b/src/time_evolution/lr_mesolve.jl
@@ -478,8 +478,8 @@ function lr_mesolveProblem(
     end
 
     # Initialization of ODEProblem's kwargs
-    !haskey(kwargs2, :abstol) && (kwargs2 = merge(kwargs2, Dict(:abstol => 1e-7)))
-    !haskey(kwargs2, :reltol) && (kwargs2 = merge(kwargs2, Dict(:reltol => 1e-5)))
+    !haskey(kwargs2, :abstol) && (kwargs2 = merge(kwargs2, Dict(:abstol => 1e-8)))
+    !haskey(kwargs2, :reltol) && (kwargs2 = merge(kwargs2, Dict(:reltol => 1e-6)))
     !haskey(kwargs2, :saveat) && (kwargs2 = merge(kwargs2, Dict(:saveat => [t_l[end]])))
 
     # Initialization of ODEProblem

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -161,7 +161,7 @@ If the environmental measurements register a quantum jump, the wave function und
 
 - The states will be saved depend on the keyword argument `saveat` in `kwargs`.
 - If `e_ops` is specified, the default value of `saveat=[t_l[end]]` (only save the final state), otherwise, `saveat=t_l` (saving the states corresponding to `t_l`). You can also specify `e_ops` and `saveat` separately.
-- The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+- The default tolerances in `kwargs` are given as `reltol=1e-6` and `abstol=1e-8`.
 - For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
@@ -194,7 +194,7 @@ function mcsolveProblem(
         e_ops2[i] = get_data(e_ops[i])
     end
     saveat = is_empty_e_ops_mc ? t_l : [t_l[end]]
-    default_values = (abstol = 1e-7, reltol = 1e-5, saveat = saveat)
+    default_values = (abstol = 1e-8, reltol = 1e-6, saveat = saveat)
     kwargs2 = merge(default_values, kwargs)
 
     expvals = Array{ComplexF64}(undef, length(e_ops), length(t_l))
@@ -341,7 +341,7 @@ If the environmental measurements register a quantum jump, the wave function und
 
 - The states will be saved depend on the keyword argument `saveat` in `kwargs`.
 - If `e_ops` is specified, the default value of `saveat=[t_l[end]]` (only save the final state), otherwise, `saveat=t_l` (saving the states corresponding to `t_l`). You can also specify `e_ops` and `saveat` separately.
-- The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+- The default tolerances in `kwargs` are given as `reltol=1e-6` and `abstol=1e-8`.
 - For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
@@ -453,7 +453,7 @@ If the environmental measurements register a quantum jump, the wave function und
 - `ensemble_method` can be one of `EnsembleThreads()`, `EnsembleSerial()`, `EnsembleDistributed()`
 - The states will be saved depend on the keyword argument `saveat` in `kwargs`.
 - If `e_ops` is specified, the default value of `saveat=[t_l[end]]` (only save the final state), otherwise, `saveat=t_l` (saving the states corresponding to `t_l`). You can also specify `e_ops` and `saveat` separately.
-- The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+- The default tolerances in `kwargs` are given as `reltol=1e-6` and `abstol=1e-8`.
 - For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -67,7 +67,7 @@ where
 
 - The states will be saved depend on the keyword argument `saveat` in `kwargs`.
 - If `e_ops` is specified, the default value of `saveat=[t_l[end]]` (only save the final state), otherwise, `saveat=t_l` (saving the states corresponding to `t_l`). You can also specify `e_ops` and `saveat` separately.
-- The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+- The default tolerances in `kwargs` are given as `reltol=1e-6` and `abstol=1e-8`.
 - For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
@@ -121,7 +121,7 @@ function mesolveProblem(
     )
 
     saveat = is_empty_e_ops ? t_l : [t_l[end]]
-    default_values = (abstol = 1e-7, reltol = 1e-5, saveat = saveat)
+    default_values = (abstol = 1e-8, reltol = 1e-6, saveat = saveat)
     kwargs2 = merge(default_values, kwargs)
     if !isempty(e_ops) || progress_bar
         cb1 = PresetTimeCallback(t_l, _save_func_mesolve, save_positions = (false, false))
@@ -199,7 +199,7 @@ where
 
 - The states will be saved depend on the keyword argument `saveat` in `kwargs`.
 - If `e_ops` is specified, the default value of `saveat=[t_l[end]]` (only save the final state), otherwise, `saveat=t_l` (saving the states corresponding to `t_l`). You can also specify `e_ops` and `saveat` separately.
-- The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+- The default tolerances in `kwargs` are given as `reltol=1e-6` and `abstol=1e-8`.
 - For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns

--- a/src/time_evolution/sesolve.jl
+++ b/src/time_evolution/sesolve.jl
@@ -56,7 +56,7 @@ Generates the ODEProblem for the Schrödinger time evolution of a quantum system
 
 - The states will be saved depend on the keyword argument `saveat` in `kwargs`.
 - If `e_ops` is specified, the default value of `saveat=[t_l[end]]` (only save the final state), otherwise, `saveat=t_l` (saving the states corresponding to `t_l`). You can also specify `e_ops` and `saveat` separately.
-- The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+- The default tolerances in `kwargs` are given as `reltol=1e-6` and `abstol=1e-8`.
 - For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns
@@ -101,7 +101,7 @@ function sesolveProblem(
     )
 
     saveat = is_empty_e_ops ? t_l : [t_l[end]]
-    default_values = (abstol = 1e-7, reltol = 1e-5, saveat = saveat)
+    default_values = (abstol = 1e-8, reltol = 1e-6, saveat = saveat)
     kwargs2 = merge(default_values, kwargs)
     if !isempty(e_ops) || progress_bar
         cb1 = PresetTimeCallback(t_l, _save_func_sesolve, save_positions = (false, false))
@@ -171,7 +171,7 @@ Time evolution of a closed quantum system using the Schrödinger equation:
 
 - The states will be saved depend on the keyword argument `saveat` in `kwargs`.
 - If `e_ops` is specified, the default value of `saveat=[t_l[end]]` (only save the final state), otherwise, `saveat=t_l` (saving the states corresponding to `t_l`). You can also specify `e_ops` and `saveat` separately.
-- The default tolerances in `kwargs` are given as `reltol=1e-5` and `abstol=1e-7`.
+- The default tolerances in `kwargs` are given as `reltol=1e-6` and `abstol=1e-8`.
 - For more details about `alg` and extra `kwargs`, please refer to [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/)
 
 # Returns


### PR DESCRIPTION
The relative and absolute tolerances (`reltol` and `abstol`) in QuTiP is `1e-6` and `1e-8`, respectively.

Maybe we should make it the same as QuTiP, so that people can easily compare the results between two packages under the similar condition.