### PR TITLE
Fix type instabilities for `sesolve`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ QuantumToolboxCUDAExt = "CUDA"
 [compat]
 ArrayInterface = "6, 7"
 CUDA = "5"
-DiffEqCallbacks = "2, 3"
+DiffEqCallbacks = "2, 3.1"
 FFTW = "1.5"
 Graphs = "1.7"
 IncompleteLU = "0.2"

--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ QuantumToolboxCUDAExt = "CUDA"
 [compat]
 ArrayInterface = "6, 7"
 CUDA = "5"
-DiffEqCallbacks = "2, 3.1"
+DiffEqCallbacks = "2, <3.2"
 FFTW = "1.5"
 Graphs = "1.7"
 IncompleteLU = "0.2"

--- a/test/time_evolution_and_partial_trace.jl
+++ b/test/time_evolution_and_partial_trace.jl
@@ -35,9 +35,11 @@
               "reltol = $(sol.reltol)\n"
 
         @testset "Type Inference sesolve" begin
-            @inferred sesolve(H, psi0, t_l, e_ops = e_ops, progress_bar = false)
-            @inferred sesolve(H, psi0, t_l, progress_bar = false)
-            @inferred sesolve(H, psi0, t_l, e_ops = e_ops, saveat = t_l, progress_bar = false)
+            if VERSION >= v"1.10"
+                @inferred sesolve(H, psi0, t_l, e_ops = e_ops, progress_bar = false)
+                @inferred sesolve(H, psi0, t_l, progress_bar = false)
+                @inferred sesolve(H, psi0, t_l, e_ops = e_ops, saveat = t_l, progress_bar = false)
+            end
         end
     end
 

--- a/test/time_evolution_and_partial_trace.jl
+++ b/test/time_evolution_and_partial_trace.jl
@@ -11,7 +11,7 @@
         psi0 = kron(fock(N, 0), fock(2, 0))
         t_l = LinRange(0, 1000, 1000)
         e_ops = [a_d * a]
-        sol = sesolve(H, psi0, t_l, e_ops = e_ops, alg = Vern7(), progress_bar = false)
+        sol = sesolve(H, psi0, t_l, e_ops = e_ops, progress_bar = false)
         sol2 = sesolve(H, psi0, t_l, progress_bar = false)
         sol3 = sesolve(H, psi0, t_l, e_ops = e_ops, saveat = t_l, progress_bar = false)
         sol_string = sprint((t, s) -> show(t, "text/plain", s), sol)
@@ -33,6 +33,12 @@
               "ODE alg.: $(sol.alg)\n" *
               "abstol = $(sol.abstol)\n" *
               "reltol = $(sol.reltol)\n"
+
+        @testset "Type Inference sesolve" begin
+            @inferred sesolve(H, psi0, t_l, e_ops = e_ops, progress_bar = false)
+            @inferred sesolve(H, psi0, t_l, progress_bar = false)
+            @inferred sesolve(H, psi0, t_l, e_ops = e_ops, saveat = t_l, progress_bar = false)
+        end
     end
 
     @testset "mesolve and mcsolve" begin


### PR DESCRIPTION
This is the first of a long series of Pull Requests for fixing all the type instabilities of the functions.

Here, I have downgraded the maximum version of DiffEqCallbacks.jl to v3.1.0, since after that version it generates type instabilities. Moreover, I made some small changes to the code.