### PR TITLE
make element-type of `zero_ket` as complex

### DIFF
--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -16,8 +16,8 @@ The `dimensions` can be either the following types:
 - `dimensions::Int`: Number of basis states in the Hilbert space.
 - `dimensions::Vector{Int}`: list of dimensions representing the each number of basis in the subsystems.
 """
-zero_ket(dimensions::Int) = QuantumObject(zeros(dimensions), Ket, [dimensions])
-zero_ket(dimensions::Vector{Int}) = QuantumObject(zeros(prod(dimensions)), Ket, dimensions)
+zero_ket(dimensions::Int) = QuantumObject(zeros(ComplexF64, dimensions), Ket, [dimensions])
+zero_ket(dimensions::Vector{Int}) = QuantumObject(zeros(ComplexF64, prod(dimensions)), Ket, dimensions)
 
 @doc raw"""
     fock(N::Int, pos::Int=0; dims::Vector{Int}=[N], sparse::Bool=false)


### PR DESCRIPTION
As title, because usually people will make a zero ket first and start to stack some values at different position of the vector. 
It would be better to generate it with the element-type `ComplexF64`, so that users can directly assign complex values to it.