### PR TITLE
Divide some tests into sub-testsets

### DIFF
--- a/src/qobj/quantum_object.jl
+++ b/src/qobj/quantum_object.jl
@@ -324,11 +324,11 @@ Returns the length of the matrix or vector corresponding to the [`QuantumObject`
 Base.length(A::QuantumObject{<:AbstractArray{T}}) where {T} = length(A.data)
 
 Base.isequal(A::QuantumObject{<:AbstractArray{T}}, B::QuantumObject{<:AbstractArray{T}}) where {T} =
-    isequal(A.data, B.data) && isequal(A.type, B.type) && isequal(A.dims, B.dims)
-Base.isapprox(A::QuantumObject{<:AbstractArray{T}}, B::QuantumObject{<:AbstractArray{T}}) where {T} =
-    isapprox(A.data, B.data) && isequal(A.type, B.type) && isequal(A.dims, B.dims)
+    isequal(A.type, B.type) && isequal(A.dims, B.dims) && isequal(A.data, B.data)
+Base.isapprox(A::QuantumObject{<:AbstractArray{T}}, B::QuantumObject{<:AbstractArray{T}}; kwargs...) where {T} =
+    isequal(A.type, B.type) && isequal(A.dims, B.dims) && isapprox(A.data, B.data; kwargs...)
 Base.:(==)(A::QuantumObject{<:AbstractArray{T}}, B::QuantumObject{<:AbstractArray{T}}) where {T} =
-    (A.data == B.data) && (A.type == B.type) && (A.dims == B.dims)
+    (A.type == B.type) && (A.dims == B.dims) && (A.data == B.data)
 
 SparseArrays.sparse(A::QuantumObject{<:AbstractArray{T}}) where {T} = QuantumObject(sparse(A.data), A.type, A.dims)
 SparseArrays.nnz(A::QuantumObject{<:AbstractSparseArray}) = nnz(A.data)

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,5 +1,0 @@
-using Aqua
-
-@testset "Code quality (Aqua.jl)" begin
-    Aqua.test_all(QuantumToolbox; ambiguities = false)
-end

--- a/test/code_quality.jl
+++ b/test/code_quality.jl
@@ -1,0 +1,11 @@
+using Aqua, JET
+
+@testset "Code quality" verbose = true begin
+    @testset "Aqua.jl" begin
+        Aqua.test_all(QuantumToolbox; ambiguities = false)
+    end
+
+    @testset "JET.jl" begin
+        JET.test_package(QuantumToolbox; target_defined_modules = true, ignore_missing_comparison = true)
+    end
+end

--- a/test/cuda_ext.jl
+++ b/test/cuda_ext.jl
@@ -4,7 +4,7 @@ using CUDA.CUSPARSE
 QuantumToolbox.about()
 CUDA.versioninfo()
 
-@testset "CUDA Extension" begin
+@testset "CUDA Extension" verbose = true begin
     ψdi = Qobj(Int64[1, 0])
     ψdf = Qobj(Float64[1, 0])
     ψdc = Qobj(ComplexF64[1, 0])

--- a/test/jet.jl
+++ b/test/jet.jl
@@ -1,5 +1,0 @@
-using JET
-
-@testset "Code quality (JET.jl)" begin
-    JET.test_package(QuantumToolbox; target_defined_modules = true, ignore_missing_comparison = true)
-end

--- a/test/negativity_and_partial_transpose.jl
+++ b/test/negativity_and_partial_transpose.jl
@@ -1,32 +1,34 @@
-@testset "Negativity and Partial Transpose" begin
-    # tests for negativity
-    rho = (1 / 40) * Qobj(
-        [
-            15 1 1 15
-            1 5 -3 1
-            1 -3 5 1
-            15 1 1 15
-        ];
-        dims = [2, 2],
-    )
-    Neg = negativity(rho, 1)
-    @test Neg ≈ 0.25
-    @test negativity(rho, 2) ≈ Neg
-    @test negativity(rho, 1; logarithmic = true) ≈ log2(2 * Neg + 1)
-    @test_throws ArgumentError negativity(rho, 3)
+@testset "Negativity and Partial Transpose" verbose = true begin
+    @testset "negativity" begin
+        rho = (1 / 40) * Qobj(
+            [
+                15 1 1 15
+                1 5 -3 1
+                1 -3 5 1
+                15 1 1 15
+            ];
+            dims = [2, 2],
+        )
+        Neg = negativity(rho, 1)
+        @test Neg ≈ 0.25
+        @test negativity(rho, 2) ≈ Neg
+        @test negativity(rho, 1; logarithmic = true) ≈ log2(2 * Neg + 1)
+        @test_throws ArgumentError negativity(rho, 3)
+    end
 
-    # tests for partial transpose (PT)
-    # A (24 * 24)-matrix which contains number 1 ~ 576
-    A_dense = Qobj(reshape(1:(24^2), (24, 24)), dims = [2, 3, 4])
-    A_sparse = dense_to_sparse(A_dense)
-    PT = (true, false)
-    for s1 in PT
-        for s2 in PT
-            for s3 in PT
-                mask = [s1, s2, s3]
-                @test partial_transpose(A_dense, mask) == partial_transpose(A_sparse, mask)
+    @testset "partial_transpose" begin
+        # A (24 * 24)-matrix which contains number 1 ~ 576
+        A_dense = Qobj(reshape(1:(24^2), (24, 24)), dims = [2, 3, 4])
+        A_sparse = dense_to_sparse(A_dense)
+        PT = (true, false)
+        for s1 in PT
+            for s2 in PT
+                for s3 in PT
+                    mask = [s1, s2, s3]
+                    @test partial_transpose(A_dense, mask) == partial_transpose(A_sparse, mask)
+                end
             end
         end
+        @test_throws ArgumentError partial_transpose(A_dense, [true])
     end
-    @test_throws ArgumentError partial_transpose(rho, [true])
 end

--- a/test/quantum_objects.jl
+++ b/test/quantum_objects.jl
@@ -1,4 +1,4 @@
-@testset "Quantum Objects" begin
+@testset "Quantum Objects" verbose = true begin
     @testset "Type Inference" begin
         for T in [ComplexF32, ComplexF64]
             N = 4
@@ -24,409 +24,441 @@
     end
 
     # ArgumentError: type is incompatible with vector or matrix
-    a = rand(ComplexF64, 2)
-    for t in [Operator, SuperOperator, Bra, OperatorBra]
-        @test_throws ArgumentError Qobj(a, type = t)
+    @testset "ArgumentError" begin
+        a = rand(ComplexF64, 2)
+        for t in [Operator, SuperOperator, Bra, OperatorBra]
+            @test_throws ArgumentError Qobj(a, type = t)
+        end
+        a = rand(ComplexF64, 2, 2)
+        @test_throws ArgumentError Qobj(a, type = Ket)
+        @test_throws ArgumentError Qobj(a, type = OperatorKet)
     end
-    a = rand(ComplexF64, 2, 2)
-    @test_throws ArgumentError Qobj(a, type = Ket)
-    @test_throws ArgumentError Qobj(a, type = OperatorKet)
 
     # DomainError: incompatible between size of array and type
-    a = rand(ComplexF64, 3, 2)
-    for t in [nothing, Operator, SuperOperator, Bra, OperatorBra]
-        @test_throws DomainError Qobj(a, type = t)
+    @testset "DomainError" begin
+        a = rand(ComplexF64, 3, 2)
+        for t in [nothing, Operator, SuperOperator, Bra, OperatorBra]
+            @test_throws DomainError Qobj(a, type = t)
+        end
+        a = rand(ComplexF64, 2, 2, 2)
+        for t in [nothing, Ket, Bra, Operator, SuperOperator, OperatorBra, OperatorKet]
+            @test_throws DomainError Qobj(a, type = t)
+        end
+        a = rand(ComplexF64, 1, 2)
+        @test_throws DomainError Qobj(a, type = Operator)
+        @test_throws DomainError Qobj(a, type = SuperOperator)
     end
-    a = rand(ComplexF64, 2, 2, 2)
-    for t in [nothing, Ket, Bra, Operator, SuperOperator, OperatorBra, OperatorKet]
-        @test_throws DomainError Qobj(a, type = t)
-    end
-    a = rand(ComplexF64, 1, 2)
-    @test_throws DomainError Qobj(a, type = Operator)
-    @test_throws DomainError Qobj(a, type = SuperOperator)
 
     # unsupported type of dims
-    @test_throws ArgumentError Qobj(rand(2, 2), dims = 2)
-    @test_throws ArgumentError Qobj(rand(2, 2), dims = [2.0])
-    @test_throws ArgumentError Qobj(rand(2, 2), dims = [2.0 + 0.0im])
-    @test_throws DomainError Qobj(rand(2, 2), dims = [0])
-    @test_throws DomainError Qobj(rand(2, 2), dims = [2, -2])
-
-    N = 10
-    a = rand(ComplexF64, 10)
-    # @test_logs (:warn, "The norm of the input data is not one.") QuantumObject(a)
-    @test_throws DimensionMismatch Qobj(a, dims = [2])
-    @test_throws DimensionMismatch Qobj(a', dims = [2])
-    a2 = Qobj(a')
-    a3 = Qobj(a)
-    @test dag(a3) == a2 # Here we are also testing the dag function
-    @test isket(a2) == false
-    @test isbra(a2) == true
-    @test isoper(a2) == false
-    @test issuper(a2) == false
-    @test isoperket(a2) == false
-    @test isoperbra(a2) == false
-    @test isket(a3) == true
-    @test isbra(a3) == false
-    @test isoper(a3) == false
-    @test issuper(a3) == false
-    @test isoperket(a3) == false
-    @test isoperbra(a3) == false
-    @test Qobj(a3) == a3
-    @test !(Qobj(a3) === a3)
-
-    a = sprand(ComplexF64, 100, 100, 0.1)
-    a2 = Qobj(a)
-    a3 = Qobj(a, type = SuperOperator)
-
-    @test isket(a2) == false
-    @test isbra(a2) == false
-    @test isoper(a2) == true
-    @test issuper(a2) == false
-    @test isoperket(a2) == false
-    @test isoperbra(a2) == false
-    @test isket(a3) == false
-    @test isbra(a3) == false
-    @test isoper(a3) == false
-    @test issuper(a3) == true
-    @test isoperket(a3) == false
-    @test isoperbra(a3) == false
-    @test_throws DimensionMismatch Qobj(a, dims = [2])
-
-    # Operator-Ket, Operator-Bra tests
-    H = 0.3 * sigmax() + 0.7 * sigmaz()
-    L = liouvillian(H)
-    ρ = Qobj(rand(ComplexF64, 2, 2))
-    ρ_ket = mat2vec(ρ)
-    ρ_bra = ρ_ket'
-    @test ρ_bra == Qobj(mat2vec(ρ.data)', type = OperatorBra)
-    @test ρ == vec2mat(ρ_ket)
-    @test isket(ρ_ket) == false
-    @test isbra(ρ_ket) == false
-    @test isoper(ρ_ket) == false
-    @test issuper(ρ_ket) == false
-    @test isoperket(ρ_ket) == true
-    @test isoperbra(ρ_ket) == false
-    @test isket(ρ_bra) == false
-    @test isbra(ρ_bra) == false
-    @test isoper(ρ_bra) == false
-    @test issuper(ρ_bra) == false
-    @test isoperket(ρ_bra) == false
-    @test isoperbra(ρ_bra) == true
-    @test ρ_bra.dims == [2]
-    @test ρ_ket.dims == [2]
-    @test H * ρ ≈ spre(H) * ρ
-    @test ρ * H ≈ spost(H) * ρ
-    @test H * ρ * H ≈ sprepost(H, H) * ρ
-    @test (L * ρ_ket).dims == [2]
-    @test L * ρ_ket ≈ -1im * (+(spre(H) * ρ_ket) - spost(H) * ρ_ket)
-    @test (ρ_bra * L')' == L * ρ_ket
-    @test sum((conj(ρ) .* ρ).data) ≈ dot(ρ_ket, ρ_ket) ≈ ρ_bra * ρ_ket
-    @test_throws DimensionMismatch Qobj(ρ_ket.data, type = OperatorKet, dims = [4])
-    @test_throws DimensionMismatch Qobj(ρ_bra.data, type = OperatorBra, dims = [4])
-
-    # matrix element
-    s0 = Qobj(basis(4, 0).data; type = OperatorKet)
-    s1 = Qobj(basis(4, 1).data; type = OperatorKet)
-    s_wrong = Qobj(basis(9, 0).data; type = OperatorKet)
-    @test matrix_element(basis(2, 0), H, basis(2, 1)) == H[1, 2]
-    @test matrix_element(s0, L, s1) == L[1, 2]
-    @test_throws DimensionMismatch matrix_element(basis(3, 0), H, basis(2, 1))
-    @test_throws DimensionMismatch matrix_element(basis(2, 0), H, basis(3, 1))
-    @test_throws DimensionMismatch matrix_element(s0, L, s_wrong)
-    @test_throws DimensionMismatch matrix_element(s_wrong, L, s0)
-
-    a = Array(a)
-    a4 = Qobj(a)
-    a5 = sparse(a4)
-    @test isequal(a5, a2)
-    @test (a5 == a3) == false
-    @test a5 ≈ a2
-
-    @test +a2 == a2
-    @test -(-a2) == a2
-    @test a2^3 ≈ a2 * a2 * a2
-    @test a2 + 2 == 2 + a2
-    @test (a2 + 2).data == a2.data + 2 * I
-    @test a2 * 2 == 2 * a2
-
-    @test trans(trans(a2)) == a2
-    @test trans(a2).data == transpose(a2.data)
-    @test adjoint(a2) ≈ trans(conj(a2))
-    @test adjoint(adjoint(a2)) == a2
-    @test adjoint(a2).data == adjoint(a2.data)
-
-    N = 10
-    a = fock(N, 3)
-    @test proj(a) ≈ proj(a') ≈ sparse(ket2dm(a)) ≈ projection(N, 3, 3)
-    @test isket(a') == false
-    @test isbra(a') == true
-    @test shape(a) == (N,)
-    @test shape(a') == (1, N)
-    @test norm(a) ≈ 1
-    @test norm(a') ≈ 1
-
-    ψ = Qobj(normalize(rand(ComplexF64, N)))
-    @test dot(ψ, ψ) ≈ norm(ψ)
-    @test dot(ψ, ψ) ≈ ψ' * ψ
-
-    # normalize, normalize!, unit
-    a = Qobj(rand(ComplexF64, N))
-    M = a * a'
-    @test (norm(a) ≈ 1) == false
-    @test (norm(M) ≈ 1) == false
-    @test (norm(unit(a)) ≈ 1) == true
-    @test (norm(unit(M)) ≈ 1) == true
-    @test (norm(a) ≈ 1) == false # Again, to be sure that it is still non-normalized
-    @test (norm(M) ≈ 1) == false # Again, to be sure that it is still non-normalized
-    normalize!(a)
-    normalize!(M)
-    @test (norm(a) ≈ 1) == true
-    @test (norm(M) ≈ 1) == true
-    @test M ≈ a * a'
-    @test (unit(qeye(N)) ≈ (qeye(N) / N)) == true
-
-    a = destroy(N)
-    a_d = a'
-    X = a + a_d
-    Y = 1im * (a - a_d)
-    Z = a + trans(a)
-    @test isherm(X) == true
-    @test isherm(Y) == true
-    @test issymmetric(Y) == false
-    @test issymmetric(Z) == true
-
-    # diag
-    @test diag(a, 1) ≈ [sqrt(i) for i in 1:(N-1)]
-    @test diag(a_d, -1) == [sqrt(i) for i in 1:(N-1)]
-    @test diag(a_d * a) ≈ collect(0:(N-1))
-
-    @test Y[1, 2] == conj(Y[2, 1])
-
-    @test triu(X) == a
-    @test tril(X) == a_d
-
-    triu!(X)
-    @test X == a
-    tril!(X)
-    @test nnz(X) == 0
-
-    # Eigenvalues
-    @test eigenenergies(a_d * a) ≈ 0:9
-
-    # Random density matrix
-    ρ = rand_dm(10)
-    @test tr(ρ) ≈ 1
-    @test isposdef(ρ) == true
-
-    # Expectation value
-    a = destroy(10)
-    ψ = normalize(fock(10, 3) + 1im * fock(10, 4))
-    @test expect(a, ψ) ≈ expect(a, ψ')
-    ψ = fock(10, 3)
-    @test norm(ψ' * a) ≈ 2
-    @test expect(a' * a, ψ' * a) ≈ 16
-
-    # REPL show
-    a = destroy(N)
-    ψ = fock(N, 3)
-
-    opstring = sprint((t, s) -> show(t, "text/plain", s), a)
-    datastring = sprint((t, s) -> show(t, "text/plain", s), a.data)
-    a_dims = a.dims
-    a_size = size(a)
-    a_isherm = isherm(a)
-    @test opstring ==
-          "Quantum Object:   type=Operator   dims=$a_dims   size=$a_size   ishermitian=$a_isherm\n$datastring"
-
-    a = spre(a)
-    opstring = sprint((t, s) -> show(t, "text/plain", s), a)
-    datastring = sprint((t, s) -> show(t, "text/plain", s), a.data)
-    a_dims = a.dims
-    a_size = size(a)
-    a_isherm = isherm(a)
-    @test opstring == "Quantum Object:   type=SuperOperator   dims=$a_dims   size=$a_size\n$datastring"
-
-    opstring = sprint((t, s) -> show(t, "text/plain", s), ψ)
-    datastring = sprint((t, s) -> show(t, "text/plain", s), ψ.data)
-    ψ_dims = ψ.dims
-    ψ_size = size(ψ)
-    @test opstring == "Quantum Object:   type=Ket   dims=$ψ_dims   size=$ψ_size\n$datastring"
-
-    ψ = ψ'
-    opstring = sprint((t, s) -> show(t, "text/plain", s), ψ)
-    datastring = sprint((t, s) -> show(t, "text/plain", s), ψ.data)
-    ψ_dims = ψ.dims
-    ψ_size = size(ψ)
-    @test opstring == "Quantum Object:   type=Bra   dims=$ψ_dims   size=$ψ_size\n$datastring"
-
-    ψ2 = Qobj(rand(ComplexF64, 4), type = OperatorKet)
-    opstring = sprint((t, s) -> show(t, "text/plain", s), ψ2)
-    datastring = sprint((t, s) -> show(t, "text/plain", s), ψ2.data)
-    ψ2_dims = ψ2.dims
-    ψ2_size = size(ψ2)
-    @test opstring == "Quantum Object:   type=OperatorKet   dims=$ψ2_dims   size=$ψ2_size\n$datastring"
-
-    ψ2 = ψ2'
-    opstring = sprint((t, s) -> show(t, "text/plain", s), ψ2)
-    datastring = sprint((t, s) -> show(t, "text/plain", s), ψ2.data)
-    ψ2_dims = ψ2.dims
-    ψ2_size = size(ψ2)
-    @test opstring == "Quantum Object:   type=OperatorBra   dims=$ψ2_dims   size=$ψ2_size\n$datastring"
-
-    # get coherence
-    ψ = coherent(30, 3)
-    α, δψ = get_coherence(ψ)
-    @test isapprox(abs(α), 3, atol = 1e-5) && abs2(δψ[1]) > 0.999
-    ρ = ket2dm(ψ)
-    α, δρ = get_coherence(ρ)
-    @test isapprox(abs(α), 3, atol = 1e-5) && abs2(δρ[1, 1]) > 0.999
-
-    # svdvals, Schatten p-norm
-    vd = Qobj(rand(ComplexF64, 10))
-    vs = Qobj(sprand(ComplexF64, 100, 0.1))
-    Md = Qobj(rand(ComplexF64, 10, 10))
-    Ms = Qobj(sprand(ComplexF64, 10, 10, 0.5))
-    @test svdvals(vd)[1] ≈ √(vd' * vd)
-    @test svdvals(vs)[1] ≈ √(vs' * vs)
-    @test norm(Md, 1) ≈ sum(sqrt, abs.(eigenenergies(Md' * Md))) atol = 1e-6
-    @test norm(Ms, 1) ≈ sum(sqrt, abs.(eigenenergies(Ms' * Ms))) atol = 1e-6
-
-    # purity
-    ψ = normalize!(Qobj(rand(ComplexF64, N)))
-    ψd = ψ'
-    ρ1 = ψ * ψ'
-    M2 = rand(ComplexF64, N, N)
-    ρ2 = normalize!(Qobj(M2 * M2'))
-    @test purity(ψ) ≈ norm(ψ)^2 ≈ 1.0
-    @test purity(ψd) ≈ norm(ψd)^2 ≈ 1.0
-    @test purity(ρ1) ≈ 1.0
-    @test (1.0 / N) <= purity(ρ2) <= 1.0
-
-    # trace distance
-    ψz0 = basis(2, 0)
-    ψz1 = basis(2, 1)
-    ρz0 = dense_to_sparse(ket2dm(ψz0))
-    ρz1 = dense_to_sparse(ket2dm(ψz1))
-    ψx0 = sqrt(0.5) * (basis(2, 0) + basis(2, 1))
-    @test tracedist(ψz0, ψx0) ≈ sqrt(0.5)
-    @test tracedist(ρz0, ψz1) ≈ 1.0
-    @test tracedist(ψz1, ρz0) ≈ 1.0
-    @test tracedist(ρz0, ρz1) ≈ 1.0
-
-    # sqrtm (sqrt) and fidelity
-    M = sprand(ComplexF64, 5, 5, 0.5)
-    M0 = Qobj(M * M')
-    ψ1 = Qobj(rand(ComplexF64, 5))
-    ψ2 = Qobj(rand(ComplexF64, 5))
-    M1 = ψ1 * ψ1'
-    @test sqrtm(M0) ≈ sqrtm(sparse_to_dense(M0))
-    @test isapprox(fidelity(M0, M1), fidelity(ψ1, M0); atol = 1e-6)
-    @test isapprox(fidelity(ψ1, ψ2), fidelity(ket2dm(ψ1), ket2dm(ψ2)); atol = 1e-6)
-
-    # logm (log), expm (exp), sinm, cosm
-    M0 = rand(ComplexF64, 4, 4)
-    Md = Qobj(M0 * M0')
-    Ms = dense_to_sparse(Md)
-    e_p = expm(1im * Md)
-    e_m = expm(-1im * Md)
-    @test logm(expm(Ms)) ≈ expm(logm(Md))
-    @test cosm(Ms) ≈ (e_p + e_m) / 2
-    @test sinm(Ms) ≈ (e_p - e_m) / 2im
-
-    # Broadcasting
-    a = destroy(20)
-    for op in ((+), (-), (*), (^))
-        A = broadcast(op, a, a)
-        @test A.data == broadcast(op, a.data, a.data) && A.type == a.type && A.dims == a.dims
-
-        A = broadcast(op, 2.1, a)
-        @test A.data == broadcast(op, 2.1, a.data) && A.type == a.type && A.dims == a.dims
-
-        A = broadcast(op, a, 2.1)
-        @test A.data == broadcast(op, a.data, 2.1) && A.type == a.type && A.dims == a.dims
+    @testset "unsupported dims" begin
+        @test_throws ArgumentError Qobj(rand(2, 2), dims = 2)
+        @test_throws ArgumentError Qobj(rand(2, 2), dims = [2.0])
+        @test_throws ArgumentError Qobj(rand(2, 2), dims = [2.0 + 0.0im])
+        @test_throws DomainError Qobj(rand(2, 2), dims = [0])
+        @test_throws DomainError Qobj(rand(2, 2), dims = [2, -2])
     end
 
-    # tidyup tests
-    N = 20
-    tol = 0.5
-    ## Vector{Float64} with in-place tidyup
-    ψ1 = Qobj(rand(Float64, N))
-    ψ2 = dense_to_sparse(ψ1)
-    @test tidyup!(ψ2, tol) == ψ2 != ψ1
-    @test dense_to_sparse(tidyup!(ψ1, tol)) == ψ2
+    @testset "Ket and Bra" begin
+        N = 10
+        a = rand(ComplexF64, 10)
+        # @test_logs (:warn, "The norm of the input data is not one.") QuantumObject(a)
+        @test_throws DimensionMismatch Qobj(a, dims = [2])
+        @test_throws DimensionMismatch Qobj(a', dims = [2])
+        a2 = Qobj(a')
+        a3 = Qobj(a)
+        @test dag(a3) == a2 # Here we are also testing the dag function
+        @test isket(a2) == false
+        @test isbra(a2) == true
+        @test isoper(a2) == false
+        @test issuper(a2) == false
+        @test isoperket(a2) == false
+        @test isoperbra(a2) == false
+        @test isket(a3) == true
+        @test isbra(a3) == false
+        @test isoper(a3) == false
+        @test issuper(a3) == false
+        @test isoperket(a3) == false
+        @test isoperbra(a3) == false
+        @test Qobj(a3) == a3
+        @test !(Qobj(a3) === a3)
+    end
 
-    ## Vector{Float64} with normal tidyup
-    ψ1 = Qobj(rand(Float64, N))
-    ψ2 = dense_to_sparse(ψ1)
-    @test tidyup(ψ2, tol) != ψ2
-    @test dense_to_sparse(tidyup(ψ1, tol)) == tidyup(ψ2, tol)
+    @testset "Operator and SuperOperator" begin
+        a = sprand(ComplexF64, 100, 100, 0.1)
+        a2 = Qobj(a)
+        a3 = Qobj(a, type = SuperOperator)
 
-    ## Matrix{ComplexF64} with in-place tidyup
-    tol = 0.1
-    ρ1 = rand_dm(N)
-    ρ2 = dense_to_sparse(ρ1)
-    @test tidyup!(ρ2, tol) == ρ2 != ρ1
-    @test dense_to_sparse(tidyup!(ρ1, tol)) == ρ2
+        @test isket(a2) == false
+        @test isbra(a2) == false
+        @test isoper(a2) == true
+        @test issuper(a2) == false
+        @test isoperket(a2) == false
+        @test isoperbra(a2) == false
+        @test isket(a3) == false
+        @test isbra(a3) == false
+        @test isoper(a3) == false
+        @test issuper(a3) == true
+        @test isoperket(a3) == false
+        @test isoperbra(a3) == false
+        @test_throws DimensionMismatch Qobj(a, dims = [2])
+    end
 
-    ## Matrix{ComplexF64} with normal tidyup
-    ρ1 = rand_dm(N)
-    ρ2 = dense_to_sparse(ρ1)
-    @test tidyup(ρ2, tol) != ρ2
-    @test dense_to_sparse(tidyup(ρ1, tol)) == tidyup(ρ2, tol)
+    @testset "OperatorKet and OperatorBra" begin
+        H = 0.3 * sigmax() + 0.7 * sigmaz()
+        L = liouvillian(H)
+        ρ = Qobj(rand(ComplexF64, 2, 2))
+        ρ_ket = mat2vec(ρ)
+        ρ_bra = ρ_ket'
+        @test ρ_bra == Qobj(mat2vec(ρ.data)', type = OperatorBra)
+        @test ρ == vec2mat(ρ_ket)
+        @test isket(ρ_ket) == false
+        @test isbra(ρ_ket) == false
+        @test isoper(ρ_ket) == false
+        @test issuper(ρ_ket) == false
+        @test isoperket(ρ_ket) == true
+        @test isoperbra(ρ_ket) == false
+        @test isket(ρ_bra) == false
+        @test isbra(ρ_bra) == false
+        @test isoper(ρ_bra) == false
+        @test issuper(ρ_bra) == false
+        @test isoperket(ρ_bra) == false
+        @test isoperbra(ρ_bra) == true
+        @test ρ_bra.dims == [2]
+        @test ρ_ket.dims == [2]
+        @test H * ρ ≈ spre(H) * ρ
+        @test ρ * H ≈ spost(H) * ρ
+        @test H * ρ * H ≈ sprepost(H, H) * ρ
+        @test (L * ρ_ket).dims == [2]
+        @test L * ρ_ket ≈ -1im * (+(spre(H) * ρ_ket) - spost(H) * ρ_ket)
+        @test (ρ_bra * L')' == L * ρ_ket
+        @test sum((conj(ρ) .* ρ).data) ≈ dot(ρ_ket, ρ_ket) ≈ ρ_bra * ρ_ket
+        @test_throws DimensionMismatch Qobj(ρ_ket.data, type = OperatorKet, dims = [4])
+        @test_throws DimensionMismatch Qobj(ρ_bra.data, type = OperatorBra, dims = [4])
+    end
 
-    # data element type conversion
-    vd = Qobj(Int64[0, 0])
-    vs = Qobj(dense_to_sparse(vd))
-    Md = Qobj(Int64[0 0; 0 0])
-    Ms = Qobj(dense_to_sparse(Md))
-    @test typeof(Vector(vd).data) == Vector{Int64}
-    @test typeof(Vector(vs).data) == Vector{Int64}
-    @test typeof(Vector{ComplexF64}(vd).data) == Vector{ComplexF64}
-    @test typeof(Vector{ComplexF64}(vs).data) == Vector{ComplexF64}
-    @test typeof(SparseVector(vd).data) == SparseVector{Int64,Int64}
-    @test typeof(SparseVector(vs).data) == SparseVector{Int64,Int64}
-    @test typeof(SparseVector{ComplexF64}(vs).data) == SparseVector{ComplexF64,Int64}
-    @test typeof(Matrix(Md).data) == Matrix{Int64}
-    @test typeof(Matrix(Ms).data) == Matrix{Int64}
-    @test typeof(Matrix{ComplexF64}(Ms).data) == Matrix{ComplexF64}
-    @test typeof(Matrix{ComplexF64}(Md).data) == Matrix{ComplexF64}
-    @test typeof(SparseMatrixCSC(Md).data) == SparseMatrixCSC{Int64,Int64}
-    @test typeof(SparseMatrixCSC(Ms).data) == SparseMatrixCSC{Int64,Int64}
-    @test typeof(SparseMatrixCSC{ComplexF64}(Ms).data) == SparseMatrixCSC{ComplexF64,Int64}
+    @testset "arithmetic" begin
+        a = sprand(ComplexF64, 100, 100, 0.1)
+        a2 = Qobj(a)
+        a3 = Qobj(a, type = SuperOperator)
+        a4 = sparse(a2)
+        @test isequal(a4, a2) == true
+        @test isequal(a4, a3) == false
+        @test a4 ≈ a2
 
-    # permute tests
-    ket_a = Qobj(rand(ComplexF64, 2))
-    ket_b = Qobj(rand(ComplexF64, 3))
-    ket_c = Qobj(rand(ComplexF64, 4))
-    ket_d = Qobj(rand(ComplexF64, 5))
-    ket_bdca = permute(tensor(ket_a, ket_b, ket_c, ket_d), [2, 4, 3, 1])
-    bra_a = ket_a'
-    bra_b = ket_b'
-    bra_c = ket_c'
-    bra_d = ket_d'
-    bra_bdca = permute(tensor(bra_a, bra_b, bra_c, bra_d), [2, 4, 3, 1])
-    op_a = Qobj(rand(ComplexF64, 2, 2))
-    op_b = Qobj(rand(ComplexF64, 3, 3))
-    op_c = Qobj(rand(ComplexF64, 4, 4))
-    op_d = Qobj(rand(ComplexF64, 5, 5))
-    op_bdca = permute(tensor(op_a, op_b, op_c, op_d), [2, 4, 3, 1])
-    correct_dims = [3, 5, 4, 2]
-    wrong_order1 = [1]
-    wrong_order2 = [2, 3, 4, 5]
-    @test ket_bdca ≈ tensor(ket_b, ket_d, ket_c, ket_a)
-    @test bra_bdca ≈ tensor(bra_b, bra_d, bra_c, bra_a)
-    @test op_bdca ≈ tensor(op_b, op_d, op_c, op_a)
-    @test ket_bdca.dims == correct_dims
-    @test bra_bdca.dims == correct_dims
-    @test op_bdca.dims == correct_dims
-    @test isket(ket_bdca)
-    @test isbra(bra_bdca)
-    @test isoper(op_bdca)
-    @test_throws ArgumentError permute(ket_bdca, wrong_order1)
-    @test_throws ArgumentError permute(ket_bdca, wrong_order2)
-    @test_throws ArgumentError permute(bra_bdca, wrong_order1)
-    @test_throws ArgumentError permute(bra_bdca, wrong_order2)
-    @test_throws ArgumentError permute(op_bdca, wrong_order1)
-    @test_throws ArgumentError permute(op_bdca, wrong_order2)
+        @test +a2 == a2
+        @test -(-a2) == a2
+        @test a2^3 ≈ a2 * a2 * a2
+        @test a2 + 2 == 2 + a2
+        @test (a2 + 2).data == a2.data + 2 * I
+        @test a2 * 2 == 2 * a2
+
+        @test trans(trans(a2)) == a2
+        @test trans(a2).data == transpose(a2.data)
+        @test adjoint(a2) ≈ trans(conj(a2))
+        @test adjoint(adjoint(a2)) == a2
+        @test adjoint(a2).data == adjoint(a2.data)
+
+        N = 10
+        a = destroy(N)
+        a_d = a'
+        X = a + a_d
+        Y = 1im * (a - a_d)
+        Z = a + trans(a)
+        @test isherm(X) == true
+        @test isherm(Y) == true
+        @test issymmetric(Y) == false
+        @test issymmetric(Z) == true
+
+        # diag
+        @test diag(a, 1) ≈ [sqrt(i) for i in 1:(N-1)]
+        @test diag(a_d, -1) == [sqrt(i) for i in 1:(N-1)]
+        @test diag(a_d * a) ≈ collect(0:(N-1))
+
+        @test Y[1, 2] == conj(Y[2, 1])
+
+        # triu and tril
+        @test triu(X) == a
+        @test tril(X) == a_d
+
+        triu!(X)
+        @test X == a
+        tril!(X)
+        @test nnz(X) == 0
+    end
+
+    @testset "broadcasting" begin
+        a = destroy(20)
+        for op in ((+), (-), (*), (^))
+            A = broadcast(op, a, a)
+            @test A.data == broadcast(op, a.data, a.data) && A.type == a.type && A.dims == a.dims
+
+            A = broadcast(op, 2.1, a)
+            @test A.data == broadcast(op, 2.1, a.data) && A.type == a.type && A.dims == a.dims
+
+            A = broadcast(op, a, 2.1)
+            @test A.data == broadcast(op, a.data, 2.1) && A.type == a.type && A.dims == a.dims
+        end
+    end
+
+    @testset "REPL show" begin
+        N = 10
+        a = destroy(N)
+        ψ = fock(N, 3)
+
+        opstring = sprint((t, s) -> show(t, "text/plain", s), a)
+        datastring = sprint((t, s) -> show(t, "text/plain", s), a.data)
+        a_dims = a.dims
+        a_size = size(a)
+        a_isherm = isherm(a)
+        @test opstring ==
+              "Quantum Object:   type=Operator   dims=$a_dims   size=$a_size   ishermitian=$a_isherm\n$datastring"
+
+        a = spre(a)
+        opstring = sprint((t, s) -> show(t, "text/plain", s), a)
+        datastring = sprint((t, s) -> show(t, "text/plain", s), a.data)
+        a_dims = a.dims
+        a_size = size(a)
+        a_isherm = isherm(a)
+        @test opstring == "Quantum Object:   type=SuperOperator   dims=$a_dims   size=$a_size\n$datastring"
+
+        opstring = sprint((t, s) -> show(t, "text/plain", s), ψ)
+        datastring = sprint((t, s) -> show(t, "text/plain", s), ψ.data)
+        ψ_dims = ψ.dims
+        ψ_size = size(ψ)
+        @test opstring == "Quantum Object:   type=Ket   dims=$ψ_dims   size=$ψ_size\n$datastring"
+
+        ψ = ψ'
+        opstring = sprint((t, s) -> show(t, "text/plain", s), ψ)
+        datastring = sprint((t, s) -> show(t, "text/plain", s), ψ.data)
+        ψ_dims = ψ.dims
+        ψ_size = size(ψ)
+        @test opstring == "Quantum Object:   type=Bra   dims=$ψ_dims   size=$ψ_size\n$datastring"
+
+        ψ2 = Qobj(rand(ComplexF64, 4), type = OperatorKet)
+        opstring = sprint((t, s) -> show(t, "text/plain", s), ψ2)
+        datastring = sprint((t, s) -> show(t, "text/plain", s), ψ2.data)
+        ψ2_dims = ψ2.dims
+        ψ2_size = size(ψ2)
+        @test opstring == "Quantum Object:   type=OperatorKet   dims=$ψ2_dims   size=$ψ2_size\n$datastring"
+
+        ψ2 = ψ2'
+        opstring = sprint((t, s) -> show(t, "text/plain", s), ψ2)
+        datastring = sprint((t, s) -> show(t, "text/plain", s), ψ2.data)
+        ψ2_dims = ψ2.dims
+        ψ2_size = size(ψ2)
+        @test opstring == "Quantum Object:   type=OperatorBra   dims=$ψ2_dims   size=$ψ2_size\n$datastring"
+    end
+
+    @testset "Matrix Element" begin
+        H = Qobj([1 2; 3 4])
+        L = liouvillian(H)
+        s0 = Qobj(basis(4, 0).data; type = OperatorKet)
+        s1 = Qobj(basis(4, 1).data; type = OperatorKet)
+        s_wrong = Qobj(basis(9, 0).data; type = OperatorKet)
+        @test matrix_element(basis(2, 0), H, basis(2, 1)) == H[1, 2]
+        @test matrix_element(s0, L, s1) == L[1, 2]
+        @test_throws DimensionMismatch matrix_element(basis(3, 0), H, basis(2, 1))
+        @test_throws DimensionMismatch matrix_element(basis(2, 0), H, basis(3, 1))
+        @test_throws DimensionMismatch matrix_element(s0, L, s_wrong)
+        @test_throws DimensionMismatch matrix_element(s_wrong, L, s0)
+    end
+
+    @testset "element type conversion" begin
+        vd = Qobj(Int64[0, 0])
+        vs = Qobj(dense_to_sparse(vd))
+        Md = Qobj(Int64[0 0; 0 0])
+        Ms = Qobj(dense_to_sparse(Md))
+        @test typeof(Vector(vd).data) == Vector{Int64}
+        @test typeof(Vector(vs).data) == Vector{Int64}
+        @test typeof(Vector{ComplexF64}(vd).data) == Vector{ComplexF64}
+        @test typeof(Vector{ComplexF64}(vs).data) == Vector{ComplexF64}
+        @test typeof(SparseVector(vd).data) == SparseVector{Int64,Int64}
+        @test typeof(SparseVector(vs).data) == SparseVector{Int64,Int64}
+        @test typeof(SparseVector{ComplexF64}(vs).data) == SparseVector{ComplexF64,Int64}
+        @test typeof(Matrix(Md).data) == Matrix{Int64}
+        @test typeof(Matrix(Ms).data) == Matrix{Int64}
+        @test typeof(Matrix{ComplexF64}(Ms).data) == Matrix{ComplexF64}
+        @test typeof(Matrix{ComplexF64}(Md).data) == Matrix{ComplexF64}
+        @test typeof(SparseMatrixCSC(Md).data) == SparseMatrixCSC{Int64,Int64}
+        @test typeof(SparseMatrixCSC(Ms).data) == SparseMatrixCSC{Int64,Int64}
+        @test typeof(SparseMatrixCSC{ComplexF64}(Ms).data) == SparseMatrixCSC{ComplexF64,Int64}
+    end
+
+    @testset "projection" begin
+        N = 10
+        a = fock(N, 3)
+        @test proj(a) ≈ proj(a') ≈ sparse(ket2dm(a)) ≈ projection(N, 3, 3)
+        @test isket(a') == false
+        @test isbra(a') == true
+        @test shape(a) == (N,)
+        @test shape(a') == (1, N)
+        @test norm(a) ≈ 1
+        @test norm(a') ≈ 1
+    end
+
+    @testset "dot product" begin
+        ψ = rand_ket(10)
+        @test dot(ψ, ψ) ≈ ψ' * ψ ≈ norm(ψ) ≈ 1.0
+    end
+
+    @testset "normalization" begin
+        # normalize, normalize!, unit
+        N = 10
+        a = Qobj(rand(ComplexF64, N))
+        M = a * a'
+        @test (norm(a) ≈ 1) == false
+        @test (norm(M) ≈ 1) == false
+        @test (norm(unit(a)) ≈ 1) == true
+        @test (norm(unit(M)) ≈ 1) == true
+        @test (norm(a) ≈ 1) == false # Again, to be sure that it is still non-normalized
+        @test (norm(M) ≈ 1) == false # Again, to be sure that it is still non-normalized
+        normalize!(a)
+        normalize!(M)
+        @test (norm(a) ≈ 1) == true
+        @test (norm(M) ≈ 1) == true
+        @test M ≈ a * a'
+        @test (unit(qeye(N)) ≈ (qeye(N) / N)) == true
+    end
+
+    @testset "expectation value" begin
+        N = 10
+        a = destroy(N)
+        ψ = normalize(fock(N, 3) + 1im * fock(N, 4))
+        @test expect(a, ψ) ≈ expect(a, ψ')
+        ψ = fock(N, 3)
+        @test norm(ψ' * a) ≈ 2
+        @test expect(a' * a, ψ' * a) ≈ 16
+    end
+
+    @testset "get coherence" begin
+        ψ = coherent(30, 3)
+        α, δψ = get_coherence(ψ)
+        @test isapprox(abs(α), 3, atol = 1e-5) && abs2(δψ[1]) > 0.999
+        ρ = ket2dm(ψ)
+        α, δρ = get_coherence(ρ)
+        @test isapprox(abs(α), 3, atol = 1e-5) && abs2(δρ[1, 1]) > 0.999
+    end
+
+    @testset "SVD and Schatten p-norm" begin
+        vd = Qobj(rand(ComplexF64, 10))
+        vs = Qobj(sprand(ComplexF64, 100, 0.1))
+        Md = Qobj(rand(ComplexF64, 10, 10))
+        Ms = Qobj(sprand(ComplexF64, 10, 10, 0.5))
+        @test svdvals(vd)[1] ≈ √(vd' * vd)
+        @test svdvals(vs)[1] ≈ √(vs' * vs)
+        @test norm(Md, 1) ≈ sum(sqrt, abs.(eigenenergies(Md' * Md))) atol = 1e-6
+        @test norm(Ms, 1) ≈ sum(sqrt, abs.(eigenenergies(Ms' * Ms))) atol = 1e-6
+    end
+
+    @testset "purity" begin
+        N = 10
+        ψ = rand_ket(N)
+        ψd = ψ'
+        ρ1 = ψ * ψ'
+        M2 = rand_dm(N)
+        ρ2 = normalize!(Qobj(M2 * M2'))
+        @test purity(ψ) ≈ norm(ψ)^2 ≈ 1.0
+        @test purity(ψd) ≈ norm(ψd)^2 ≈ 1.0
+        @test purity(ρ1) ≈ 1.0
+        @test (1.0 / N) <= purity(ρ2) <= 1.0
+    end
+
+    @testset "trace distance" begin
+        ψz0 = basis(2, 0)
+        ψz1 = basis(2, 1)
+        ρz0 = dense_to_sparse(ket2dm(ψz0))
+        ρz1 = dense_to_sparse(ket2dm(ψz1))
+        ψx0 = sqrt(0.5) * (basis(2, 0) + basis(2, 1))
+        @test tracedist(ψz0, ψx0) ≈ sqrt(0.5)
+        @test tracedist(ρz0, ψz1) ≈ 1.0
+        @test tracedist(ψz1, ρz0) ≈ 1.0
+        @test tracedist(ρz0, ρz1) ≈ 1.0
+    end
+
+    @testset "sqrt and fidelity" begin
+        M = sprand(ComplexF64, 5, 5, 0.5)
+        M0 = Qobj(M * M')
+        ψ1 = Qobj(rand(ComplexF64, 5))
+        ψ2 = Qobj(rand(ComplexF64, 5))
+        M1 = ψ1 * ψ1'
+        @test sqrtm(M0) ≈ sqrtm(sparse_to_dense(M0))
+        @test isapprox(fidelity(M0, M1), fidelity(ψ1, M0); atol = 1e-6)
+        @test isapprox(fidelity(ψ1, ψ2), fidelity(ket2dm(ψ1), ket2dm(ψ2)); atol = 1e-6)
+    end
+
+    @testset "log, exp, sinm, cosm" begin
+        M0 = rand(ComplexF64, 4, 4)
+        Md = Qobj(M0 * M0')
+        Ms = dense_to_sparse(Md)
+        e_p = expm(1im * Md)
+        e_m = expm(-1im * Md)
+        @test logm(expm(Ms)) ≈ expm(logm(Md))
+        @test cosm(Ms) ≈ (e_p + e_m) / 2
+        @test sinm(Ms) ≈ (e_p - e_m) / 2im
+    end
+
+    @testset "tidyup" begin
+        N = 20
+        tol = 0.5
+        ## Vector{Float64} with in-place tidyup
+        ψ1 = Qobj(rand(Float64, N))
+        ψ2 = dense_to_sparse(ψ1)
+        @test tidyup!(ψ2, tol) == ψ2 != ψ1
+        @test dense_to_sparse(tidyup!(ψ1, tol)) == ψ2
+
+        ## Vector{Float64} with normal tidyup
+        ψ1 = Qobj(rand(Float64, N))
+        ψ2 = dense_to_sparse(ψ1)
+        @test tidyup(ψ2, tol) != ψ2
+        @test dense_to_sparse(tidyup(ψ1, tol)) == tidyup(ψ2, tol)
+
+        ## Matrix{ComplexF64} with in-place tidyup
+        tol = 0.1
+        ρ1 = rand_dm(N)
+        ρ2 = dense_to_sparse(ρ1)
+        @test tidyup!(ρ2, tol) == ρ2 != ρ1
+        @test dense_to_sparse(tidyup!(ρ1, tol)) == ρ2
+
+        ## Matrix{ComplexF64} with normal tidyup
+        ρ1 = rand_dm(N)
+        ρ2 = dense_to_sparse(ρ1)
+        @test tidyup(ρ2, tol) != ρ2
+        @test dense_to_sparse(tidyup(ρ1, tol)) == tidyup(ρ2, tol)
+    end
+
+    @testset "permute" begin
+        ket_a = Qobj(rand(ComplexF64, 2))
+        ket_b = Qobj(rand(ComplexF64, 3))
+        ket_c = Qobj(rand(ComplexF64, 4))
+        ket_d = Qobj(rand(ComplexF64, 5))
+        ket_bdca = permute(tensor(ket_a, ket_b, ket_c, ket_d), [2, 4, 3, 1])
+        bra_a = ket_a'
+        bra_b = ket_b'
+        bra_c = ket_c'
+        bra_d = ket_d'
+        bra_bdca = permute(tensor(bra_a, bra_b, bra_c, bra_d), [2, 4, 3, 1])
+        op_a = Qobj(rand(ComplexF64, 2, 2))
+        op_b = Qobj(rand(ComplexF64, 3, 3))
+        op_c = Qobj(rand(ComplexF64, 4, 4))
+        op_d = Qobj(rand(ComplexF64, 5, 5))
+        op_bdca = permute(tensor(op_a, op_b, op_c, op_d), [2, 4, 3, 1])
+        correct_dims = [3, 5, 4, 2]
+        wrong_order1 = [1]
+        wrong_order2 = [2, 3, 4, 5]
+        @test ket_bdca ≈ tensor(ket_b, ket_d, ket_c, ket_a)
+        @test bra_bdca ≈ tensor(bra_b, bra_d, bra_c, bra_a)
+        @test op_bdca ≈ tensor(op_b, op_d, op_c, op_a)
+        @test ket_bdca.dims == correct_dims
+        @test bra_bdca.dims == correct_dims
+        @test op_bdca.dims == correct_dims
+        @test isket(ket_bdca)
+        @test isbra(bra_bdca)
+        @test isoper(op_bdca)
+        @test_throws ArgumentError permute(ket_bdca, wrong_order1)
+        @test_throws ArgumentError permute(ket_bdca, wrong_order2)
+        @test_throws ArgumentError permute(bra_bdca, wrong_order1)
+        @test_throws ArgumentError permute(bra_bdca, wrong_order2)
+        @test_throws ArgumentError permute(op_bdca, wrong_order1)
+        @test_throws ArgumentError permute(op_bdca, wrong_order2)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,8 +28,7 @@ core_tests = [
 
 if ((GROUP == "All") || (GROUP == "Code-Quality")) && (VERSION >= v"1.9")
     Pkg.add(["Aqua", "JET"])
-    include(joinpath(testdir, "aqua.jl"))
-    include(joinpath(testdir, "jet.jl"))
+    include(joinpath(testdir, "code_quality.jl"))
 end
 
 if (GROUP == "All") || (GROUP == "Core")

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -1,294 +1,323 @@
-@testset "States and Operators" begin
-    # zero_ket
-    v1 = zero_ket(4)
-    v2 = zero_ket([2, 2])
-    @test size(v1) == (4,)
-    @test size(v2) == (4,)
-    @test v1.data == v2.data
-    @test v1 != v2
-    @test isket(v1)
-    @test isket(v2)
-    @test v1.dims == [4]
-    @test v2.dims == [2, 2]
-
-    # fock, basis, fock_dm
-    @test fock_dm(4; dims = [2, 2], sparse = true) ≈ ket2dm(basis(4; dims = [2, 2]))
-    @test_throws DimensionMismatch fock(4; dims = [2])
-
-    # coherent, coherent_dm
-    N = 4
-    α = 0.25im
-    ψα = coherent(N, α)
-    ρα = coherent_dm(N, α)
-    @test isket(ψα)
-    @test isoper(ρα)
-    @test ket2dm(ψα) ≈ ρα
-    @test tr(ρα) ≈ 1.0
-
-    # thermal_dm
-    ρTd = thermal_dm(5, 0.123)
-    ρTs = thermal_dm(5, 0.123; sparse = true)
-    @test isoper(ρTd)
-    @test ρTd.dims == [5]
-    @test tr(ρTd) ≈ 1.0
-    @test ρTd.data ≈ spdiagm(
-        0 => Float64[
-            0.8904859864731106,
-            0.09753319353178326,
-            0.010682620484781245,
-            0.0011700465891612583,
-            0.00012815292116369966,
-        ],
-    )
-    @test typeof(ρTs.data) <: AbstractSparseMatrix
-    @test ρTd ≈ ρTs
-
-    # maximally_mixed_dm
-    ρ1 = maximally_mixed_dm(4)
-    ρ2 = maximally_mixed_dm([2, 2])
-    @test size(ρ1) == (4, 4)
-    @test size(ρ2) == (4, 4)
-    @test tr(ρ1) ≈ 1.0
-    @test ρ1.data == ρ2.data
-    @test ρ1 != ρ2
-    @test isoper(ρ1)
-    @test isoper(ρ2)
-    @test ρ1.dims == [4]
-    @test ρ2.dims == [2, 2]
-    @test entropy_vn(ρ1, base = 2) ≈ log(2, 4)
-
-    # rand_ket and rand_dm
-    ψ = rand_ket(10)
-    ρ_AB = rand_dm([2, 2])
-    ρ_A = ptrace(ρ_AB, 1)
-    ρ_B = ptrace(ρ_AB, 2)
-    rank = 5
-    ρ_low_rank = rand_dm(10, rank = rank)
-    eig_val = eigenenergies(ρ_low_rank)
-    @test ψ' * ψ ≈ 1.0
-    @test tr(ρ_AB) ≈ 1.0
-    @test tr(ρ_A) ≈ 1.0
-    @test tr(ρ_B) ≈ 1.0
-    @test tr(ρ_low_rank) ≈ 1.0
-    @test ishermitian(ρ_AB) == true
-    @test ishermitian(ρ_A) == true
-    @test ishermitian(ρ_B) == true
-    @test ishermitian(ρ_low_rank) == true
-    @test all(eigenenergies(ρ_AB) .>= 0)
-    @test all(eigenenergies(ρ_A) .>= 0)
-    @test all(eigenenergies(ρ_B) .>= 0)
-    @test all(isapprox.(eig_val[1:rank], 0.0, atol = 1e-10))
-    @test all(eig_val[(rank+1):10] .>= 0)
-    @test_throws DomainError rand_dm(4, rank = rank)
-    @test_throws DomainError rand_dm(4, rank = 0)
-
-    # bell_state, singlet_state, triplet_states, w_state, ghz_state
-    e0 = basis(2, 0)
-    e1 = basis(2, 1)
-    d0 = basis(3, 0)
-    d1 = basis(3, 1)
-    d2 = basis(3, 2)
-    B00 = (e0 ⊗ e0 + e1 ⊗ e1) / √2
-    B01 = (e0 ⊗ e0 - e1 ⊗ e1) / √2
-    B10 = (e0 ⊗ e1 + e1 ⊗ e0) / √2
-    B11 = (e0 ⊗ e1 - e1 ⊗ e0) / √2
-    S = singlet_state()
-    T = triplet_states()
-    @test bell_state(0, 0) == B00 == ghz_state(2)
-    @test bell_state(0, 1) == B01
-    @test bell_state(1, 0) == B10 == T[2] == w_state(2)
-    @test bell_state(1, 1) == B11 == S
-    @test T[1] == e1 ⊗ e1
-    @test T[3] == e0 ⊗ e0
-    @test w_state(3) == (e0 ⊗ e0 ⊗ e1 + e0 ⊗ e1 ⊗ e0 + e1 ⊗ e0 ⊗ e0) / √3
-    @test ghz_state(3) == (e0 ⊗ e0 ⊗ e0 + e1 ⊗ e1 ⊗ e1) / √2
-    @test ghz_state(3; d = 3) == (d0 ⊗ d0 ⊗ d0 + d1 ⊗ d1 ⊗ d1 + d2 ⊗ d2 ⊗ d2) / √3
-    @test_throws ArgumentError bell_state(0, 2)
-    @test_throws ArgumentError bell_state(3, 1)
-    @test_throws ArgumentError bell_state(2, 3)
-
-    # destroy, create, num, position, momentum
-    n = 10
-    a = destroy(n)
-    ad = create(n)
-    N = num(n)
-    x = position(n)
-    p = momentum(n)
-    @test isoper(x)
-    @test isoper(p)
-    @test a.dims == ad.dims == N.dims == x.dims == p.dims == [n]
-    @test commutator(N, a) ≈ -a
-    @test commutator(N, ad) ≈ ad
-    @test all(diag(commutator(x, p))[1:(n-1)] .≈ 1.0im)
-
-    # displace, squeeze
-    N = 10
-    α = rand(ComplexF64)
-    z = rand(ComplexF64)
-    II = qeye(N)
-    D = displace(N, α)
-    S = squeeze(N, z)
-    @test D * D' ≈ II
-    @test S * S' ≈ II
-
-    # phase
-    ## verify Equation (33) in: 
-    ## Michael Martin Nieto, QUANTUM PHASE AND QUANTUM PHASE OPERATORS: Some Physics and Some History
-    s = 10
-    ϕ0 = 2 * π * rand()
-    II = qeye(s + 1)
-    ket = [basis(s + 1, i) for i in 0:s]
-    SUM = Qobj(zeros(ComplexF64, s + 1, s + 1))
-    for j in 0:s
-        for k in 0:s
-            j != k ?
-            SUM += (exp(1im * (j - k) * ϕ0) / (exp(1im * (j - k) * 2 * π / (s + 1)) - 1)) * ket[j+1] * ket[k+1]' :
-            nothing
-        end
+@testset "States and Operators" verbose = true begin
+    @testset "zero state" begin
+        v1 = zero_ket(4)
+        v2 = zero_ket([2, 2])
+        @test size(v1) == (4,)
+        @test size(v2) == (4,)
+        @test v1.data == v2.data
+        @test v1 != v2
+        @test isket(v1)
+        @test isket(v2)
+        @test v1.dims == [4]
+        @test v2.dims == [2, 2]
     end
-    @test (ϕ0 + s * π / (s + 1)) * II + (2 * π / (s + 1)) * SUM ≈ phase(s + 1, ϕ0)
 
-    # tunneling
-    @test tunneling(10, 2) == tunneling(10, 2; sparse = true)
-    @test_throws ArgumentError tunneling(10, 0)
-
-    # qft (quantum Fourier transform)
-    N = 9
-    dims = [3, 3]
-    ω = exp(2.0im * π / N)
-    x = Qobj(rand(ComplexF64, N))
-    ψx = basis(N, 0; dims = dims)
-    ψk = unit(Qobj(ones(ComplexF64, N); dims = dims))
-    F_9 = qft(N)
-    F_3_3 = qft(dims)
-    y = F_9 * x
-    for k in 0:(N-1)
-        nk = collect(0:(N-1)) * k
-        @test y[k+1] ≈ sum(x.data .* (ω .^ nk)) / sqrt(N)
+    @testset "fock state" begin
+        # fock, basis, and fock_dm
+        @test fock_dm(4; dims = [2, 2], sparse = true) ≈ ket2dm(basis(4; dims = [2, 2]))
+        @test_throws DimensionMismatch fock(4; dims = [2])
     end
-    @test ψk ≈ F_3_3 * ψx
-    @test ψx ≈ F_3_3' * ψk
 
-    # Pauli matrices and general Spin-j operators
-    J0 = Qobj(spdiagm(0 => [0.0im]))
-    Jx, Jy, Jz = spin_J_set(0.5)
-    @test spin_Jx(0) == spin_Jy(0) == spin_Jz(0) == spin_Jp(0) == spin_Jm(0) == J0
-    @test sigmax() ≈ 2 * spin_Jx(0.5) ≈ 2 * Jx ≈ Qobj(sparse([0.0im 1; 1 0]))
-    @test sigmay() ≈ 2 * spin_Jy(0.5) ≈ 2 * Jy ≈ Qobj(sparse([0.0im -1im; 1im 0]))
-    @test sigmaz() ≈ 2 * spin_Jz(0.5) ≈ 2 * Jz ≈ Qobj(sparse([1 0.0im; 0 -1]))
-    @test sigmap() ≈ spin_Jp(0.5) ≈ Qobj(sparse([0.0im 1; 0 0]))
-    @test sigmam() ≈ spin_Jm(0.5) ≈ Qobj(sparse([0.0im 0; 1 0]))
-    for which in [:x, :y, :z, :+, :-]
-        @test jmat(2.5, which).dims == [6] # 2.5 * 2 + 1 = 6
-
-        for j_wrong in [-1, 8.7]  # Invalid j
-            @test_throws ArgumentError jmat(j_wrong, which)
-        end
+    @testset "coherent state" begin
+        # coherent and coherent_dm
+        N = 4
+        α = 0.25im
+        ψα = coherent(N, α)
+        ρα = coherent_dm(N, α)
+        @test isket(ψα)
+        @test isoper(ρα)
+        @test ket2dm(ψα) ≈ ρα
+        @test tr(ρα) ≈ 1.0
     end
-    @test_throws ArgumentError jmat(0.5, :wrong)
 
-    # test commutation relations for general Spin-j operators
-    # the negative signs follow the rule of Levi-Civita symbol (ϵ_ijk)
-    j = 2
-    Jx, Jy, Jz = spin_J_set(j)
-    @test commutator(Jx, Jy) ≈ 1im * Jz
-    @test commutator(Jy, Jz) ≈ 1im * Jx
-    @test commutator(Jz, Jx) ≈ 1im * Jy
-    @test commutator(Jx, Jz) ≈ -1im * Jy
-    @test commutator(Jy, Jx) ≈ -1im * Jz
-    @test commutator(Jz, Jy) ≈ -1im * Jx
-
-    # spin_state
-    j = 3.5
-    Jz = spin_Jz(j)
-    for m in (-j):1:j
-        ψm = spin_state(j, m)
-        @test Jz * ψm ≈ m * ψm  # check eigenvalue
+    @testset "thermal state" begin
+        ρTd = thermal_dm(5, 0.123)
+        ρTs = thermal_dm(5, 0.123; sparse = true)
+        @test isoper(ρTd)
+        @test ρTd.dims == [5]
+        @test tr(ρTd) ≈ 1.0
+        @test ρTd.data ≈ spdiagm(
+            0 => Float64[
+                0.8904859864731106,
+                0.09753319353178326,
+                0.010682620484781245,
+                0.0011700465891612583,
+                0.00012815292116369966,
+            ],
+        )
+        @test typeof(ρTs.data) <: AbstractSparseMatrix
+        @test ρTd ≈ ρTs
     end
-    @test_throws ArgumentError spin_state(8.7, 8.7)
-    @test_throws ArgumentError spin_state(-1, 0)
-    @test_throws ArgumentError spin_state(2.5, 2)
-    @test_throws ArgumentError spin_state(2.5, 3.5)
-    @test_throws ArgumentError spin_state(2.5, -3.5)
 
-    # spin_coherent
-    ## spin-half (state in Bloch sphere)
-    s = 0.5
-    θ = π * rand()
-    ϕ = 2 * π * rand()
-    @test spin_coherent(s, θ, ϕ) ≈ cos(θ / 2) * basis(2, 0) + exp(1im * ϕ) * sin(θ / 2) * basis(2, 1)
+    @testset "maximally mixed state" begin
+        ρ1 = maximally_mixed_dm(4)
+        ρ2 = maximally_mixed_dm([2, 2])
+        @test size(ρ1) == (4, 4)
+        @test size(ρ2) == (4, 4)
+        @test tr(ρ1) ≈ 1.0
+        @test ρ1.data == ρ2.data
+        @test ρ1 != ρ2
+        @test isoper(ρ1)
+        @test isoper(ρ2)
+        @test ρ1.dims == [4]
+        @test ρ2.dims == [2, 2]
+        @test entropy_vn(ρ1, base = 2) ≈ log(2, 4)
+    end
 
-    ## also verify the equation in: 
-    ## Robert Jones, Spin Coherent States and Statistical Physics, page 3
-    s = 3.5
-    θ1 = π * rand()
-    θ2 = π * rand()
-    ϕ1 = 2 * π * rand()
-    ϕ2 = 2 * π * rand()
-    γ = rand()
-    Sz = spin_Jz(s)
-    n1 = spin_coherent(s, θ1, ϕ1)
-    n2 = spin_coherent(s, θ2, ϕ2)
-    @test dot(n1, n2) ≈ (cos(θ1 / 2) * cos(θ2 / 2) + exp(1im * (ϕ2 - ϕ1)) * sin(θ1 / 2) * sin(θ2 / 2))^(2 * s)
-    @test dot(n1, exp(-γ * Sz), n2) ≈
-          (exp(-γ / 2) * cos(θ1 / 2) * cos(θ2 / 2) + exp(1im * (ϕ2 - ϕ1) + γ / 2) * sin(θ1 / 2) * sin(θ2 / 2))^(2 * s)
+    @testset "random state" begin
+        # rand_ket and rand_dm
+        ψ = rand_ket(10)
+        ρ_AB = rand_dm([2, 2])
+        ρ_A = ptrace(ρ_AB, 1)
+        ρ_B = ptrace(ρ_AB, 2)
+        rank = 5
+        ρ_low_rank = rand_dm(10, rank = rank)
+        eig_val = eigenenergies(ρ_low_rank)
+        @test ψ' * ψ ≈ 1.0
+        @test tr(ρ_AB) ≈ 1.0
+        @test tr(ρ_A) ≈ 1.0
+        @test tr(ρ_B) ≈ 1.0
+        @test tr(ρ_low_rank) ≈ 1.0
+        @test isposdef(ρ_AB) == true
+        @test ishermitian(ρ_AB) == true
+        @test ishermitian(ρ_A) == true
+        @test ishermitian(ρ_B) == true
+        @test ishermitian(ρ_low_rank) == true
+        @test all(eigenenergies(ρ_AB) .>= 0)
+        @test all(eigenenergies(ρ_A) .>= 0)
+        @test all(eigenenergies(ρ_B) .>= 0)
+        @test all(isapprox.(eig_val[1:rank], 0.0, atol = 1e-10))
+        @test all(eig_val[(rank+1):10] .>= 0)
+        @test_throws DomainError rand_dm(4, rank = rank)
+        @test_throws DomainError rand_dm(4, rank = 0)
+    end
 
-    # test commutation relations for fermionic creation and annihilation operators
-    sites = 4
-    SIZE = 2^sites
-    dims = fill(2, sites)
-    Q_iden = Qobj(sparse((1.0 + 0.0im) * LinearAlgebra.I, SIZE, SIZE); dims = dims)
-    Q_zero = Qobj(spzeros(ComplexF64, SIZE, SIZE); dims = dims)
-    for i in 0:(sites-1)
-        d_i = fdestroy(sites, i)
-        @test d_i' ≈ fcreate(sites, i)
+    @testset "entanglement states" begin
+        # bell_state, singlet_state, triplet_states, w_state, and ghz_state
+        e0 = basis(2, 0)
+        e1 = basis(2, 1)
+        d0 = basis(3, 0)
+        d1 = basis(3, 1)
+        d2 = basis(3, 2)
+        B00 = (e0 ⊗ e0 + e1 ⊗ e1) / √2
+        B01 = (e0 ⊗ e0 - e1 ⊗ e1) / √2
+        B10 = (e0 ⊗ e1 + e1 ⊗ e0) / √2
+        B11 = (e0 ⊗ e1 - e1 ⊗ e0) / √2
+        S = singlet_state()
+        T = triplet_states()
+        @test bell_state(0, 0) == B00 == ghz_state(2)
+        @test bell_state(0, 1) == B01
+        @test bell_state(1, 0) == B10 == T[2] == w_state(2)
+        @test bell_state(1, 1) == B11 == S
+        @test T[1] == e1 ⊗ e1
+        @test T[3] == e0 ⊗ e0
+        @test w_state(3) == (e0 ⊗ e0 ⊗ e1 + e0 ⊗ e1 ⊗ e0 + e1 ⊗ e0 ⊗ e0) / √3
+        @test ghz_state(3) == (e0 ⊗ e0 ⊗ e0 + e1 ⊗ e1 ⊗ e1) / √2
+        @test ghz_state(3; d = 3) == (d0 ⊗ d0 ⊗ d0 + d1 ⊗ d1 ⊗ d1 + d2 ⊗ d2 ⊗ d2) / √3
+        @test_throws ArgumentError bell_state(0, 2)
+        @test_throws ArgumentError bell_state(3, 1)
+        @test_throws ArgumentError bell_state(2, 3)
+    end
 
-        for j in 0:(sites-1)
-            d_j = fdestroy(sites, j)
+    @testset "bosonic operators" begin
+        # destroy, create, num, position, momentum
+        n = 10
+        a = destroy(n)
+        ad = create(n)
+        N = num(n)
+        x = position(n)
+        p = momentum(n)
+        @test isoper(x)
+        @test isoper(p)
+        @test a.dims == ad.dims == N.dims == x.dims == p.dims == [n]
+        @test eigenenergies(ad * a) ≈ 0:(n-1)
+        @test commutator(N, a) ≈ -a
+        @test commutator(N, ad) ≈ ad
+        @test all(diag(commutator(x, p))[1:(n-1)] .≈ 1.0im)
+    end
 
-            if i == j
-                @test commutator(d_i, d_j'; anti = true) ≈ Q_iden
-            else
-                @test commutator(d_i, d_j'; anti = true) ≈ Q_zero
+    @testset "displacement and squeezing operators" begin
+        N = 10
+        α = rand(ComplexF64)
+        z = rand(ComplexF64)
+        II = qeye(N)
+        D = displace(N, α)
+        S = squeeze(N, z)
+        @test D * D' ≈ II
+        @test S * S' ≈ II
+    end
+
+    @testset "phase" begin
+        # verify Equation (33) in: 
+        # Michael Martin Nieto, QUANTUM PHASE AND QUANTUM PHASE OPERATORS: Some Physics and Some History
+        s = 10
+        ϕ0 = 2 * π * rand()
+        II = qeye(s + 1)
+        ket = [basis(s + 1, i) for i in 0:s]
+        SUM = Qobj(zeros(ComplexF64, s + 1, s + 1))
+        for j in 0:s
+            for k in 0:s
+                (j != k) && (
+                    SUM +=
+                        (exp(1im * (j - k) * ϕ0) / (exp(1im * (j - k) * 2 * π / (s + 1)) - 1)) * ket[j+1] * ket[k+1]'
+                )
             end
-            @test commutator(d_i', d_j'; anti = true) ≈ Q_zero
-            @test commutator(d_i, d_j; anti = true) ≈ Q_zero
         end
+        @test isapprox((ϕ0 + s * π / (s + 1)) * II + (2 * π / (s + 1)) * SUM, phase(s + 1, ϕ0); atol = 1e-8)
     end
-    @test_throws ArgumentError fdestroy(0, 0)
-    @test_throws ArgumentError fdestroy(sites, -1)
-    @test_throws ArgumentError fdestroy(sites, sites)
 
-    # identity operator
-    I_op1 = qeye(4)
-    I_op2 = qeye(4, dims = [2, 2])
-    I_su1 = qeye(4, type = SuperOperator)
-    I_su2 = qeye(4, type = SuperOperator, dims = [2])
-    @test I_op1.data == I_op2.data == I_su1.data == I_su2.data
-    @test (I_op1 == I_op2) == false
-    @test (I_op1 == I_su1) == false
-    @test (I_op1 == I_su2) == false
-    @test (I_op2 == I_su1) == false
-    @test (I_op2 == I_su2) == false
-    @test (I_su1 == I_su2) == true
-    @test_throws DimensionMismatch qeye(4, dims = [2])
-    @test_throws DimensionMismatch qeye(2, type = SuperOperator)
-    @test_throws DimensionMismatch qeye(4, type = SuperOperator, dims = [2, 2])
+    @testset "tunneling" begin
+        @test tunneling(10, 2) == tunneling(10, 2; sparse = true)
+        @test_throws ArgumentError tunneling(10, 0)
+    end
 
-    # spre, spost, and sprepost
-    Xs = sigmax()
-    Xd = sparse_to_dense(Xs)
-    A_wrong1 = Qobj(rand(4, 4), dims = [4])
-    A_wrong2 = Qobj(rand(4, 4), dims = [2, 2])
-    A_wrong3 = Qobj(rand(3, 3))
-    @test (typeof(spre(Xd).data) <: SparseMatrixCSC) == true
-    @test (typeof(spre(Xs).data) <: SparseMatrixCSC) == true
-    @test (typeof(spost(Xd).data) <: SparseMatrixCSC) == true
-    @test (typeof(spost(Xs).data) <: SparseMatrixCSC) == true
-    @test (typeof(sprepost(Xd, Xd).data) <: SparseMatrixCSC) == true
-    @test (typeof(sprepost(Xs, Xs).data) <: SparseMatrixCSC) == true
-    @test (typeof(sprepost(Xs, Xd).data) <: SparseMatrixCSC) == true
-    @test (typeof(sprepost(Xd, Xs).data) <: SparseMatrixCSC) == true
-    @test_throws DimensionMismatch sprepost(A_wrong1, A_wrong2)
-    @test_throws DimensionMismatch sprepost(A_wrong1, A_wrong3)
+    @testset "quantum Fourier transform" begin
+        N = 9
+        dims = [3, 3]
+        ω = exp(2.0im * π / N)
+        x = Qobj(rand(ComplexF64, N))
+        ψx = basis(N, 0; dims = dims)
+        ψk = unit(Qobj(ones(ComplexF64, N); dims = dims))
+        F_9 = qft(N)
+        F_3_3 = qft(dims)
+        y = F_9 * x
+        for k in 0:(N-1)
+            nk = collect(0:(N-1)) * k
+            @test y[k+1] ≈ sum(x.data .* (ω .^ nk)) / sqrt(N)
+        end
+        @test ψk ≈ F_3_3 * ψx
+        @test ψx ≈ F_3_3' * ψk
+    end
+
+    @testset "Spin-j operators" begin
+        # Pauli matrices and general Spin-j operators
+        J0 = Qobj(spdiagm(0 => [0.0im]))
+        Jx, Jy, Jz = spin_J_set(0.5)
+        @test spin_Jx(0) == spin_Jy(0) == spin_Jz(0) == spin_Jp(0) == spin_Jm(0) == J0
+        @test sigmax() ≈ 2 * spin_Jx(0.5) ≈ 2 * Jx ≈ Qobj(sparse([0.0im 1; 1 0]))
+        @test sigmay() ≈ 2 * spin_Jy(0.5) ≈ 2 * Jy ≈ Qobj(sparse([0.0im -1im; 1im 0]))
+        @test sigmaz() ≈ 2 * spin_Jz(0.5) ≈ 2 * Jz ≈ Qobj(sparse([1 0.0im; 0 -1]))
+        @test sigmap() ≈ spin_Jp(0.5) ≈ Qobj(sparse([0.0im 1; 0 0]))
+        @test sigmam() ≈ spin_Jm(0.5) ≈ Qobj(sparse([0.0im 0; 1 0]))
+        for which in [:x, :y, :z, :+, :-]
+            @test jmat(2.5, which).dims == [6] # 2.5 * 2 + 1 = 6
+
+            for j_wrong in [-1, 8.7]  # Invalid j
+                @test_throws ArgumentError jmat(j_wrong, which)
+            end
+        end
+        @test_throws ArgumentError jmat(0.5, :wrong)
+
+        # test commutation relations for general Spin-j operators
+        # the negative signs follow the rule of Levi-Civita symbol (ϵ_ijk)
+        j = 2
+        Jx, Jy, Jz = spin_J_set(j)
+        @test commutator(Jx, Jy) ≈ 1im * Jz
+        @test commutator(Jy, Jz) ≈ 1im * Jx
+        @test commutator(Jz, Jx) ≈ 1im * Jy
+        @test commutator(Jx, Jz) ≈ -1im * Jy
+        @test commutator(Jy, Jx) ≈ -1im * Jz
+        @test commutator(Jz, Jy) ≈ -1im * Jx
+    end
+
+    @testset "spin state" begin
+        j = 3.5
+        Jz = spin_Jz(j)
+        for m in (-j):1:j
+            ψm = spin_state(j, m)
+            @test Jz * ψm ≈ m * ψm  # check eigenvalue
+        end
+        @test_throws ArgumentError spin_state(8.7, 8.7)
+        @test_throws ArgumentError spin_state(-1, 0)
+        @test_throws ArgumentError spin_state(2.5, 2)
+        @test_throws ArgumentError spin_state(2.5, 3.5)
+        @test_throws ArgumentError spin_state(2.5, -3.5)
+    end
+
+    @testset "spin coherent state" begin
+        # spin-half (state in Bloch sphere)
+        s = 0.5
+        θ = π * rand()
+        ϕ = 2 * π * rand()
+        @test spin_coherent(s, θ, ϕ) ≈ cos(θ / 2) * basis(2, 0) + exp(1im * ϕ) * sin(θ / 2) * basis(2, 1)
+
+        # also verify the equation in: 
+        # Robert Jones, Spin Coherent States and Statistical Physics, page 3
+        s = 3.5
+        θ1 = π * rand()
+        θ2 = π * rand()
+        ϕ1 = 2 * π * rand()
+        ϕ2 = 2 * π * rand()
+        γ = rand()
+        Sz = spin_Jz(s)
+        n1 = spin_coherent(s, θ1, ϕ1)
+        n2 = spin_coherent(s, θ2, ϕ2)
+        @test dot(n1, n2) ≈ (cos(θ1 / 2) * cos(θ2 / 2) + exp(1im * (ϕ2 - ϕ1)) * sin(θ1 / 2) * sin(θ2 / 2))^(2 * s)
+        @test dot(n1, exp(-γ * Sz), n2) ≈
+              (
+            exp(-γ / 2) * cos(θ1 / 2) * cos(θ2 / 2) + exp(1im * (ϕ2 - ϕ1) + γ / 2) * sin(θ1 / 2) * sin(θ2 / 2)
+        )^(2 * s)
+
+        # test commutation relations for fermionic creation and annihilation operators
+        sites = 4
+        SIZE = 2^sites
+        dims = fill(2, sites)
+        Q_iden = Qobj(sparse((1.0 + 0.0im) * LinearAlgebra.I, SIZE, SIZE); dims = dims)
+        Q_zero = Qobj(spzeros(ComplexF64, SIZE, SIZE); dims = dims)
+        for i in 0:(sites-1)
+            d_i = fdestroy(sites, i)
+            @test d_i' ≈ fcreate(sites, i)
+
+            for j in 0:(sites-1)
+                d_j = fdestroy(sites, j)
+
+                if i == j
+                    @test commutator(d_i, d_j'; anti = true) ≈ Q_iden
+                else
+                    @test commutator(d_i, d_j'; anti = true) ≈ Q_zero
+                end
+                @test commutator(d_i', d_j'; anti = true) ≈ Q_zero
+                @test commutator(d_i, d_j; anti = true) ≈ Q_zero
+            end
+        end
+        @test_throws ArgumentError fdestroy(0, 0)
+        @test_throws ArgumentError fdestroy(sites, -1)
+        @test_throws ArgumentError fdestroy(sites, sites)
+    end
+
+    @testset "identity operator" begin
+        I_op1 = qeye(4)
+        I_op2 = qeye(4, dims = [2, 2])
+        I_su1 = qeye(4, type = SuperOperator)
+        I_su2 = qeye(4, type = SuperOperator, dims = [2])
+        @test I_op1.data == I_op2.data == I_su1.data == I_su2.data
+        @test (I_op1 == I_op2) == false
+        @test (I_op1 == I_su1) == false
+        @test (I_op1 == I_su2) == false
+        @test (I_op2 == I_su1) == false
+        @test (I_op2 == I_su2) == false
+        @test (I_su1 == I_su2) == true
+        @test_throws DimensionMismatch qeye(4, dims = [2])
+        @test_throws DimensionMismatch qeye(2, type = SuperOperator)
+        @test_throws DimensionMismatch qeye(4, type = SuperOperator, dims = [2, 2])
+    end
+
+    @testset "superoperators" begin
+        # spre, spost, and sprepost
+        Xs = sigmax()
+        Xd = sparse_to_dense(Xs)
+        A_wrong1 = Qobj(rand(4, 4), dims = [4])
+        A_wrong2 = Qobj(rand(4, 4), dims = [2, 2])
+        A_wrong3 = Qobj(rand(3, 3))
+        @test (typeof(spre(Xd).data) <: SparseMatrixCSC) == true
+        @test (typeof(spre(Xs).data) <: SparseMatrixCSC) == true
+        @test (typeof(spost(Xd).data) <: SparseMatrixCSC) == true
+        @test (typeof(spost(Xs).data) <: SparseMatrixCSC) == true
+        @test (typeof(sprepost(Xd, Xd).data) <: SparseMatrixCSC) == true
+        @test (typeof(sprepost(Xs, Xs).data) <: SparseMatrixCSC) == true
+        @test (typeof(sprepost(Xs, Xd).data) <: SparseMatrixCSC) == true
+        @test (typeof(sprepost(Xd, Xs).data) <: SparseMatrixCSC) == true
+        @test_throws DimensionMismatch sprepost(A_wrong1, A_wrong2)
+        @test_throws DimensionMismatch sprepost(A_wrong1, A_wrong3)
+    end
 end

--- a/test/time_evolution_and_partial_trace.jl
+++ b/test/time_evolution_and_partial_trace.jl
@@ -1,109 +1,120 @@
-@testset "Time Evolution and Partial Trace" begin
-    # sesolve
-    N = 10
-    a_d = kron(create(N), qeye(2))
-    a = a_d'
-    sx = kron(qeye(N), sigmax())
-    sy = tensor(qeye(N), sigmay())
-    sz = qeye(N) ⊗ sigmaz()
-    η = 0.01
-    H = a_d * a + 0.5 * sz - 1im * η * (a - a_d) * sx
-    psi0 = kron(fock(N, 0), fock(2, 0))
-    t_l = LinRange(0, 1000, 1000)
-    e_ops = [a_d * a]
-    sol = sesolve(H, psi0, t_l, e_ops = e_ops, alg = Vern7(), progress_bar = false)
-    sol2 = sesolve(H, psi0, t_l, progress_bar = false)
-    sol3 = sesolve(H, psi0, t_l, e_ops = e_ops, saveat = t_l, progress_bar = false)
-    sol_string = sprint((t, s) -> show(t, "text/plain", s), sol)
-    @test sum(abs.(sol.expect[1, :] .- sin.(η * t_l) .^ 2)) / length(t_l) < 0.1
-    @test ptrace(sol.states[end], 1) ≈ ptrace(ket2dm(sol.states[end]), 1)
-    @test ptrace(sol.states[end]', 1) ≈ ptrace(sol.states[end], 1)
-    @test length(sol.states) == 1
-    @test size(sol.expect) == (length(e_ops), length(t_l))
-    @test length(sol2.states) == length(t_l)
-    @test size(sol2.expect) == (0, length(t_l))
-    @test length(sol3.states) == length(t_l)
-    @test size(sol3.expect) == (length(e_ops), length(t_l))
-    @test sol_string ==
-          "Solution of time evolution\n" *
-          "(return code: $(sol.retcode))\n" *
-          "--------------------------\n" *
-          "num_states = $(length(sol.states))\n" *
-          "num_expect = $(size(sol.expect, 1))\n" *
-          "ODE alg.: $(sol.alg)\n" *
-          "abstol = $(sol.abstol)\n" *
-          "reltol = $(sol.reltol)\n"
+@testset "Time Evolution and Partial Trace" verbose = true begin
+    @testset "sesolve" begin
+        N = 10
+        a_d = kron(create(N), qeye(2))
+        a = a_d'
+        sx = kron(qeye(N), sigmax())
+        sy = tensor(qeye(N), sigmay())
+        sz = qeye(N) ⊗ sigmaz()
+        η = 0.01
+        H = a_d * a + 0.5 * sz - 1im * η * (a - a_d) * sx
+        psi0 = kron(fock(N, 0), fock(2, 0))
+        t_l = LinRange(0, 1000, 1000)
+        e_ops = [a_d * a]
+        sol = sesolve(H, psi0, t_l, e_ops = e_ops, alg = Vern7(), progress_bar = false)
+        sol2 = sesolve(H, psi0, t_l, progress_bar = false)
+        sol3 = sesolve(H, psi0, t_l, e_ops = e_ops, saveat = t_l, progress_bar = false)
+        sol_string = sprint((t, s) -> show(t, "text/plain", s), sol)
+        @test sum(abs.(sol.expect[1, :] .- sin.(η * t_l) .^ 2)) / length(t_l) < 0.1
+        @test ptrace(sol.states[end], 1) ≈ ptrace(ket2dm(sol.states[end]), 1)
+        @test ptrace(sol.states[end]', 1) ≈ ptrace(sol.states[end], 1)
+        @test length(sol.states) == 1
+        @test size(sol.expect) == (length(e_ops), length(t_l))
+        @test length(sol2.states) == length(t_l)
+        @test size(sol2.expect) == (0, length(t_l))
+        @test length(sol3.states) == length(t_l)
+        @test size(sol3.expect) == (length(e_ops), length(t_l))
+        @test sol_string ==
+              "Solution of time evolution\n" *
+              "(return code: $(sol.retcode))\n" *
+              "--------------------------\n" *
+              "num_states = $(length(sol.states))\n" *
+              "num_expect = $(size(sol.expect, 1))\n" *
+              "ODE alg.: $(sol.alg)\n" *
+              "abstol = $(sol.abstol)\n" *
+              "reltol = $(sol.reltol)\n"
+    end
 
-    # mesolve and mcsolve
-    a = destroy(N)
-    a_d = a'
-    H = a_d * a
-    c_ops = [sqrt(0.1) * a]
-    e_ops = [a_d * a]
-    psi0 = basis(N, 3)
-    t_l = LinRange(0, 100, 1000)
-    sol_me = mesolve(H, psi0, t_l, c_ops, e_ops = e_ops, alg = Vern7(), progress_bar = false)
-    sol_me2 = mesolve(H, psi0, t_l, c_ops, progress_bar = false)
-    sol_me3 = mesolve(H, psi0, t_l, c_ops, e_ops = e_ops, saveat = t_l, progress_bar = false)
-    sol_mc = mcsolve(H, psi0, t_l, c_ops, n_traj = 500, e_ops = e_ops, progress_bar = false)
-    sol_me_string = sprint((t, s) -> show(t, "text/plain", s), sol_me)
-    sol_mc_string = sprint((t, s) -> show(t, "text/plain", s), sol_mc)
-    @test sum(abs.(sol_mc.expect .- sol_me.expect)) / length(t_l) < 0.1
-    @test length(sol_me.states) == 1
-    @test size(sol_me.expect) == (length(e_ops), length(t_l))
-    @test length(sol_me2.states) == length(t_l)
-    @test size(sol_me2.expect) == (0, length(t_l))
-    @test length(sol_me3.states) == length(t_l)
-    @test size(sol_me3.expect) == (length(e_ops), length(t_l))
-    @test sol_me_string ==
-          "Solution of time evolution\n" *
-          "(return code: $(sol_me.retcode))\n" *
-          "--------------------------\n" *
-          "num_states = $(length(sol_me.states))\n" *
-          "num_expect = $(size(sol_me.expect, 1))\n" *
-          "ODE alg.: $(sol_me.alg)\n" *
-          "abstol = $(sol_me.abstol)\n" *
-          "reltol = $(sol_me.reltol)\n"
-    @test sol_mc_string ==
-          "Solution of quantum trajectories\n" *
-          "(converged: $(sol_mc.converged))\n" *
-          "--------------------------------\n" *
-          "num_trajectories = $(sol_mc.n_traj)\n" *
-          "num_states = $(length(sol_mc.states[1]))\n" *
-          "num_expect = $(size(sol_mc.expect, 1))\n" *
-          "ODE alg.: $(sol_mc.alg)\n" *
-          "abstol = $(sol_mc.abstol)\n" *
-          "reltol = $(sol_mc.reltol)\n"
+    @testset "mesolve and mcsolve" begin
+        N = 10
+        a = destroy(N)
+        a_d = a'
+        H = a_d * a
+        c_ops = [sqrt(0.1) * a]
+        e_ops = [a_d * a]
+        psi0 = basis(N, 3)
+        t_l = LinRange(0, 100, 1000)
+        sol_me = mesolve(H, psi0, t_l, c_ops, e_ops = e_ops, alg = Vern7(), progress_bar = false)
+        sol_me2 = mesolve(H, psi0, t_l, c_ops, progress_bar = false)
+        sol_me3 = mesolve(H, psi0, t_l, c_ops, e_ops = e_ops, saveat = t_l, progress_bar = false)
+        sol_mc = mcsolve(H, psi0, t_l, c_ops, n_traj = 500, e_ops = e_ops, progress_bar = false)
+        sol_me_string = sprint((t, s) -> show(t, "text/plain", s), sol_me)
+        sol_mc_string = sprint((t, s) -> show(t, "text/plain", s), sol_mc)
+        @test sum(abs.(sol_mc.expect .- sol_me.expect)) / length(t_l) < 0.1
+        @test length(sol_me.states) == 1
+        @test size(sol_me.expect) == (length(e_ops), length(t_l))
+        @test length(sol_me2.states) == length(t_l)
+        @test size(sol_me2.expect) == (0, length(t_l))
+        @test length(sol_me3.states) == length(t_l)
+        @test size(sol_me3.expect) == (length(e_ops), length(t_l))
+        @test sol_me_string ==
+              "Solution of time evolution\n" *
+              "(return code: $(sol_me.retcode))\n" *
+              "--------------------------\n" *
+              "num_states = $(length(sol_me.states))\n" *
+              "num_expect = $(size(sol_me.expect, 1))\n" *
+              "ODE alg.: $(sol_me.alg)\n" *
+              "abstol = $(sol_me.abstol)\n" *
+              "reltol = $(sol_me.reltol)\n"
+        @test sol_mc_string ==
+              "Solution of quantum trajectories\n" *
+              "(converged: $(sol_mc.converged))\n" *
+              "--------------------------------\n" *
+              "num_trajectories = $(sol_mc.n_traj)\n" *
+              "num_states = $(length(sol_mc.states[1]))\n" *
+              "num_expect = $(size(sol_mc.expect, 1))\n" *
+              "ODE alg.: $(sol_mc.alg)\n" *
+              "abstol = $(sol_mc.abstol)\n" *
+              "reltol = $(sol_mc.reltol)\n"
+    end
 
-    # exceptions
-    psi_wrong = basis(N - 1, 3)
-    @test_throws DimensionMismatch sesolve(H, psi_wrong, t_l)
-    @test_throws DimensionMismatch mesolve(H, psi_wrong, t_l)
-    @test_throws DimensionMismatch mcsolve(H, psi_wrong, t_l)
-    @test_throws ArgumentError sesolve(H, psi0, t_l, save_idxs = [1, 2])
-    @test_throws ArgumentError mesolve(H, psi0, t_l, save_idxs = [1, 2])
-    @test_throws ArgumentError mcsolve(H, psi0, t_l, save_idxs = [1, 2])
+    @testset "exceptions" begin
+        N = 10
+        a = destroy(N)
+        H = a' * a
+        psi0 = basis(N, 3)
+        t_l = LinRange(0, 100, 1000)
+        psi_wrong = basis(N - 1, 3)
+        @test_throws DimensionMismatch sesolve(H, psi_wrong, t_l)
+        @test_throws DimensionMismatch mesolve(H, psi_wrong, t_l)
+        @test_throws DimensionMismatch mcsolve(H, psi_wrong, t_l)
+        @test_throws ArgumentError sesolve(H, psi0, t_l, save_idxs = [1, 2])
+        @test_throws ArgumentError mesolve(H, psi0, t_l, save_idxs = [1, 2])
+        @test_throws ArgumentError mcsolve(H, psi0, t_l, save_idxs = [1, 2])
+    end
 
-    sp1 = kron(sigmap(), qeye(2))
-    sm1 = sp1'
-    sx1 = sm1 + sp1
-    sy1 = 1im * (sm1 - sp1)
-    sz1 = sp1 * sm1 - sm1 * sp1
-    sp2 = kron(qeye(2), sigmap())
-    sm2 = sp2'
-    sx2 = sm2 + sp2
-    sy2 = 1im * (sm2 - sp2)
-    sz2 = sp2 * sm2 - sm2 * sp2
-    ωq1, ωq2 = 1, 1
-    γ1, γ2 = 0.05, 0.1
-    H = 0.5 * ωq1 * sz1 + 0.5 * ωq2 * sz2
-    c_ops = [sqrt(γ1) * sm1, sqrt(γ2) * sm2]
-    psi0_1 = normalize(fock(2, 0) + fock(2, 1))
-    psi0_2 = normalize(fock(2, 0) + fock(2, 1))
-    psi0 = kron(psi0_1, psi0_2)
-    t_l = LinRange(0, 20 / γ1, 1000)
-    sol_me = mesolve(H, psi0, t_l, c_ops, e_ops = [sp1 * sm1, sp2 * sm2], progress_bar = false)
-    sol_mc = mcsolve(H, psi0, t_l, c_ops, n_traj = 500, e_ops = [sp1 * sm1, sp2 * sm2], progress_bar = false)
-    @test sum(abs.(sol_mc.expect[1:2, :] .- sol_me.expect[1:2, :])) / length(t_l) < 0.1
-    @test expect(sp1 * sm1, sol_me.states[end]) ≈ expect(sigmap() * sigmam(), ptrace(sol_me.states[end], 1))
+    @testset "example" begin
+        sp1 = kron(sigmap(), qeye(2))
+        sm1 = sp1'
+        sx1 = sm1 + sp1
+        sy1 = 1im * (sm1 - sp1)
+        sz1 = sp1 * sm1 - sm1 * sp1
+        sp2 = kron(qeye(2), sigmap())
+        sm2 = sp2'
+        sx2 = sm2 + sp2
+        sy2 = 1im * (sm2 - sp2)
+        sz2 = sp2 * sm2 - sm2 * sp2
+        ωq1, ωq2 = 1, 1
+        γ1, γ2 = 0.05, 0.1
+        H = 0.5 * ωq1 * sz1 + 0.5 * ωq2 * sz2
+        c_ops = [sqrt(γ1) * sm1, sqrt(γ2) * sm2]
+        psi0_1 = normalize(fock(2, 0) + fock(2, 1))
+        psi0_2 = normalize(fock(2, 0) + fock(2, 1))
+        psi0 = kron(psi0_1, psi0_2)
+        t_l = LinRange(0, 20 / γ1, 1000)
+        sol_me = mesolve(H, psi0, t_l, c_ops, e_ops = [sp1 * sm1, sp2 * sm2], progress_bar = false)
+        sol_mc = mcsolve(H, psi0, t_l, c_ops, n_traj = 500, e_ops = [sp1 * sm1, sp2 * sm2], progress_bar = false)
+        @test sum(abs.(sol_mc.expect[1:2, :] .- sol_me.expect[1:2, :])) / length(t_l) < 0.1
+        @test expect(sp1 * sm1, sol_me.states[end]) ≈ expect(sigmap() * sigmam(), ptrace(sol_me.states[end], 1))
+    end
 end


### PR DESCRIPTION
I realize that we can add keyword argument `verbose = true` in `@testset`:
```julia
@testset "Test" verbose = true begin
    @testset "Sub-Test 1" begin
        ...
    end
    @testset "Sub-Test 2" begin
        ...
    end
end
```

So I tried to divide some tests into several sub-testsets, which I think it could improve the readability while we are debugging.

This PR also made some small changes for the following functions: `:(==)`, `isequal`, `isapprox`.
I think it would be better to check the `type` and `dims` first, and then check the `data` at the end.
Furthermore, this PR allows users to pass `kwargs` directly to `Base.isapprox`.