### PR TITLE
Optimize CI pipline using `paths` filter

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -3,13 +3,21 @@ on:
   push:
     branches:
       - 'main'
-    paths-ignore:
-      - 'docs/**'
+    paths:
+      - '.github/workflows/Benchmarks.yml'
+      - 'src/**'
+      - 'ext/**'
+      - 'benchmarks/**'
+      - 'Project.toml'
   pull_request:
     branches:
       - 'main'
-    paths-ignore:
-      - 'docs/**'
+    paths:
+      - '.github/workflows/Benchmarks.yml'
+      - 'src/**'
+      - 'ext/**'
+      - 'benchmarks/**'
+      - 'Project.toml'
     types:
       - opened
       - reopened

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,13 +4,21 @@ on:
   push:
     branches:
       - 'main'
-    paths-ignore:
-      - 'docs/**'
+    paths:
+      - '.github/workflows/CI.yml'
+      - 'src/**'
+      - 'ext/**'
+      - 'test/**'
+      - 'Project.toml'
   pull_request:
     branches:
       - 'main'
-    paths-ignore:
-      - 'docs/**'
+    paths:
+      - '.github/workflows/CI.yml'
+      - 'src/**'
+      - 'ext/**'
+      - 'test/**'
+      - 'Project.toml'
     types:
       - opened
       - reopened

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -5,12 +5,14 @@ on:
       - 'main'
     paths:
       - '.github/workflows/FormatCheck.yml'
+      - '.JuliaFormatter.toml'
       - '**.jl'
   pull_request:
     branches:
       - 'main'
     paths:
       - '.github/workflows/FormatCheck.yml'
+      - '.JuliaFormatter.toml'
       - '**.jl'
     types:
       - opened

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -3,11 +3,15 @@ on:
   push:
     branches:
       - 'main'
-    tags: 
-      - '*'
+    paths:
+      - '.github/workflows/FormatCheck.yml'
+      - '**.jl'
   pull_request:
     branches:
       - 'main'
+    paths:
+      - '.github/workflows/FormatCheck.yml'
+      - '**.jl'
     types:
       - opened
       - reopened

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,6 +9,12 @@ on:
   pull_request:
     branches:
       - 'main'
+    paths:
+      - '.github/workflows/documentation.yml'
+      - 'src/**'
+      - 'ext/**'
+      - 'docs/**'
+      - 'Project.toml'
     types:
       - opened
       - reopened


### PR DESCRIPTION
This PR changes the `paths-ignore` filter in CI pipeline configs to `paths` filter.

In this way, we don't need to add `[skip ci]` while modifying `README.md`, `.gitignore`, and so on.