### PR TITLE
Avoid scalar indexing in runtests and fix buildkite pipeline

### DIFF
--- a/.buildkite/CUDA_Ext.yml
+++ b/.buildkite/CUDA_Ext.yml
@@ -7,21 +7,21 @@ steps:
           #- "1"    # latest
     plugins:
       - JuliaCI/julia#v1:
-        version: "{{matrix.version}}"
+          version: "{{matrix.version}}"
       - JuliaCI/julia-test#v1:
-        test_args: "--quickfail"
+          test_args: "--quickfail"
       - JuliaCI/julia-coverage#v1:
-        codecov: true
-        dirs:
-          - src
-          - ext
+          codecov: true
+          dirs:
+            - src
+            - ext
     agents:
       queue: "juliagpu"
       cuda: "*"
-    timeout_in_minutes: 60
     env:
       GROUP: "CUDA_Ext"
       SECRET_CODECOV_TOKEN: "ZfhQu/IcRLqNyZ//ZNs5sjBPaV76IHfU5gui52Qn+Rp8tOurukqgScuyDt+3HQ4R0hJYBw1/Nqg6jmBsvWSc9NEUx8kGsUJFHfN3no0+b+PFxA8oJkWc9EpyIsjht5ZIjlsFWR3f0DpPqMEle/QyWOPcal63CChXR8oAoR+Fz1Bh8GkokLlnC8F9Ugp9xBlu401GCbyZhvLTZnNIgK5yy9q8HBJnBg1cPOhI81J6JvYpEmcIofEzFV/qkfpTUPclu43WNoFX2DZPzbxilf3fsAd5/+nRkRfkNML8KiN4mnmjHxPPbuY8F5zC/PS5ybXtDpfvaMQc01WApXCkZk0ZAQ==;U2FsdGVkX1+eDT7dqCME5+Ox5i8GvWRTQbwiP/VYjapThDbxXFDeSSIC6Opmon+M8go22Bun3bat6Fzie65ang=="
+    timeout_in_minutes: 60
     if: | 
         // Don't run Buildkite if the commit message includes the text [skip ci], [ci skip], or [no ci]
         // Don't run Buildkite for PR draft

--- a/.buildkite/CUDA_Ext.yml
+++ b/.buildkite/CUDA_Ext.yml
@@ -1,0 +1,33 @@
+steps:
+  - label: "CUDA Julia {{matrix.version}}"
+    matrix:
+      setup:
+        version:
+          - "1.10" # oldest
+          #- "1"    # latest
+    plugins:
+      - JuliaCI/julia#v1:
+        version: "{{matrix.version}}"
+      - JuliaCI/julia-test#v1:
+        test_args: "--quickfail"
+      - JuliaCI/julia-coverage#v1:
+        codecov: true
+        dirs:
+          - src
+          - ext
+    agents:
+      queue: "juliagpu"
+      cuda: "*"
+    timeout_in_minutes: 60
+    env:
+      GROUP: "CUDA_Ext"
+      SECRET_CODECOV_TOKEN: "ZfhQu/IcRLqNyZ//ZNs5sjBPaV76IHfU5gui52Qn+Rp8tOurukqgScuyDt+3HQ4R0hJYBw1/Nqg6jmBsvWSc9NEUx8kGsUJFHfN3no0+b+PFxA8oJkWc9EpyIsjht5ZIjlsFWR3f0DpPqMEle/QyWOPcal63CChXR8oAoR+Fz1Bh8GkokLlnC8F9Ugp9xBlu401GCbyZhvLTZnNIgK5yy9q8HBJnBg1cPOhI81J6JvYpEmcIofEzFV/qkfpTUPclu43WNoFX2DZPzbxilf3fsAd5/+nRkRfkNML8KiN4mnmjHxPPbuY8F5zC/PS5ybXtDpfvaMQc01WApXCkZk0ZAQ==;U2FsdGVkX1+eDT7dqCME5+Ox5i8GvWRTQbwiP/VYjapThDbxXFDeSSIC6Opmon+M8go22Bun3bat6Fzie65ang=="
+    if: | 
+        // Don't run Buildkite if the commit message includes the text [skip ci], [ci skip], or [no ci]
+        // Don't run Buildkite for PR draft
+        // Only run Buildkite when new commits and PR are made to main branch
+        build.message !~ /\[skip ci\]/ &&
+        build.message !~ /\[ci skip\]/ &&
+        build.message !~ /\[no ci\]/ &&
+        !build.pull_request.draft         &&
+        (build.branch =~ /main/ || build.pull_request.base_branch =~ /main/)

--- a/.buildkite/CUDA_Ext.yml
+++ b/.buildkite/CUDA_Ext.yml
@@ -28,6 +28,6 @@ steps:
         // Only run Buildkite when new commits and PR are made to main branch
         build.message !~ /\[skip ci\]/ &&
         build.message !~ /\[ci skip\]/ &&
-        build.message !~ /\[no ci\]/ &&
-        !build.pull_request.draft         &&
+        build.message !~ /\[no ci\]/   &&
+        !build.pull_request.draft      &&
         (build.branch =~ /main/ || build.pull_request.base_branch =~ /main/)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,13 +3,13 @@ steps:
   - label: ":runner: Dynamically launch pipelines"
     plugins:
       - staticfloat/forerunner:
