### PR TITLE
Fix progressbar end print

### DIFF
--- a/src/progress_bar.jl
+++ b/src/progress_bar.jl
@@ -29,7 +29,7 @@ function next!(p::ProgressBar, io::IO = stdout)
     previous_time = p.previous_time
     interval = p.interval
 
-    (time() - previous_time) < interval && return
+    ((time() - previous_time) < interval || (time() - start_time) < interval) && return
 
     p.previous_time = time()
 

--- a/src/progress_bar.jl
+++ b/src/progress_bar.jl
@@ -29,7 +29,7 @@ function next!(p::ProgressBar, io::IO = stdout)
     previous_time = p.previous_time
     interval = p.interval
 
-    ((time() - previous_time) < interval || (time() - start_time) < interval) && return
+    ((time() - previous_time) < interval && counter != p.max_counts) && return
 
     p.previous_time = time()
 

--- a/src/progress_bar.jl
+++ b/src/progress_bar.jl
@@ -61,5 +61,7 @@ function next!(p::ProgressBar, io::IO = stdout)
 
     counter == p.max_counts && print(io, "\n")
 
-    return flush(io)
+    flush(io)
+
+    return nothing
 end

--- a/test/progress_bar.jl
+++ b/test/progress_bar.jl
@@ -19,6 +19,10 @@
     for p in 1:bar_width
         output = sprint((t, s) -> next!(s, t), prog)
 
-        @test length(output) == 0
+        if p < bar_width
+            @test length(output) == 0
+        else
+            @test length(output) == strLength + 1
+        end
     end
 end


### PR DESCRIPTION
With the last improvement of the `progress_bar`, the output was very often incomplete in the final print, because it was not triggered depending on the speed of the execution.

Here I have introduced another condition that checks if the **total** time exceeds the `interval` variable. If yes, then proceed with printing.