### PR TITLE
Resolve type instabilities when generating QuantumObjects

### DIFF
--- a/src/qobj/quantum_object.jl
+++ b/src/qobj/quantum_object.jl
@@ -150,7 +150,7 @@ function QuantumObject(
         type = Operator # default type
     end
 
-    if !isa(type, Operator) && !isa(type, SuperOperator) && !isa(type, Bra) && !isa(type, OperatorBra)
+    if type != Operator && type != SuperOperator && type != Bra && type != OperatorBra
         throw(
             ArgumentError(
                 "The argument type must be Operator, SuperOperator, Bra or OperatorBra if the input array is a matrix.",
@@ -187,7 +187,7 @@ function QuantumObject(
         type = Ket # default type
     end
 
-    if !isa(type, Ket) && !isa(type, OperatorKet)
+    if type != Ket && type != OperatorKet
         throw(ArgumentError("The argument type must be Ket or OperatorKet if the input array is a vector."))
     end
 

--- a/src/qobj/quantum_object.jl
+++ b/src/qobj/quantum_object.jl
@@ -146,13 +146,16 @@ function QuantumObject(
     type::ObjType = nothing,
     dims = nothing,
 ) where {T,ObjType<:Union{Nothing,QuantumObjectType}}
-
     if type isa Nothing
         type = Operator # default type
     end
 
     if type != Operator && type != SuperOperator
-        throw(ArgumentError("The argument type must be OperatorQuantumObject or SuperOperatorQuantumObject if the input array is a matrix."))
+        throw(
+            ArgumentError(
+                "The argument type must be OperatorQuantumObject or SuperOperatorQuantumObject if the input array is a matrix.",
+            ),
+        )
     end
 
     _size = size(A)
@@ -176,13 +179,16 @@ function QuantumObject(
     type::ObjType = nothing,
     dims = nothing,
 ) where {T,ObjType<:Union{Nothing,QuantumObjectType}}
-
     if type isa Nothing
         type = Ket # default type
     end
 
     if type != Ket && type != Bra && type != OperatorKet && type != OperatorBra
-        throw(ArgumentError("The argument type must be KetQuantumObject, BraQuantumObject, OperatorKetQuantumObject or OperatorBraQuantumObject if the input array is a vector."))
+        throw(
+            ArgumentError(
+                "The argument type must be KetQuantumObject, BraQuantumObject, OperatorKetQuantumObject or OperatorBraQuantumObject if the input array is a vector.",
+            ),
+        )
     end
 
     _size = (length(A), 1)
@@ -190,7 +196,7 @@ function QuantumObject(
     if dims isa Nothing
         if (type isa KetQuantumObject) || (type isa BraQuantumObject)
             dims = [_size[1]]
-        elseif (type isa OperatorKetQuantumObject) || (type isa OperatorBraQuantumObject) 
+        elseif (type isa OperatorKetQuantumObject) || (type isa OperatorBraQuantumObject)
             dims = [isqrt(_size[1])]
         end
     else
@@ -213,7 +219,6 @@ function QuantumObject(
     type::ObjType = nothing,
     dims = nothing,
 ) where {T,N,ObjType<:Union{Nothing,QuantumObjectType}}
-
     throw(ArgumentError("The input array must be a vector or a matrix."))
 end
 

--- a/src/qobj/quantum_object.jl
+++ b/src/qobj/quantum_object.jl
@@ -150,10 +150,10 @@ function QuantumObject(
         type = Operator # default type
     end
 
-    if type != Operator && type != SuperOperator
+    if type != Operator && type != SuperOperator && type != Bra && type != OperatorBra
         throw(
             ArgumentError(
-                "The argument type must be OperatorQuantumObject or SuperOperatorQuantumObject if the input array is a matrix.",
+                "The argument type must be Operator, SuperOperator, Bra or OperatorBra if the input array is a matrix.",
             ),
         )
     end
@@ -165,6 +165,10 @@ function QuantumObject(
             dims = [_size[1]]
         elseif type isa SuperOperatorQuantumObject
             dims = [isqrt(_size[1])]
+        elseif type isa BraQuantumObject
+            dims = [_size[2]]
+        elseif type isa OperatorBraQuantumObject
+            dims = [isqrt(_size[2])]
         end
     else
         _check_dims(dims)
@@ -183,35 +187,24 @@ function QuantumObject(
         type = Ket # default type
     end
 
-    if type != Ket && type != Bra && type != OperatorKet && type != OperatorBra
-        throw(
-            ArgumentError(
-                "The argument type must be KetQuantumObject, BraQuantumObject, OperatorKetQuantumObject or OperatorBraQuantumObject if the input array is a vector.",
-            ),
-        )
+    if type != Ket && type != OperatorKet
+        throw(ArgumentError("The argument type must be Ket or OperatorKet if the input array is a vector."))
     end
 
     _size = (length(A), 1)
 
     if dims isa Nothing
-        if (type isa KetQuantumObject) || (type isa BraQuantumObject)
+        if type isa KetQuantumObject
             dims = [_size[1]]
-        elseif (type isa OperatorKetQuantumObject) || (type isa OperatorBraQuantumObject)
+        elseif type isa OperatorKetQuantumObject
             dims = [isqrt(_size[1])]
         end
     else
         _check_dims(dims)
     end
 
-    if (type isa BraQuantumObject) || (type isa OperatorBraQuantumObject)
-        data = A'
-        _size = (1, length(A))
-    else
-        data = A
-    end
-
     _check_QuantumObject(type, dims, _size[1], _size[2])
-    return QuantumObject(data, type, dims)
+    return QuantumObject(A, type, dims)
 end
 
 function QuantumObject(

--- a/src/qobj/quantum_object.jl
+++ b/src/qobj/quantum_object.jl
@@ -150,7 +150,7 @@ function QuantumObject(
         type = Operator # default type
     end
 
-    if type != Operator && type != SuperOperator && type != Bra && type != OperatorBra
+    if !isa(type, Operator) && !isa(type, SuperOperator) && !isa(type, Bra) && !isa(type, OperatorBra)
         throw(
             ArgumentError(
                 "The argument type must be Operator, SuperOperator, Bra or OperatorBra if the input array is a matrix.",
@@ -187,7 +187,7 @@ function QuantumObject(
         type = Ket # default type
     end
 
-    if type != Ket && type != OperatorKet
+    if !isa(type, Ket) && !isa(type, OperatorKet)
         throw(ArgumentError("The argument type must be Ket or OperatorKet if the input array is a vector."))
     end
 

--- a/test/quantum_objects.jl
+++ b/test/quantum_objects.jl
@@ -24,6 +24,7 @@
     # @test_logs (:warn, "The norm of the input data is not one.") QuantumObject(a)
     @test_throws ArgumentError Qobj(a, type = Operator)
     @test_throws ArgumentError Qobj(a, type = SuperOperator)
+    @test_throws ArgumentError Qobj(a, type = OperatorBra)
     @test_throws ArgumentError Qobj(a', type = Ket)
     @test_throws DomainError Qobj(a', type = Operator)
     @test_throws DomainError Qobj(a', type = SuperOperator)
@@ -32,7 +33,7 @@
     @test_throws DomainError Qobj(a', dims = [2])
     a2 = Qobj(a', type = Bra)
     a3 = Qobj(a)
-    @test a3' == a2
+    @test dag(a3) == a2 # Here we are also testing the dag function
     @test isket(a2) == false
     @test isbra(a2) == true
     @test isoper(a2) == false

--- a/test/quantum_objects.jl
+++ b/test/quantum_objects.jl
@@ -1,10 +1,10 @@
 @testset "Quantum Objects" begin
     # unsupported size of array
     a = rand(ComplexF64, 3, 2)
-    for t in [nothing, Operator, SuperOperator]
+    for t in [nothing, Operator, SuperOperator, Bra, OperatorBra]
         @test_throws DomainError Qobj(a, type = t)
     end
-    for t in [Ket, Bra, OperatorBra, OperatorKet]
+    for t in [Ket, OperatorKet]
         @test_throws ArgumentError Qobj(a, type = t)
     end
     a = rand(ComplexF64, 2, 2, 2)
@@ -30,7 +30,7 @@
     @test_throws ArgumentError Qobj(a', type = OperatorKet)
     @test_throws DimensionMismatch Qobj(a, dims = [2])
     @test_throws DomainError Qobj(a', dims = [2])
-    a2 = Qobj(a, type = Bra)
+    a2 = Qobj(a', type = Bra)
     a3 = Qobj(a)
     @test a3' == a2
     @test isket(a2) == false
@@ -72,7 +72,7 @@
     ρ = Qobj(rand(ComplexF64, 2, 2))
     ρ_ket = mat2vec(ρ)
     ρ_bra = ρ_ket'
-    @test ρ_bra == Qobj(mat2vec(ρ.data), type = OperatorBra)
+    @test ρ_bra == Qobj(mat2vec(ρ.data)', type = OperatorBra)
     @test ρ == vec2mat(ρ_ket)
     @test isket(ρ_ket) == false
     @test isbra(ρ_ket) == false
@@ -96,7 +96,7 @@
     @test (ρ_bra * L')' == L * ρ_ket
     @test sum((conj(ρ) .* ρ).data) ≈ dot(ρ_ket, ρ_ket) ≈ ρ_bra * ρ_ket
     @test_throws DimensionMismatch Qobj(ρ_ket.data, type = OperatorKet, dims = [4])
-    @test_throws ArgumentError Qobj(ρ_bra.data, type = OperatorBra, dims = [4])
+    @test_throws DimensionMismatch Qobj(ρ_bra.data, type = OperatorBra, dims = [4])
 
     # matrix element
     s0 = Qobj(basis(4, 0).data; type = OperatorKet)
@@ -390,8 +390,11 @@
         for T in [Float32, Float64, ComplexF32, ComplexF64]
             N = 25
             a = rand(T, N)
-            for type in [Ket, Bra, OperatorKet, OperatorBra]
+            for type in [Ket, OperatorKet]
                 @inferred Qobj(a, type = type)
+            end
+            for type in [Bra, OperatorBra]
+                @inferred Qobj(a', type = type)
             end
 
             a = rand(T, N, N)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,28 +9,28 @@ const testdir = dirname(@__FILE__)
 
 # Put core tests in alphabetical order
 core_tests = [
-    "correlations_and_spectrum.jl",
-    "dynamical_fock_dimension_mesolve.jl",
-    "dynamical-shifted-fock.jl",
-    "eigenvalues_and_operators.jl",
-    "entanglement.jl",
-    "generalized_master_equation.jl",
-    "low_rank_dynamics.jl",
-    "negativity_and_partial_transpose.jl",
-    "permutation.jl",
-    "progress_bar.jl",
+    # "correlations_and_spectrum.jl",
+    # "dynamical_fock_dimension_mesolve.jl",
+    # "dynamical-shifted-fock.jl",
+    # "eigenvalues_and_operators.jl",
+    # "entanglement.jl",
+    # "generalized_master_equation.jl",
+    # "low_rank_dynamics.jl",
+    # "negativity_and_partial_transpose.jl",
+    # "permutation.jl",
+    # "progress_bar.jl",
     "quantum_objects.jl",
-    "states_and_operators.jl",
-    "steady_state.jl",
-    "time_evolution_and_partial_trace.jl",
-    "wigner.jl",
+    # "states_and_operators.jl",
+    # "steady_state.jl",
+    # "time_evolution_and_partial_trace.jl",
+    # "wigner.jl",
 ]
 
-if ((GROUP == "All") || (GROUP == "Code-Quality")) && (VERSION >= v"1.9")
-    Pkg.add(["Aqua", "JET"])
-    include(joinpath(testdir, "aqua.jl"))
-    include(joinpath(testdir, "jet.jl"))
-end
+# if ((GROUP == "All") || (GROUP == "Code-Quality")) && (VERSION >= v"1.9")
+#     Pkg.add(["Aqua", "JET"])
+#     include(joinpath(testdir, "aqua.jl"))
+#     include(joinpath(testdir, "jet.jl"))
+# end
 
 if (GROUP == "All") || (GROUP == "Core")
     QuantumToolbox.about()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,28 +9,28 @@ const testdir = dirname(@__FILE__)
 
 # Put core tests in alphabetical order
 core_tests = [
-    # "correlations_and_spectrum.jl",
-    # "dynamical_fock_dimension_mesolve.jl",
-    # "dynamical-shifted-fock.jl",
-    # "eigenvalues_and_operators.jl",
-    # "entanglement.jl",
-    # "generalized_master_equation.jl",
-    # "low_rank_dynamics.jl",
-    # "negativity_and_partial_transpose.jl",
-    # "permutation.jl",
-    # "progress_bar.jl",
+    "correlations_and_spectrum.jl",
+    "dynamical_fock_dimension_mesolve.jl",
+    "dynamical-shifted-fock.jl",
+    "eigenvalues_and_operators.jl",
+    "entanglement.jl",
+    "generalized_master_equation.jl",
+    "low_rank_dynamics.jl",
+    "negativity_and_partial_transpose.jl",
+    "permutation.jl",
+    "progress_bar.jl",
     "quantum_objects.jl",
-    # "states_and_operators.jl",
-    # "steady_state.jl",
-    # "time_evolution_and_partial_trace.jl",
-    # "wigner.jl",
+    "states_and_operators.jl",
+    "steady_state.jl",
+    "time_evolution_and_partial_trace.jl",
+    "wigner.jl",
 ]
 
-# if ((GROUP == "All") || (GROUP == "Code-Quality")) && (VERSION >= v"1.9")
-#     Pkg.add(["Aqua", "JET"])
-#     include(joinpath(testdir, "aqua.jl"))
-#     include(joinpath(testdir, "jet.jl"))
-# end
+if ((GROUP == "All") || (GROUP == "Code-Quality")) && (VERSION >= v"1.9")
+    Pkg.add(["Aqua", "JET"])
+    include(joinpath(testdir, "aqua.jl"))
+    include(joinpath(testdir, "jet.jl"))
+end
 
 if (GROUP == "All") || (GROUP == "Core")
     QuantumToolbox.about()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,11 +26,11 @@ core_tests = [
     "wigner.jl",
 ]
 
-if ((GROUP == "All") || (GROUP == "Code-Quality")) && (VERSION >= v"1.9")
-    Pkg.add(["Aqua", "JET"])
-    include(joinpath(testdir, "aqua.jl"))
-    include(joinpath(testdir, "jet.jl"))
-end
+# if ((GROUP == "All") || (GROUP == "Code-Quality")) && (VERSION >= v"1.9")
+#     Pkg.add(["Aqua", "JET"])
+#     include(joinpath(testdir, "aqua.jl"))
+#     include(joinpath(testdir, "jet.jl"))
+# end
 
 if (GROUP == "All") || (GROUP == "Core")
     QuantumToolbox.about()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,11 +26,11 @@ core_tests = [
     "wigner.jl",
 ]
 
-# if ((GROUP == "All") || (GROUP == "Code-Quality")) && (VERSION >= v"1.9")
-#     Pkg.add(["Aqua", "JET"])
-#     include(joinpath(testdir, "aqua.jl"))
-#     include(joinpath(testdir, "jet.jl"))
-# end
+if ((GROUP == "All") || (GROUP == "Code-Quality")) && (VERSION >= v"1.9")
+    Pkg.add(["Aqua", "JET"])
+    include(joinpath(testdir, "aqua.jl"))
+    include(joinpath(testdir, "jet.jl"))
+end
 
 if (GROUP == "All") || (GROUP == "Core")
     QuantumToolbox.about()


### PR DESCRIPTION
This PR fixes #177.

here I used the multiple dispatch to manage the different types, instead of using several `if` conditions inside a single function. The only “dowside” (if we want to call it like that), is that the generation of `BraQuantumObject` and `OperatorBraQuantumObject` needs a vector instead of a transposed vector (actually a matrix). It is then conjugate-transposed inside the function.

I added a test of the type `@inferred code…`, just to test that there are no type instabilities.