### PR TITLE
support `real` and `imag` for `Qobj`

### DIFF
--- a/src/qobj/quantum_object.jl
+++ b/src/qobj/quantum_object.jl
@@ -330,6 +330,9 @@ Base.isapprox(A::QuantumObject{<:AbstractArray{T}}, B::QuantumObject{<:AbstractA
 Base.:(==)(A::QuantumObject{<:AbstractArray{T}}, B::QuantumObject{<:AbstractArray{T}}) where {T} =
     (A.type == B.type) && (A.dims == B.dims) && (A.data == B.data)
 
+Base.real(x::QuantumObject) = QuantumObject(real(x.data), x.type, x.dims)
+Base.imag(x::QuantumObject) = QuantumObject(imag(x.data), x.type, x.dims)
+
 SparseArrays.sparse(A::QuantumObject{<:AbstractArray{T}}) where {T} = QuantumObject(sparse(A.data), A.type, A.dims)
 SparseArrays.nnz(A::QuantumObject{<:AbstractSparseArray}) = nnz(A.data)
 SparseArrays.nonzeros(A::QuantumObject{<:AbstractSparseArray}) = nonzeros(A.data)

--- a/test/quantum_objects.jl
+++ b/test/quantum_objects.jl
@@ -145,6 +145,8 @@
         @test isequal(a4, a3) == false
         @test a4 ≈ a2
 
+        @test real(a2) == real(a)
+        @test imag(a2) == imag(a)
         @test +a2 == a2
         @test -(-a2) == a2
         @test a2^3 ≈ a2 * a2 * a2

--- a/test/quantum_objects.jl
+++ b/test/quantum_objects.jl
@@ -145,8 +145,8 @@
         @test isequal(a4, a3) == false
         @test a4 ≈ a2
 
-        @test real(a2) == real(a)
-        @test imag(a2) == imag(a)
+        @test real(a2).data == real(a)
+        @test imag(a2).data == imag(a)
         @test +a2 == a2
         @test -(-a2) == a2
         @test a2^3 ≈ a2 * a2 * a2


### PR DESCRIPTION
This PR allows users to extract the real or imaginary parts of an `Qobj`.