-        watch:
-          - ".buildkite/pipeline.yml"
-          - ".buildkite/CUDA_Ext.yml"
-          - "src/**"
-          - "ext/QuantumToolboxCUDAExt.jl"
-          - "test/runtests.jl"
-          - "Project.toml"
-        target: ".buildkite/CUDA_Ext.yml"
+          watch:
+            - ".buildkite/pipeline.yml"
+            - ".buildkite/CUDA_Ext.yml"
+            - "src/**"
+            - "ext/QuantumToolboxCUDAExt.jl"
+            - "test/runtests.jl"
+            - "Project.toml"
+          target: ".buildkite/CUDA_Ext.yml"
     agents:
       queue: "juliagpu"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,25 +1,15 @@
+# see: https://github.com/staticfloat/forerunner-buildkite-plugin
 steps:
-  - label: "QuantumToolboxCUDAExt"
+  - label: ":runner: Dynamically launch pipelines"
     plugins:
-      - JuliaCI/julia#v1:
-          version: "1"
-      - JuliaCI/julia-test#v1:
-          test_args: "--quickfail"
-      - JuliaCI/julia-coverage#v1:
-          dirs:
-            - src
-            - ext
+      - staticfloat/forerunner:
+        watch:
+          - ".buildkite/pipeline.yml"
+          - ".buildkite/CUDA_Ext.yml"
+          - "src/**"
+          - "ext/QuantumToolboxCUDAExt.jl"
+          - "test/runtests.jl"
+          - "Project.toml"
+        target: ".buildkite/CUDA_Ext.yml"
     agents:
       queue: "juliagpu"
-      cuda: "*"
-    env:
-      GROUP: "CUDA_Ext"
-      SECRET_CODECOV_TOKEN: "ZfhQu/IcRLqNyZ//ZNs5sjBPaV76IHfU5gui52Qn+Rp8tOurukqgScuyDt+3HQ4R0hJYBw1/Nqg6jmBsvWSc9NEUx8kGsUJFHfN3no0+b+PFxA8oJkWc9EpyIsjht5ZIjlsFWR3f0DpPqMEle/QyWOPcal63CChXR8oAoR+Fz1Bh8GkokLlnC8F9Ugp9xBlu401GCbyZhvLTZnNIgK5yy9q8HBJnBg1cPOhI81J6JvYpEmcIofEzFV/qkfpTUPclu43WNoFX2DZPzbxilf3fsAd5/+nRkRfkNML8KiN4mnmjHxPPbuY8F5zC/PS5ybXtDpfvaMQc01WApXCkZk0ZAQ==;U2FsdGVkX1+eDT7dqCME5+Ox5i8GvWRTQbwiP/VYjapThDbxXFDeSSIC6Opmon+M8go22Bun3bat6Fzie65ang=="
-    timeout_in_minutes: 60
-    if: | 
-        // Don't run Buildkite if the commit message includes the text [skip tests]
-        // Don't run Buildkite for PR draft
-        // Only run Buildkite when new commits and PR are made to main branch
-        build.message !~ /\[skip tests\]/ &&
-        !build.pull_request.draft         &&
-        (build.branch =~ /main/ || build.pull_request.base_branch =~ /main/)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,7 @@ steps:
             - "src/**"
             - "ext/QuantumToolboxCUDAExt.jl"
             - "test/runtests.jl"
+            - "test/cuda_ext.jl"
             - "Project.toml"
           target: ".buildkite/CUDA_Ext.yml"
     agents:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -103,6 +103,7 @@ We can easily pass the computation to the GPU, by simply passing all the `Qobj`s
 ```julia
 using QuantumToolbox
 using CUDA
+CUDA.allowscalar(false) # Avoid unexpected scalar indexing
 
 a_gpu = cu(destroy(N)) # The only difference in the code is the cu() function
 

--- a/docs/src/users_guide/extensions/cuda.md
+++ b/docs/src/users_guide/extensions/cuda.md
@@ -13,6 +13,7 @@ This extension will be automatically loaded if user imports both `QuantumToolbox
 using QuantumToolbox
 using CUDA
 using CUDA.CUSPARSE
+CUDA.allowscalar(false) # Avoid unexpected scalar indexing
 ```
 
 We wrapped several functions in `CUDA` and `CUDA.CUSPARSE` in order to not only converting `QuantumObject.data` into GPU arrays, but also changing the element type and word size (`32` and `64`) since some of the GPUs perform better in `32`-bit. The functions are listed as follows (where input `A` is a [`QuantumObject`](@ref)):

--- a/test/cuda_ext.jl
+++ b/test/cuda_ext.jl
@@ -1,5 +1,6 @@
 using CUDA
 using CUDA.CUSPARSE
+CUDA.allowscalar(false) # Avoid unexpected scalar indexing
 
 QuantumToolbox.about()
 CUDA.versioninfo()


### PR DESCRIPTION
As title.

Now, the buildkite pipeline will be triggered dynamically depending on the settings in `.buildkite/pipeline.yml` with the buildkite plugin called `forerunner-buildkite-plugin`.

After this PR, it will trigger `.buildkite/CUDA_Ext.yml` only if the following files/paths has been changed:
- `.buildkite/pipeline.yml`
- `.buildkite/CUDA_Ext.yml`
- `src/**`
- `ext/QuantumToolboxCUDAExt.jl`
- `test/runtests.jl`
- `test/cuda_ext.jl`
- `Project.toml`

In order to re-trigger all CI-pipelines again, I add the following code into the runtests and also documentation:
```julia
CUDA.allowscalar(false) # Avoid unexpected scalar indexing
```