### PR TITLE
introduce intrinsic constant tuple `DEFAULT_ODE_SOLVER_OPTIONS`

### DIFF
--- a/src/time_evolution/lr_mesolve.jl
+++ b/src/time_evolution/lr_mesolve.jl
@@ -440,7 +440,7 @@ function lr_mesolveProblem(
     p.Si .= pinv(Hermitian(p.S), atol = opt.atol_inv)
 
     # Initialization of ODEProblem's kwargs
-    default_values = (_Default_ODE_Solver_Options..., saveat = [t_l[end]])
+    default_values = (DEFAULT_ODE_SOLVER_OPTIONS..., saveat = [t_l[end]])
     kwargs2 = merge(default_values, kwargs)
 
     # Initialization of Callbacks

--- a/src/time_evolution/lr_mesolve.jl
+++ b/src/time_evolution/lr_mesolve.jl
@@ -439,8 +439,11 @@ function lr_mesolveProblem(
     mul!(p.S, z', z)
     p.Si .= pinv(Hermitian(p.S), atol = opt.atol_inv)
 
+    # Initialization of ODEProblem's kwargs
+    default_values = (_Default_ODE_Solver_Options..., saveat = [t_l[end]])
+    kwargs2 = merge(default_values, kwargs)
+
     # Initialization of Callbacks
-    kwargs2 = kwargs
     if !isempty(e_ops) || !isempty(f_ops)
         _calculate_expectation!(p, z, B, 1)
         cb_save = DiscreteCallback(_save_control_lr_mesolve, _save_affect_lr_mesolve!, save_positions = (false, false))
@@ -476,11 +479,6 @@ function lr_mesolveProblem(
             Dict(:callback => cb_adjM),
         )
     end
-
-    # Initialization of ODEProblem's kwargs
-    !haskey(kwargs2, :abstol) && (kwargs2 = merge(kwargs2, Dict(:abstol => 1e-8)))
-    !haskey(kwargs2, :reltol) && (kwargs2 = merge(kwargs2, Dict(:reltol => 1e-6)))
-    !haskey(kwargs2, :saveat) && (kwargs2 = merge(kwargs2, Dict(:saveat => [t_l[end]])))
 
     # Initialization of ODEProblem
     tspan = (t_l[1], t_l[end])

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -194,7 +194,7 @@ function mcsolveProblem(
         e_ops2[i] = get_data(e_ops[i])
     end
     saveat = is_empty_e_ops_mc ? t_l : [t_l[end]]
-    default_values = (abstol = 1e-8, reltol = 1e-6, saveat = saveat)
+    default_values = (_Default_ODE_Solver_Options..., saveat = saveat)
     kwargs2 = merge(default_values, kwargs)
 
     expvals = Array{ComplexF64}(undef, length(e_ops), length(t_l))

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -194,7 +194,7 @@ function mcsolveProblem(
         e_ops2[i] = get_data(e_ops[i])
     end
     saveat = is_empty_e_ops_mc ? t_l : [t_l[end]]
-    default_values = (_Default_ODE_Solver_Options..., saveat = saveat)
+    default_values = (DEFAULT_ODE_SOLVER_OPTIONS..., saveat = saveat)
     kwargs2 = merge(default_values, kwargs)
 
     expvals = Array{ComplexF64}(undef, length(e_ops), length(t_l))

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -121,7 +121,7 @@ function mesolveProblem(
     )
 
     saveat = is_empty_e_ops ? t_l : [t_l[end]]
-    default_values = (abstol = 1e-8, reltol = 1e-6, saveat = saveat)
+    default_values = (_Default_ODE_Solver_Options..., saveat = saveat)
     kwargs2 = merge(default_values, kwargs)
     if !isempty(e_ops) || progress_bar
         cb1 = PresetTimeCallback(t_l, _save_func_mesolve, save_positions = (false, false))

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -121,7 +121,7 @@ function mesolveProblem(
     )
 
     saveat = is_empty_e_ops ? t_l : [t_l[end]]
-    default_values = (_Default_ODE_Solver_Options..., saveat = saveat)
+    default_values = (DEFAULT_ODE_SOLVER_OPTIONS..., saveat = saveat)
     kwargs2 = merge(default_values, kwargs)
     if !isempty(e_ops) || progress_bar
         cb1 = PresetTimeCallback(t_l, _save_func_mesolve, save_positions = (false, false))

--- a/src/time_evolution/sesolve.jl
+++ b/src/time_evolution/sesolve.jl
@@ -101,7 +101,7 @@ function sesolveProblem(
     )
 
     saveat = is_empty_e_ops ? t_l : [t_l[end]]
-    default_values = (abstol = 1e-8, reltol = 1e-6, saveat = saveat)
+    default_values = (_Default_ODE_Solver_Options..., saveat = saveat)
     kwargs2 = merge(default_values, kwargs)
     if !isempty(e_ops) || progress_bar
         cb1 = PresetTimeCallback(t_l, _save_func_sesolve, save_positions = (false, false))

--- a/src/time_evolution/sesolve.jl
+++ b/src/time_evolution/sesolve.jl
@@ -101,7 +101,7 @@ function sesolveProblem(
     )
 
     saveat = is_empty_e_ops ? t_l : [t_l[end]]
-    default_values = (_Default_ODE_Solver_Options..., saveat = saveat)
+    default_values = (DEFAULT_ODE_SOLVER_OPTIONS..., saveat = saveat)
     kwargs2 = merge(default_values, kwargs)
     if !isempty(e_ops) || progress_bar
         cb1 = PresetTimeCallback(t_l, _save_func_sesolve, save_positions = (false, false))

--- a/src/time_evolution/time_evolution.jl
+++ b/src/time_evolution/time_evolution.jl
@@ -3,6 +3,8 @@ export TimeEvolutionSol, TimeEvolutionMCSol
 
 export liouvillian, liouvillian_floquet, liouvillian_generalized
 
+const _Default_ODE_Solver_Options = (abstol = 1e-8, reltol = 1e-6, save_everystep = false, save_end = true)
+
 @doc raw"""
     struct TimeEvolutionSol
 

--- a/src/time_evolution/time_evolution.jl
+++ b/src/time_evolution/time_evolution.jl
@@ -3,7 +3,7 @@ export TimeEvolutionSol, TimeEvolutionMCSol
 
 export liouvillian, liouvillian_floquet, liouvillian_generalized
 
-const _Default_ODE_Solver_Options = (abstol = 1e-8, reltol = 1e-6, save_everystep = false, save_end = true)
+const DEFAULT_ODE_SOLVER_OPTIONS = (abstol = 1e-8, reltol = 1e-6, save_everystep = false, save_end = true)
 
 @doc raw"""
     struct TimeEvolutionSol

--- a/test/time_evolution_and_partial_trace.jl
+++ b/test/time_evolution_and_partial_trace.jl
@@ -12,10 +12,18 @@
     t_l = LinRange(0, 1000, 1000)
     e_ops = [a_d * a]
     sol = sesolve(H, psi0, t_l, e_ops = e_ops, alg = Vern7(), progress_bar = false)
+    sol2 = sesolve(H, psi0, t_l, progress_bar = false)
+    sol3 = sesolve(H, psi0, t_l, e_ops = e_ops, saveat = t_l, progress_bar = false)
     sol_string = sprint((t, s) -> show(t, "text/plain", s), sol)
     @test sum(abs.(sol.expect[1, :] .- sin.(η * t_l) .^ 2)) / length(t_l) < 0.1
     @test ptrace(sol.states[end], 1) ≈ ptrace(ket2dm(sol.states[end]), 1)
     @test ptrace(sol.states[end]', 1) ≈ ptrace(sol.states[end], 1)
+    @test length(sol.states) == 1
+    @test size(sol.expect) == (length(e_ops), length(t_l))
+    @test length(sol2.states) == length(t_l)
+    @test size(sol2.expect) == (0, length(t_l))
+    @test length(sol3.states) == length(t_l)
+    @test size(sol3.expect) == (length(e_ops), length(t_l))
     @test sol_string ==
           "Solution of time evolution\n" *
           "(return code: $(sol.retcode))\n" *
@@ -35,10 +43,18 @@
     psi0 = basis(N, 3)
     t_l = LinRange(0, 100, 1000)
     sol_me = mesolve(H, psi0, t_l, c_ops, e_ops = e_ops, alg = Vern7(), progress_bar = false)
+    sol_me2 = mesolve(H, psi0, t_l, c_ops, progress_bar = false)
+    sol_me3 = mesolve(H, psi0, t_l, c_ops, e_ops = e_ops, saveat = t_l, progress_bar = false)
     sol_mc = mcsolve(H, psi0, t_l, c_ops, n_traj = 500, e_ops = e_ops, progress_bar = false)
     sol_me_string = sprint((t, s) -> show(t, "text/plain", s), sol_me)
     sol_mc_string = sprint((t, s) -> show(t, "text/plain", s), sol_mc)
     @test sum(abs.(sol_mc.expect .- sol_me.expect)) / length(t_l) < 0.1
+    @test length(sol_me.states) == 1
+    @test size(sol_me.expect) == (length(e_ops), length(t_l))
+    @test length(sol_me2.states) == length(t_l)
+    @test size(sol_me2.expect) == (0, length(t_l))
+    @test length(sol_me3.states) == length(t_l)
+    @test size(sol_me3.expect) == (length(e_ops), length(t_l))
     @test sol_me_string ==
           "Solution of time evolution\n" *
           "(return code: $(sol_me.retcode))\n" *


### PR DESCRIPTION
The default keyword arguments for ODE solvers are:
- `abstol = 1e-8`
- `reltol = 1e-6`
- `save_everystep = false` : this can avoid storing all the internal states in `sol.u` if users set `saveat = []`
- `save_end = true`

This PR also add some runtests for `sesolve` and `mesolve`.