### PR TITLE
Fix hermitian check for `expect`

### DIFF
--- a/src/qobj/functions.jl
+++ b/src/qobj/functions.jl
@@ -58,7 +58,8 @@ function expect(
     O::QuantumObject{<:AbstractArray{T1},OperatorQuantumObject},
     ρ::QuantumObject{<:AbstractArray{T2},OperatorQuantumObject},
 ) where {T1,T2}
-    return ishermitian(O) ? real(tr(O * ρ)) : tr(O * ρ)
+    A = O * ρ
+    return ishermitian(A) ? real(tr(A)) : tr(A)
 end
 
 @doc raw"""


### PR DESCRIPTION
## Description
For the current method, if one calls
```julia
O   # Operator
rho # Operator
expect(O, rho)
```
It will automatically take the real value after `tr` when depend on whether `O` is hermitian or not.
But the condition of taking the real value should depend on whether `O * rho` is hermitian or not.