### PR TITLE
Handle `tidyup` separately for real and imaginary values

### DIFF
--- a/test/quantum_objects.jl
+++ b/test/quantum_objects.jl
@@ -350,25 +350,25 @@
     # tidyup tests
     N = 20
     tol = 0.1
-    ## Float64 with in-place tidyup
-    ρ1 = Qobj(rand(Float64, N, N))
-    ρ2 = dense_to_sparse(ρ1)
-    @test tidyup!(ρ2, tol) == ρ2 != ρ1
-    @test dense_to_sparse(tidyup!(ρ1, tol)) == ρ2
+    ## Vector{Float64} with in-place tidyup
+    ψ1 = Qobj(rand(Float64, N))
+    ψ2 = dense_to_sparse(ψ1)
+    @test tidyup!(ψ2, tol) == ψ2 != ψ1
+    @test dense_to_sparse(tidyup!(ψ1, tol)) == ψ2
 
-    ## Float64 with normal tidyup
-    ρ1 = Qobj(rand(Float64, N, N))
-    ρ2 = dense_to_sparse(ρ1)
-    @test tidyup(ρ2, tol) != ρ2
-    @test dense_to_sparse(tidyup(ρ1, tol)) == tidyup(ρ2, tol)
+    ## Vector{Float64} with normal tidyup
+    ψ1 = Qobj(rand(Float64, N))
+    ψ2 = dense_to_sparse(ψ1)
+    @test tidyup(ψ2, tol) != ψ2
+    @test dense_to_sparse(tidyup(ψ1, tol)) == tidyup(ψ2, tol)
 
-    ## ComplexF64 with in-place tidyup
+    ## Matrix{ComplexF64} with in-place tidyup
     ρ1 = rand_dm(N)
     ρ2 = dense_to_sparse(ρ1)
     @test tidyup!(ρ2, tol) == ρ2 != ρ1
     @test dense_to_sparse(tidyup!(ρ1, tol)) == ρ2
 
-    ## ComplexF64 with normal tidyup
+    ## Matrix{ComplexF64} with normal tidyup
     ρ1 = rand_dm(N)
     ρ2 = dense_to_sparse(ρ1)
     @test tidyup(ρ2, tol) != ρ2

--- a/test/quantum_objects.jl
+++ b/test/quantum_objects.jl
@@ -348,15 +348,31 @@
     end
 
     # tidyup tests
-    ρ1 = rand_dm(20)
+    N = 20
+    tol = 0.1
+    ## Float64 with in-place tidyup
+    ρ1 = Qobj(rand(Float64, N, N))
     ρ2 = dense_to_sparse(ρ1)
-    @test tidyup!(ρ2, 0.1) == ρ2 != ρ1
-    @test dense_to_sparse(tidyup!(ρ1, 0.1)) == ρ2
+    @test tidyup!(ρ2, tol) == ρ2 != ρ1
+    @test dense_to_sparse(tidyup!(ρ1, tol)) == ρ2
 
-    ρ1 = rand_dm(20)
+    ## Float64 with normal tidyup
+    ρ1 = Qobj(rand(Float64, N, N))
     ρ2 = dense_to_sparse(ρ1)
-    @test tidyup(ρ2, 0.1) != ρ2
-    @test dense_to_sparse(tidyup(ρ1, 0.1)) == tidyup(ρ2, 0.1)
+    @test tidyup(ρ2, tol) != ρ2
+    @test dense_to_sparse(tidyup(ρ1, tol)) == tidyup(ρ2, tol)
+
+    ## ComplexF64 with in-place tidyup
+    ρ1 = rand_dm(N)
+    ρ2 = dense_to_sparse(ρ1)
+    @test tidyup!(ρ2, tol) == ρ2 != ρ1
+    @test dense_to_sparse(tidyup!(ρ1, tol)) == ρ2
+
+    ## ComplexF64 with normal tidyup
+    ρ1 = rand_dm(N)
+    ρ2 = dense_to_sparse(ρ1)
+    @test tidyup(ρ2, tol) != ρ2
+    @test dense_to_sparse(tidyup(ρ1, tol)) == tidyup(ρ2, tol)
 
     # data element type conversion
     vd = Qobj(Int64[0, 0])

--- a/test/quantum_objects.jl
+++ b/test/quantum_objects.jl
@@ -349,7 +349,7 @@
 
     # tidyup tests
     N = 20
-    tol = 0.1
+    tol = 0.5
     ## Vector{Float64} with in-place tidyup
     ψ1 = Qobj(rand(Float64, N))
     ψ2 = dense_to_sparse(ψ1)
@@ -363,6 +363,7 @@
     @test dense_to_sparse(tidyup(ψ1, tol)) == tidyup(ψ2, tol)
 
     ## Matrix{ComplexF64} with in-place tidyup
+    tol = 0.1
     ρ1 = rand_dm(N)
     ρ2 = dense_to_sparse(ρ1)
     @test tidyup!(ρ2, tol) == ρ2 != ρ1


### PR DESCRIPTION
This PR calls `tidyup!` inside `tidyup`, namely
```julia
tidyup(A, tol) = tidyup!(copy(A), tol)
```

Also, use multiple dispatch for different element types `T<:Real` or `T<:Complex` for function `tidyup!`:

If `T<:Real`, then use the origin method: 
```julia
@. A = T(abs(A) > tol) * A
```

If `T<:Complex`, then use the following method:
```julia
@. A = T(abs(real(A)) > tol) * real(A) + 1im * T(abs(imag(A)) > tol) * imag(A)
```