### PR TITLE
introduce `rand_unitary` and `isunitary`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -115,6 +115,7 @@ singlet_state
 triplet_states
 w_state
 ghz_state
+rand_unitary
 sigmap
 sigmam
 sigmax

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -38,6 +38,7 @@ issuper
 LinearAlgebra.ishermitian
 LinearAlgebra.issymmetric
 LinearAlgebra.isposdef
+isunitary
 ```
 
 ## [Qobj arithmetic and attributes](@id doc-API:Qobj-arithmetic-and-attributes)

--- a/src/qobj/boolean_functions.jl
+++ b/src/qobj/boolean_functions.jl
@@ -3,6 +3,7 @@ All boolean functions for checking the data or type in `QuantumObject`
 =#
 
 export isket, isbra, isoper, isoperbra, isoperket, issuper
+export isunitary
 
 @doc raw"""
     isbra(A::QuantumObject)
@@ -70,3 +71,13 @@ LinearAlgebra.issymmetric(A::QuantumObject{<:AbstractArray{T}}) where {T} = issy
 Test whether the [`QuantumObject`](@ref) is positive definite (and Hermitian) by trying to perform a Cholesky factorization of `A`.
 """
 LinearAlgebra.isposdef(A::QuantumObject{<:AbstractArray{T}}) where {T} = isposdef(A.data)
+
+@doc raw"""
+    isunitary(U::QuantumObject; kwargs...)
+
+Test whether the [`QuantumObject`](@ref) ``U`` is unitary operator. This function calls `Base.isapprox` to test whether ``U U^\dagger`` is approximately equal to identity operator.
+
+Note that all the keyword arguments will be passed to `Base.isapprox`.
+"""
+isunitary(U::QuantumObject{<:AbstractArray{T}}; kwargs...) where {T} =
+    isoper(U) ? isapprox(U.data * U.data', I(size(U, 1)); kwargs...) : false

--- a/src/qobj/operators.jl
+++ b/src/qobj/operators.jl
@@ -43,7 +43,7 @@ function rand_unitary(dimensions::Vector{Int}, ::Val{:haar})
     # Because inv(Λ) ⋅ R has real and strictly positive elements, Q · Λ is therefore Haar distributed.
     Λ = diag(R) # take the diagonal elements of R
     Λ ./= abs.(Λ) # rescaling the elements
-    return QuantumObject(Q * Diagonal(Λ); type = Operator, dims = dimensions)
+    return QuantumObject(dense_to_sparse(Q * Diagonal(Λ)); type = Operator, dims = dimensions)
 end
 function rand_unitary(dimensions::Vector{Int}, ::Val{:exp})
     N = prod(dimensions)

--- a/test/quantum_objects.jl
+++ b/test/quantum_objects.jl
@@ -73,12 +73,14 @@
         @test issuper(a2) == false
         @test isoperket(a2) == false
         @test isoperbra(a2) == false
+        @test isunitary(a2) == false
         @test isket(a3) == true
         @test isbra(a3) == false
         @test isoper(a3) == false
         @test issuper(a3) == false
         @test isoperket(a3) == false
         @test isoperbra(a3) == false
+        @test isunitary(a3) == false
         @test Qobj(a3) == a3
         @test !(Qobj(a3) === a3)
     end
@@ -100,6 +102,7 @@
         @test issuper(a3) == true
         @test isoperket(a3) == false
         @test isoperbra(a3) == false
+        @test isunitary(a3) == false
         @test_throws DimensionMismatch Qobj(a, dims = [2])
     end
 
@@ -117,12 +120,14 @@
         @test issuper(ρ_ket) == false
         @test isoperket(ρ_ket) == true
         @test isoperbra(ρ_ket) == false
+        @test isunitary(ρ_ket) == false
         @test isket(ρ_bra) == false
         @test isbra(ρ_bra) == false
         @test isoper(ρ_bra) == false
         @test issuper(ρ_bra) == false
         @test isoperket(ρ_bra) == false
         @test isoperbra(ρ_bra) == true
+        @test isunitary(ρ_bra) == false
         @test ρ_bra.dims == [2]
         @test ρ_ket.dims == [2]
         @test H * ρ ≈ spre(H) * ρ

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -189,16 +189,35 @@
         @test ψx ≈ F_3_3' * ψk
     end
 
+    @testset "random unitary" begin
+        U1 = rand_unitary(20)
+        U2 = rand_unitary(20, :exp)
+        U3 = rand_unitary([5, 5])
+        U4 = rand_unitary([5, 5], :exp)
+        @test isunitary(U1)
+        @test isunitary(U2)
+        @test isunitary(U3)
+        @test isunitary(U4)
+        @test U1.dims == U2.dims == [20]
+        @test U3.dims == U4.dims == [5, 5]
+    end
+
     @testset "Spin-j operators" begin
         # Pauli matrices and general Spin-j operators
         J0 = Qobj(spdiagm(0 => [0.0im]))
         Jx, Jy, Jz = spin_J_set(0.5)
+        Sx = sigmax()
+        Sy = sigmay()
+        Sz = sigmaz()
         @test spin_Jx(0) == spin_Jy(0) == spin_Jz(0) == spin_Jp(0) == spin_Jm(0) == J0
-        @test sigmax() ≈ 2 * spin_Jx(0.5) ≈ 2 * Jx ≈ Qobj(sparse([0.0im 1; 1 0]))
-        @test sigmay() ≈ 2 * spin_Jy(0.5) ≈ 2 * Jy ≈ Qobj(sparse([0.0im -1im; 1im 0]))
-        @test sigmaz() ≈ 2 * spin_Jz(0.5) ≈ 2 * Jz ≈ Qobj(sparse([1 0.0im; 0 -1]))
+        @test Sx ≈ 2 * spin_Jx(0.5) ≈ 2 * Jx ≈ Qobj(sparse([0.0im 1; 1 0]))
+        @test Sy ≈ 2 * spin_Jy(0.5) ≈ 2 * Jy ≈ Qobj(sparse([0.0im -1im; 1im 0]))
+        @test Sz ≈ 2 * spin_Jz(0.5) ≈ 2 * Jz ≈ Qobj(sparse([1 0.0im; 0 -1]))
         @test sigmap() ≈ spin_Jp(0.5) ≈ Qobj(sparse([0.0im 1; 0 0]))
         @test sigmam() ≈ spin_Jm(0.5) ≈ Qobj(sparse([0.0im 0; 1 0]))
+        @test isunitary(Sx)
+        @test isunitary(Sy)
+        @test isunitary(Sz)
         for which in [:x, :y, :z, :+, :-]
             @test jmat(2.5, which).dims == [6] # 2.5 * 2 + 1 = 6
 
@@ -290,6 +309,10 @@
         I_op2 = qeye(4, dims = [2, 2])
         I_su1 = qeye(4, type = SuperOperator)
         I_su2 = qeye(4, type = SuperOperator, dims = [2])
+        @test isunitary(I_op1) == true
+        @test isunitary(I_op2) == true
+        @test isunitary(I_su1) == false
+        @test isunitary(I_su2) == false
         @test I_op1.data == I_op2.data == I_su1.data == I_su2.data
         @test (I_op1 == I_op2) == false
         @test (I_op1 == I_su1) == false

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -200,6 +200,8 @@
         @test isunitary(U4)
         @test U1.dims == U2.dims == [20]
         @test U3.dims == U4.dims == [5, 5]
+        @inferred QuantumObject{Matrix{ComplexF64},OperatorQuantumObject} rand_unitary(10, :haar)
+        @inferred QuantumObject{Matrix{ComplexF64},OperatorQuantumObject} rand_unitary(10, :exp)
         @test_throws ArgumentError rand_unitary(20, :wrong)
     end
 

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -200,9 +200,12 @@
         @test isunitary(U4)
         @test U1.dims == U2.dims == [20]
         @test U3.dims == U4.dims == [5, 5]
-        @inferred QuantumObject{Matrix{ComplexF64},OperatorQuantumObject} rand_unitary(10, :haar)
-        @inferred QuantumObject{Matrix{ComplexF64},OperatorQuantumObject} rand_unitary(10, :exp)
+        
         @test_throws ArgumentError rand_unitary(20, :wrong)
+        @testset "Type Inference" begin
+            @inferred rand_unitary(10, :haar)
+            @inferred rand_unitary(10, :exp)
+        end
     end
 
     @testset "Spin-j operators" begin

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -200,6 +200,7 @@
         @test isunitary(U4)
         @test U1.dims == U2.dims == [20]
         @test U3.dims == U4.dims == [5, 5]
+        @test_throws ArgumentError rand_unitary(20, :wrong)
     end
 
     @testset "Spin-j operators" begin

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -200,7 +200,7 @@
         @test isunitary(U4)
         @test U1.dims == U2.dims == [20]
         @test U3.dims == U4.dims == [5, 5]
-        
+
         @test_throws ArgumentError rand_unitary(20, :wrong)
         @testset "Type Inference" begin
             @inferred rand_unitary(10, :haar)


### PR DESCRIPTION
This PR introduces two functions which are the same ones in `qutip`:
- `rand_unitary`: Returns a random unitary with two different provided methods.
- `isunitary`: Test whether a `Qobj` $$U$$ is unitary operator. This function calls `Base.isapprox` to test whether $$U U^\dagger$$ is approximately equal to identity operator.