### PR TITLE
Add `\hat` to docs and make `fcreate`, `fdestroy` compat with `qutip`

### DIFF
--- a/docs/src/users_guide/states_and_operators.md
+++ b/docs/src/users_guide/states_and_operators.md
@@ -20,7 +20,7 @@ and then create a lowering operator ``\hat{a}`` corresponding to `5` number stat
 a = destroy(5)
 ```
 
-Now lets apply the lowering operator `a` to our vacuum state `vac`:
+Now lets apply the lowering operator `\hat{a}` to our vacuum state `vac`:
 
 ```@example states_and_operators
 a * vac
@@ -51,7 +51,7 @@ or just taking the square of the raising operator ``\left(\hat{a}^\dagger\right)
 ad^2 * vac
 ```
 
-Applying the raising operator twice gives the expected ``\sqrt{n+1}`` dependence. We can use the product of ``a^\dagger a`` to also apply the number operator to the state vector `vac`:
+Applying the raising operator twice gives the expected ``\sqrt{n+1}`` dependence. We can use the product of ``\hat{a}^\dagger \hat{a}`` to also apply the number operator to the state vector `vac`:
 
 ```@example states_and_operators
 ad * a * vac
@@ -69,7 +69,7 @@ or on the ``|2\rangle`` state:
 ad * a * (ad^2 * vac)
 ```
 
-Notice how in this last example, application of the number operator does not give the expected value ``n=2``, but rather ``2\sqrt{2}``. This is because this last state is not normalized to unity as ``a^\dagger|n\rangle=\sqrt{n+1}|n+1\rangle``. Therefore, we should [`normalize`](@ref) (or use [`unit`](@ref)) our vector first:
+Notice how in this last example, application of the number operator does not give the expected value ``n=2``, but rather ``2\sqrt{2}``. This is because this last state is not normalized to unity as ``\hat{a}^\dagger|n\rangle=\sqrt{n+1}|n+1\rangle``. Therefore, we should [`normalize`](@ref) (or use [`unit`](@ref)) our vector first:
 
 ```@example states_and_operators
 ad * a * normalize(ad^2 * vac)
@@ -204,13 +204,13 @@ At this stage, there is no difference. This should not be surprising as we calle
 create(2) * vac
 ```
 
-For a spin system, the operator analogous to the raising operator is the ``\sigma_+`` operator [`sigmap`](@ref). Applying on the spin state gives:
+For a spin system, the operator analogous to the raising operator is the ``\hat{\sigma}_+`` operator [`sigmap`](@ref). Applying on the spin state gives:
 
 ```@example states_and_operators
 sigmap() * spin
 ```
 
-Now we see the difference! The [`sigmap`](@ref) operator acting on the spin state returns the zero vector. Why is this? To see what happened, let us use the [`sigmaz`](@ref) operator:
+Now we see the difference! The [`sigmap`](@ref) operator acting on the spin state returns the zero vector. Why is this? To see what happened, let us use the ``\hat{\sigma}_z`` ([`sigmaz`](@ref)) operator:
 
 ```@example states_and_operators
 sigmaz()
@@ -228,7 +228,7 @@ spin2 = basis(2, 1)
 sigmaz() * spin2
 ```
 
-The answer is now apparent. Since the `QuantumToolbox` [`sigmaz`](@ref) function uses the standard ``Z``-basis representation of the ``\sigma_z`` spin operator, the `spin` state corresponds to the ``|\uparrow\rangle`` state of a two-level spin system while `spin2` gives the ``|\downarrow\rangle`` state. Therefore, in our previous example `sigmap() * spin`, we raised the qubit state out of the truncated two-level Hilbert space resulting in the zero state.
+The answer is now apparent. Since the `QuantumToolbox` [`sigmaz`](@ref) function uses the standard ``Z``-basis representation of the ``\hat{\sigma}_z`` spin operator, the `spin` state corresponds to the ``|\uparrow\rangle`` state of a two-level spin system while `spin2` gives the ``|\downarrow\rangle`` state. Therefore, in our previous example `sigmap() * spin`, we raised the qubit state out of the truncated two-level Hilbert space resulting in the zero state.
 
 While at first glance this convention might seem somewhat odd, it is in fact quite handy. For one, the spin operators remain in the conventional form. Second, this corresponds nicely with the quantum information definitions of qubit states, where the excited ``|\uparrow\rangle`` state is label as ``|0\rangle``, and the ``|\downarrow\rangle`` state by ``|1\rangle``.
 
@@ -309,9 +309,9 @@ This support is based on the correspondence between linear operators acting on a
 ```math
 \textrm{vec} : \mathcal{L}(\mathcal{H}) \rightarrow \mathcal{H}\otimes\mathcal{H}.
 ```
-Therefore, a given density matrix ``\rho`` can then be vectorized, denoted as 
+Therefore, a given density matrix ``\hat{\rho}`` can then be vectorized, denoted as 
 ```math
-|\rho\rangle\rangle = \textrm{vec}(\rho).
+|\hat{\rho}\rangle\rangle = \textrm{vec}(\hat{\rho}).
 ```
 
 `QuantumToolbox` uses the column-stacking convention for the isomorphism between ``\mathcal{L}(\mathcal{H})`` and ``\mathcal{H}\otimes\mathcal{H}``. This isomorphism is implemented by the functions [`mat2vec`](@ref) and [`vec2mat`](@ref):
@@ -328,7 +328,7 @@ vec_rho = mat2vec(rho)
 rho2 = vec2mat(vec_rho)
 ```
 
-The `QuantumObject.type` attribute indicates whether a quantum object is a vector corresponding to an [`OperatorKet`](@ref), or its Hermitian conjugate [`OperatorBra`](@ref). One can also use [`isoperket`](@ref) and [`isoperbra`](@ref) to check the type:
+The `QuantumObject.type` attribute indicates whether a quantum object is a vector corresponding to an [`OperatorKet`](@ref), or its Hermitian conjugate [`OperatorBra`](@ref). One can also use [`isoper`](@ref), [`isoperket`](@ref), and [`isoperbra`](@ref) to check the type:
 
 ```@example states_and_operators
 println(isoper(vec_rho))
@@ -343,12 +343,12 @@ Because `Julia` is a column-oriented languages (like `Fortran` and `MATLAB`), in
 
 ```math
 \begin{align}
-A\rho~~~ &\rightarrow \textrm{spre}(A) * \textrm{vec}(\rho) = \mathbb{1}\otimes A ~ |\rho\rangle\rangle,\notag\\
-\rho B &\rightarrow \textrm{spost}(B) * \textrm{vec}(\rho) = B^T\otimes \mathbb{1} ~ |\rho\rangle\rangle,\notag\\
-A \rho B &\rightarrow \textrm{sprepost}(A,B) * \textrm{vec}(\rho) = B^T\otimes A ~ |\rho\rangle\rangle,\notag
+\hat{A}\hat{\rho}~~~ &\rightarrow \textrm{spre}(\hat{A}) * \textrm{vec}(\hat{\rho}) = \hat{\mathbb{1}}\otimes \hat{A} ~ |\hat{\rho}\rangle\rangle,\notag\\
+\hat{\rho} \hat{B} &\rightarrow \textrm{spost}(\hat{B}) * \textrm{vec}(\hat{\rho}) = \hat{B}^T\otimes \hat{\mathbb{1}} ~ |\hat{\rho}\rangle\rangle,\notag\\
+\hat{A} \hat{\rho} \hat{B} &\rightarrow \textrm{sprepost}(\hat{A},\hat{B}) * \textrm{vec}(\hat{\rho}) = \hat{B}^T\otimes \hat{A} ~ |\hat{\rho}\rangle\rangle,\notag
 \end{align}
 ```
-where ``\mathbb{1}`` represents the identity operator with Hilbert space dimension equal to ``\rho``.
+where ``\hat{\mathbb{1}}`` represents the identity operator with Hilbert space dimension equal to ``\hat{\rho}``.
 
 ```@example states_and_operators
 A = Qobj([1 2; 3 4])
@@ -375,10 +375,10 @@ println(isoper(S_AB))
 println(issuper(S_AB))
 ```
 
-With the above definitions, the following equality holds in `Julia`:
+With the above definitions, the following equalities hold in `Julia`:
 
 ```math
-\textrm{vec}(A \rho B) = \textrm{spre}(A) * \textrm{spre}(B) * \textrm{vec}(\rho) = \textrm{sprepost}(A,B) * \textrm{vec}(\rho) ~~\forall~~A, B, \rho
+\textrm{vec}(\hat{A} \hat{\rho} \hat{B}) = \textrm{spre}(\hat{A}) * \textrm{spre}(\hat{B}) * \textrm{vec}(\hat{\rho}) = \textrm{sprepost}(\hat{A},\hat{B}) * \textrm{vec}(\hat{\rho}) ~~\forall~~\hat{A}, \hat{B}, \hat{\rho}
 ```
 
 ```@example states_and_operators

--- a/docs/src/users_guide/tensor.md
+++ b/docs/src/users_guide/tensor.md
@@ -43,13 +43,13 @@ tensor(states...)
 ```
 This state is slightly more complicated, describing two qubits in a superposition between the up and down states, while the third qubit is in its ground state.
 
-To construct operators that act on an extended Hilbert space of a combined system, we similarly pass a list of operators for each component system to the [`tensor`](@ref) (or [`kron`](@ref)) function. For example, to form the operator that represents the simultaneous action of the ``\sigma_x`` operator on two qubits:
+To construct operators that act on an extended Hilbert space of a combined system, we similarly pass a list of operators for each component system to the [`tensor`](@ref) (or [`kron`](@ref)) function. For example, to form the operator that represents the simultaneous action of the ``\hat{\sigma}_x`` operator on two qubits:
 
 ```@example tensor_products
 tensor(sigmax(), sigmax())
 ```
 
-To create operators in a combined Hilbert space that only act on a single component, we take the tensor product of the operator acting on the subspace of interest, with the identity operators corresponding to the components that are to be unchanged. For example, the operator that represents ``\sigma_z`` on the first qubit in a two-qubit system, while leaving the second qubit unaffected:
+To create operators in a combined Hilbert space that only act on a single component, we take the tensor product of the operator acting on the subspace of interest, with the identity operators corresponding to the components that are to be unchanged. For example, the operator that represents ``\hat{\sigma}_z`` on the first qubit in a two-qubit system, while leaving the second qubit unaffected:
 
 ```@example tensor_products
 tensor(sigmaz(), qeye(2))
@@ -61,7 +61,7 @@ The [`tensor`](@ref) (or [`kron`](@ref)) function is extensively used when const
 
 ### Two coupled qubits
 
-First, let’s consider a system of two coupled qubits. Assume that both the qubits have equal energy splitting, and that the qubits are coupled through a ``\sigma_x \otimes \sigma_x`` interaction with strength ``g = 0.05`` (in units where the bare qubit energy splitting is unity). The Hamiltonian describing this system is:
+First, let’s consider a system of two coupled qubits. Assume that both the qubits have equal energy splitting, and that the qubits are coupled through a ``\hat{\sigma}_x \otimes \hat{\sigma}_x`` interaction with strength ``g = 0.05`` (in units where the bare qubit energy splitting is unity). The Hamiltonian describing this system is:
 
 ```@example tensor_products
 H = tensor(sigmaz(), qeye(2)) + 
@@ -86,7 +86,7 @@ H = tensor(sigmaz(), qeye(2), qeye(2)) +
 The simplest possible quantum mechanical description for light-matter interaction is encapsulated in the Jaynes-Cummings model, which describes the coupling between a two-level atom and a single-mode electromagnetic field (a cavity mode). Denoting the energy splitting of the atom and cavity ``\omega_a`` and ``\omega_c``, respectively, and the atom-cavity interaction strength ``g``, the Jaynes-Cummings Hamiltonian can be constructed as:
 
 ```math
-H = \frac{\omega_a}{2}\sigma_z + \omega_c a^\dagger a + g (a^\dagger \sigma_- + a \sigma_+)
+H = \frac{\omega_a}{2}\hat{\sigma}_z + \omega_c \hat{a}^\dagger \hat{a} + g (\hat{a}^\dagger \hat{\sigma}_- + \hat{a} \hat{\sigma}_+)
 ```
 
 ```@example tensor_products

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -82,7 +82,7 @@ entanglement(QO::QuantumObject, sel::Int) = entanglement(QO, (sel,))
     tracedist(ρ::QuantumObject, σ::QuantumObject)
 
 Calculates the [trace distance](https://en.wikipedia.org/wiki/Trace_distance) between two [`QuantumObject`](@ref):
-``T(\rho, \sigma) = \frac{1}{2} \lVert \rho - \sigma \rVert_1``
+``T(\hat{\rho}, \hat{\sigma}) = \frac{1}{2} \lVert \hat{\rho} - \hat{\sigma} \rVert_1``
 
 Note that `ρ` and `σ` must be either [`Ket`](@ref) or [`Operator`](@ref).
 """
@@ -100,7 +100,7 @@ tracedist(
     fidelity(ρ::QuantumObject, σ::QuantumObject)
 
 Calculate the fidelity of two [`QuantumObject`](@ref):
-``F(\rho, \sigma) = \textrm{Tr} \sqrt{\sqrt{\rho} \sigma \sqrt{\rho}}``
+``F(\hat{\rho}, \hat{\sigma}) = \textrm{Tr} \sqrt{\sqrt{\hat{\rho}} \hat{\sigma} \sqrt{\hat{\rho}}}``
 
 Here, the definition is from Nielsen & Chuang, "Quantum Computation and Quantum Information". It is the square root of the fidelity defined in R. Jozsa, Journal of Modern Optics, 41:12, 2315 (1994).
 

--- a/src/negativity.jl
+++ b/src/negativity.jl
@@ -3,9 +3,9 @@ export negativity, partial_transpose
 @doc raw"""
     negativity(ρ::QuantumObject, subsys::Int; logarithmic::Bool=false)
 
-Compute the [negativity](https://en.wikipedia.org/wiki/Negativity_(quantum_mechanics)) ``N(\rho) = \frac{\Vert \rho^{\Gamma}\Vert_1 - 1}{2}``  
-where ``\rho^{\Gamma}`` is the partial transpose of ``\rho`` with respect to the subsystem,  
-and ``\Vert X \Vert_1=\textrm{Tr}\sqrt{X^\dagger X}`` is the trace norm.
+Compute the [negativity](https://en.wikipedia.org/wiki/Negativity_(quantum_mechanics)) ``N(\hat{\rho}) = \frac{\Vert \hat{\rho}^{\Gamma}\Vert_1 - 1}{2}``  
+where ``\hat{\rho}^{\Gamma}`` is the partial transpose of ``\hat{\rho}`` with respect to the subsystem,  
+and ``\Vert \hat{X} \Vert_1=\textrm{Tr}\sqrt{\hat{X}^\dagger \hat{X}}`` is the trace norm.
 
 # Arguments
 - `ρ::QuantumObject`: The density matrix (`ρ.type` must be [`OperatorQuantumObject`](@ref)).

--- a/src/qobj/arithmetic_and_attributes.jl
+++ b/src/qobj/arithmetic_and_attributes.jl
@@ -135,7 +135,7 @@ end
 @doc raw"""
     dot(i::QuantumObject, A::QuantumObject j::QuantumObject)
 
-Compute the generalized dot product `dot(i, A*j)` between three [`QuantumObject`](@ref): ``\langle i | A | j \rangle``
+Compute the generalized dot product `dot(i, A*j)` between three [`QuantumObject`](@ref): ``\langle i | \hat{A} | j \rangle``
 
 Supports the following inputs:
 - `A` is in the type of [`Operator`](@ref), with `i` and `j` are both [`Ket`](@ref).
@@ -638,7 +638,7 @@ get_data(A::QuantumObject) = A.data
 
 Get the coherence value ``\alpha`` by measuring the expectation value of the destruction operator ``\hat{a}`` on a state ``\ket{\psi}`` or a density matrix ``\hat{\rho}``.
 
-It returns both ``\alpha`` and the corresponding state with the coherence removed: ``\ket{\delta_\alpha} = \exp ( \bar{\alpha} \hat{a} - \alpha \hat{a}^\dagger ) \ket{\psi}`` for a pure state, and ``\hat{\rho_\alpha} = \exp ( \bar{\alpha} \hat{a} - \alpha \hat{a}^\dagger ) \hat{\rho} \exp ( -\bar{\alpha} \hat{a} + \alpha \hat{a}^\dagger )`` for a density matrix. These states correspond to the quantum fluctuations around the coherent state ``\ket{\alpha}`` or ``\dyad{\alpha}``.
+It returns both ``\alpha`` and the corresponding state with the coherence removed: ``\ket{\delta_\alpha} = \exp ( \alpha^* \hat{a} - \alpha \hat{a}^\dagger ) \ket{\psi}`` for a pure state, and ``\hat{\rho_\alpha} = \exp ( \alpha^* \hat{a} - \alpha \hat{a}^\dagger ) \hat{\rho} \exp ( -\bar{\alpha} \hat{a} + \alpha \hat{a}^\dagger )`` for a density matrix. These states correspond to the quantum fluctuations around the coherent state ``\ket{\alpha}`` or ``|\alpha\rangle\langle\alpha|``.
 """
 function get_coherence(ψ::QuantumObject{<:AbstractArray,KetQuantumObject})
     a = destroy(prod(ψ.dims))
@@ -665,7 +665,7 @@ Note that this method currently works for [`Ket`](@ref), [`Bra`](@ref), and [`Op
 
 # Examples
 
-If `order = [2, 1, 3]`, the Hilbert space structure will be re-arranged: H₁ ⊗ H₂ ⊗ H₃ → H₂ ⊗ H₁ ⊗ H₃.
+If `order = [2, 1, 3]`, the Hilbert space structure will be re-arranged: ``\mathcal{H}_1 \otimes \mathcal{H}_2 \otimes \mathcal{H}_3 \rightarrow \mathcal{H}_2 \otimes \mathcal{H}_1 \otimes \mathcal{H}_3``.
 
 ```
 julia> ψ1 = fock(2, 0)

--- a/src/qobj/operators.jl
+++ b/src/qobj/operators.jl
@@ -23,7 +23,7 @@ The `dimensions` can be either the following types:
 
 The `distribution` specifies which of the method used to obtain the unitary matrix:
 - `:haar`: Haar random unitary matrix using the algorithm from reference 1
-- `:exp`: Uses ``\exp(-iH)``, where ``H`` is a randomly generated Hermitian operator.
+- `:exp`: Uses ``\exp(-i\hat{H})``, where ``\hat{H}`` is a randomly generated Hermitian operator.
 
 # References
 1. [F. Mezzadri, How to generate random matrices from the classical compact groups, arXiv:math-ph/0609050 (2007)](https://arxiv.org/abs/math-ph/0609050)
@@ -68,8 +68,8 @@ rand_unitary(dimensions::Union{AbstractVector{Int},Tuple}, ::Val{T}) where {T} =
     commutator(A::QuantumObject, B::QuantumObject; anti::Bool=false)
 
 Return the commutator (or `anti`-commutator) of the two [`QuantumObject`](@ref):
-- commutator (`anti=false`): ``AB-BA``
-- anticommutator (`anti=true`): ``AB+BA``
+- commutator (`anti=false`): ``\hat{A}\hat{B}-\hat{B}\hat{A}``
+- anticommutator (`anti=true`): ``\hat{A}\hat{B}+\hat{B}\hat{A}``
 
 Note that `A` and `B` must be [`Operator`](@ref)
 """
@@ -233,13 +233,13 @@ end
 Generate higher-order Spin-`j` operators, where `j` is the spin quantum number and can be a non-negative integer or half-integer
 
 The parameter `which` specifies which of the following operator to return.
-- `:x`: ``S_x``
-- `:y`: ``S_y``
-- `:z`: ``S_z``
-- `:+`: ``S_+``
-- `:-`: ``S_-``
+- `:x`: ``\hat{S}_x``
+- `:y`: ``\hat{S}_y``
+- `:z`: ``\hat{S}_z``
+- `:+`: ``\hat{S}_+``
+- `:-`: ``\hat{S}_-``
 
-Note that if the parameter `which` is not specified, returns a set of Spin-`j` operators: ``(S_x, S_y, S_z)``
+Note that if the parameter `which` is not specified, returns a set of Spin-`j` operators: ``(\hat{S}_x, \hat{S}_y, \hat{S}_z)``
 
 # Examples
 ```
@@ -318,7 +318,7 @@ _jz(j::Real) = spdiagm(0 => Array{ComplexF64}(j .- (0:Int(2 * j))))
 @doc raw"""
     spin_Jx(j::Real)
 
-``S_x`` operator for Spin-`j`, where `j` is the spin quantum number and can be a non-negative integer or half-integer
+``\hat{S}_x`` operator for Spin-`j`, where `j` is the spin quantum number and can be a non-negative integer or half-integer.
 
 See also [`jmat`](@ref).
 """
@@ -327,7 +327,7 @@ spin_Jx(j::Real) = jmat(j, Val(:x))
 @doc raw"""
     spin_Jy(j::Real)
 
-``S_y`` operator for Spin-`j`, where `j` is the spin quantum number and can be a non-negative integer or half-integer
+``\hat{S}_y`` operator for Spin-`j`, where `j` is the spin quantum number and can be a non-negative integer or half-integer.
 
 See also [`jmat`](@ref).
 """
@@ -336,7 +336,7 @@ spin_Jy(j::Real) = jmat(j, Val(:y))
 @doc raw"""
     spin_Jz(j::Real)
 
-``S_z`` operator for Spin-`j`, where `j` is the spin quantum number and can be a non-negative integer or half-integer
+``\hat{S}_z`` operator for Spin-`j`, where `j` is the spin quantum number and can be a non-negative integer or half-integer.
 
 See also [`jmat`](@ref).
 """
@@ -345,7 +345,7 @@ spin_Jz(j::Real) = jmat(j, Val(:z))
 @doc raw"""
     spin_Jm(j::Real)
 
-``S_-`` operator for Spin-`j`, where `j` is the spin quantum number and can be a non-negative integer or half-integer
+``\hat{S}_-`` operator for Spin-`j`, where `j` is the spin quantum number and can be a non-negative integer or half-integer.
 
 See also [`jmat`](@ref).
 """
@@ -354,7 +354,7 @@ spin_Jm(j::Real) = jmat(j, Val(:-))
 @doc raw"""
     spin_Jp(j::Real)
 
-``S_+`` operator for Spin-`j`, where `j` is the spin quantum number and can be a non-negative integer or half-integer
+``\hat{S}_+`` operator for Spin-`j`, where `j` is the spin quantum number and can be a non-negative integer or half-integer.
 
 See also [`jmat`](@ref).
 """
@@ -363,7 +363,7 @@ spin_Jp(j::Real) = jmat(j, Val(:+))
 @doc raw"""
     spin_J_set(j::Real)
 
-A set of Spin-`j` operators ``(S_x, S_y, S_z)``, where `j` is the spin quantum number and can be a non-negative integer or half-integer
+A set of Spin-`j` operators ``(\hat{S}_x, \hat{S}_y, \hat{S}_z)``, where `j` is the spin quantum number and can be a non-negative integer or half-integer.
 
 Note that this functions is same as `jmat(j)`. See also [`jmat`](@ref).
 """
@@ -372,7 +372,7 @@ spin_J_set(j::Real) = jmat(j)
 @doc raw"""
     sigmap()
 
-Pauli ladder operator ``\hat{\sigma}_+ = \hat{\sigma}_x + i \hat{\sigma}_y``.
+Pauli ladder operator ``\hat{\sigma}_+ = (\hat{\sigma}_x + i \hat{\sigma}_y) / 2``.
 
 See also [`jmat`](@ref).
 """
@@ -381,7 +381,7 @@ sigmap() = jmat(0.5, Val(:+))
 @doc raw"""
     sigmam()
 
-Pauli ladder operator ``\hat{\sigma}_- = \hat{\sigma}_x - i \hat{\sigma}_y``.
+Pauli ladder operator ``\hat{\sigma}_- = (\hat{\sigma}_x - i \hat{\sigma}_y) / 2``.
 
 See also [`jmat`](@ref).
 """
@@ -437,15 +437,17 @@ Construct a fermionic destruction operator acting on the `j`-th site, where the 
 
 Here, we use the [Jordan-Wigner transformation](https://en.wikipedia.org/wiki/Jordan%E2%80%93Wigner_transformation), namely
 ```math
-d_j = \sigma_z^{\otimes j} \otimes \sigma_{-} \otimes I^{\otimes N-j-1}
+\hat{d}_j = \hat{\sigma}_z^{\otimes j-1} \otimes \hat{\sigma}_{+} \otimes \hat{\mathbb{1}}^{\otimes N-j}
 ```
 
-Note that the site index `j` should satisfy: `0 ≤ j ≤ N - 1`.
+The site index `j` should satisfy: `1 ≤ j ≤ N`.
+
+Note that we put ``\hat{\sigma}_{+} = \begin{pmatrix} 0 & 1 \\ 0 & 0 \end{pmatrix}`` here because we consider ``|0\rangle = \begin{pmatrix} 1 \\ 0 \end{pmatrix}`` to be ground (vacant) state, and ``|1\rangle = \begin{pmatrix} 0 \\ 1 \end{pmatrix}`` to be excited (occupied) state.
 
 !!! warning "Beware of type-stability!"
     If you want to keep type stability, it is recommended to use `fdestroy(Val(N), j)` instead of `fdestroy(N, j)`. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
 """
-fdestroy(N::Union{Int,Val}, j::Int) = _Jordan_Wigner(N, j, sigmam())
+fdestroy(N::Union{Int,Val}, j::Int) = _Jordan_Wigner(N, j, sigmap())
 
 @doc raw"""
     fcreate(N::Union{Int,Val}, j::Int)
@@ -454,27 +456,29 @@ Construct a fermionic creation operator acting on the `j`-th site, where the foc
 
 Here, we use the [Jordan-Wigner transformation](https://en.wikipedia.org/wiki/Jordan%E2%80%93Wigner_transformation), namely
 ```math
-d_j^\dagger = \sigma_z^{\otimes j} \otimes \sigma_{+} \otimes I^{\otimes N-j-1}
+\hat{d}^\dagger_j = \hat{\sigma}_z^{\otimes j-1} \otimes \hat{\sigma}_{-} \otimes \hat{\mathbb{1}}^{\otimes N-j}
 ```
 
-Note that the site index `j` should satisfy: `0 ≤ j ≤ N - 1`.
+The site index `j` should satisfy: `1 ≤ j ≤ N`.
+
+Note that we put ``\hat{\sigma}_{-} = \begin{pmatrix} 0 & 0 \\ 1 & 0 \end{pmatrix}`` here because we consider ``|0\rangle = \begin{pmatrix} 1 \\ 0 \end{pmatrix}`` to be ground (vacant) state, and ``|1\rangle = \begin{pmatrix} 0 \\ 1 \end{pmatrix}`` to be excited (occupied) state.
 
 !!! warning "Beware of type-stability!"
     If you want to keep type stability, it is recommended to use `fcreate(Val(N), j)` instead of `fcreate(N, j)`. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
 """
-fcreate(N::Union{Int,Val}, j::Int) = _Jordan_Wigner(N, j, sigmap())
+fcreate(N::Union{Int,Val}, j::Int) = _Jordan_Wigner(N, j, sigmam())
 
 _Jordan_Wigner(N::Int, j::Int, op::QuantumObject{<:AbstractArray{T},OperatorQuantumObject}) where {T} =
     _Jordan_Wigner(Val(N), j, op)
 
 function _Jordan_Wigner(::Val{N}, j::Int, op::QuantumObject{<:AbstractArray{T},OperatorQuantumObject}) where {N,T}
     (N < 1) && throw(ArgumentError("The total number of sites (N) cannot be less than 1"))
-    ((j >= N) || (j < 0)) && throw(ArgumentError("The site index (j) should satisfy: 0 ≤ j ≤ N - 1"))
+    ((j > N) || (j < 1)) && throw(ArgumentError("The site index (j) should satisfy: 1 ≤ j ≤ N"))
 
     σz = sigmaz().data
-    Z_tensor = kron(1, 1, fill(σz, j)...)
+    Z_tensor = kron(1, 1, fill(σz, j - 1)...)
 
-    S = 2^(N - j - 1)
+    S = 2^(N - j)
     I_tensor = sparse((1.0 + 0.0im) * LinearAlgebra.I, S, S)
 
     return QuantumObject(kron(Z_tensor, op.data, I_tensor); type = Operator, dims = ntuple(i -> 2, Val(N)))

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -190,7 +190,7 @@ end
 
 Generate the spin state: ``|j, m\rangle``
 
-The eigenstate of the Spin-`j` ``S_z`` operator with eigenvalue `m`, where where `j` is the spin quantum number and can be a non-negative integer or half-integer
+The eigenstate of the Spin-`j` ``\hat{S}_z`` operator with eigenvalue `m`, where where `j` is the spin quantum number and can be a non-negative integer or half-integer
 
 See also [`jmat`](@ref).
 """
@@ -213,14 +213,16 @@ end
 Generate the coherent spin state (rotation of the ``|j, j\rangle`` state), namely
 
 ```math
-|\theta, \phi \rangle = R(\theta, \phi) |j, j\rangle
+|\theta, \phi \rangle = \hat{R}(\theta, \phi) |j, j\rangle
 ```
 
 where the rotation operator is defined as
 
 ```math
-R(\theta, \phi) = \exp \left( \frac{\theta}{2} (S_- e^{i\phi} - S_+ e^{-i\phi}) \right)
+\hat{R}(\theta, \phi) = \exp \left( \frac{\theta}{2} (\hat{S}_- e^{i\phi} - \hat{S}_+ e^{-i\phi}) \right)
 ```
+
+and ``\hat{S}_\pm`` are plus and minus Spin-`j` operators, respectively.
 
 # Arguments
 - `j::Real`: The spin quantum number and can be a non-negative integer or half-integer

--- a/src/qobj/superoperators.jl
+++ b/src/qobj/superoperators.jl
@@ -59,7 +59,7 @@ Returns the [`SuperOperator`](@ref) form of `A` and `B` acting on the left and r
 Since the density matrix is vectorized in [`OperatorKet`](@ref) form: ``|\hat{\rho}\rangle\rangle``, this [`SuperOperator`](@ref) is always a matrix ``\hat{B}^T \otimes \hat{A}``, namely
 
 ```math
-\mathcal{O} \left(\hat{A}, \hat{B}\right) \left[ \hat{\rho} \right] = \hat{B}^T \otimes \hat{A} ~ |\hat{\rho}\rangle\rangle = \textrm{spre}(A) * \textrm{spost}(B) ~ |\hat{\rho}\rangle\rangle
+\mathcal{O} \left(\hat{A}, \hat{B}\right) \left[ \hat{\rho} \right] = \hat{B}^T \otimes \hat{A} ~ |\hat{\rho}\rangle\rangle = \textrm{spre}(\hat{A}) * \textrm{spost}(\hat{B}) ~ |\hat{\rho}\rangle\rangle
 ```
 (see the section in documentation: [Superoperators and Vectorized Operators](@ref doc:Superoperators-and-Vectorized-Operators) for more details)
 

--- a/src/qobj/synonyms.jl
+++ b/src/qobj/synonyms.jl
@@ -58,7 +58,7 @@ dag(A::QuantumObject{<:AbstractArray{T}}) where {T} = adjoint(A)
 @doc raw"""
     matrix_element(i::QuantumObject, A::QuantumObject j::QuantumObject)
 
-Compute the generalized dot product `dot(i, A*j)` between three [`QuantumObject`](@ref): ``\langle i | A | j \rangle``
+Compute the generalized dot product `dot(i, A*j)` between three [`QuantumObject`](@ref): ``\langle i | \hat{A} | j \rangle``
 
 Note that this function is same as `dot(i, A, j)`
 

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -58,13 +58,13 @@ Solve the stationary state based on time evolution (ordinary differential equati
 The termination condition of the stationary state ``|\rho\rangle\rangle`` is that either the following condition is `true`:
 
 ```math
-\lVert\frac{\partial |\rho\rangle\rangle}{\partial t}\rVert \leq \textrm{reltol} \times\lVert\frac{\partial |\rho\rangle\rangle}{\partial t}+|\rho\rangle\rangle\rVert
+\lVert\frac{\partial |\hat{\rho}\rangle\rangle}{\partial t}\rVert \leq \textrm{reltol} \times\lVert\frac{\partial |\hat{\rho}\rangle\rangle}{\partial t}+|\hat{\rho}\rangle\rangle\rVert
 ```
 
 or
 
 ```math
-\lVert\frac{\partial |\rho\rangle\rangle}{\partial t}\rVert \leq \textrm{abstol}
+\lVert\frac{\partial |\hat{\rho}\rangle\rangle}{\partial t}\rVert \leq \textrm{abstol}
 ```
 
 # Parameters

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -63,13 +63,13 @@ end
 Generates the ODEProblem for the master equation time evolution of an open quantum system:
 
 ```math
-\frac{\partial \rho(t)}{\partial t} = -i[\hat{H}, \rho(t)] + \sum_n \mathcal{D}(\hat{C}_n) [\rho(t)]
+\frac{\partial \hat{\rho}(t)}{\partial t} = -i[\hat{H}, \hat{\rho}(t)] + \sum_n \mathcal{D}(\hat{C}_n) [\hat{\rho}(t)]
 ```
 
 where 
 
 ```math
-\mathcal{D}(\hat{C}_n) [\rho(t)] = \hat{C}_n \rho(t) \hat{C}_n^\dagger - \frac{1}{2} \hat{C}_n^\dagger \hat{C}_n \rho(t) - \frac{1}{2} \rho(t) \hat{C}_n^\dagger \hat{C}_n
+\mathcal{D}(\hat{C}_n) [\hat{\rho}(t)] = \hat{C}_n \hat{\rho}(t) \hat{C}_n^\dagger - \frac{1}{2} \hat{C}_n^\dagger \hat{C}_n \hat{\rho}(t) - \frac{1}{2} \hat{\rho}(t) \hat{C}_n^\dagger \hat{C}_n
 ```
 
 # Arguments
@@ -176,13 +176,13 @@ end
 Time evolution of an open quantum system using Lindblad master equation:
 
 ```math
-\frac{\partial \rho(t)}{\partial t} = -i[\hat{H}, \rho(t)] + \sum_n \mathcal{D}(\hat{C}_n) [\rho(t)]
+\frac{\partial \hat{\rho}(t)}{\partial t} = -i[\hat{H}, \hat{\rho}(t)] + \sum_n \mathcal{D}(\hat{C}_n) [\hat{\rho}(t)]
 ```
 
 where 
 
 ```math
-\mathcal{D}(\hat{C}_n) [\rho(t)] = \hat{C}_n \rho(t) \hat{C}_n^\dagger - \frac{1}{2} \hat{C}_n^\dagger \hat{C}_n \rho(t) - \frac{1}{2} \rho(t) \hat{C}_n^\dagger \hat{C}_n
+\mathcal{D}(\hat{C}_n) [\hat{\rho}(t)] = \hat{C}_n \hat{\rho}(t) \hat{C}_n^\dagger - \frac{1}{2} \hat{C}_n^\dagger \hat{C}_n \hat{\rho}(t) - \frac{1}{2} \hat{\rho}(t) \hat{C}_n^\dagger \hat{C}_n
 ```
 
 # Arguments

--- a/test/states_and_operators.jl
+++ b/test/states_and_operators.jl
@@ -285,11 +285,11 @@
         dims = ntuple(i -> 2, Val(sites))
         Q_iden = Qobj(sparse((1.0 + 0.0im) * LinearAlgebra.I, SIZE, SIZE); dims = dims)
         Q_zero = Qobj(spzeros(ComplexF64, SIZE, SIZE); dims = dims)
-        for i in 0:(sites-1)
+        for i in 1:sites
             d_i = fdestroy(sites, i)
             @test d_i' ≈ fcreate(sites, i)
 
-            for j in 0:(sites-1)
+            for j in 1:sites
                 d_j = fdestroy(sites, j)
 
                 if i == j
@@ -301,9 +301,20 @@
                 @test commutator(d_i, d_j; anti = true) ≈ Q_zero
             end
         end
+        zero = zero_ket((2, 2))
+        vac = tensor(basis(2, 0), basis(2, 0))
+        d1 = sigmap() ⊗ qeye(2)
+        d2 = sigmaz() ⊗ sigmap()
+        @test d1 * vac == zero
+        @test d2 * vac == zero
+        @test d1' * vac == tensor(basis(2, 1), basis(2, 0))
+        @test d2' * vac == tensor(basis(2, 0), basis(2, 1))
+        @test d1' * d2' * vac == tensor(basis(2, 1), basis(2, 1))
+        @test d1' * d1' * d2' * vac == zero
+        @test d2' * d1' * d2' * vac == zero
         @test_throws ArgumentError fdestroy(0, 0)
-        @test_throws ArgumentError fdestroy(sites, -1)
-        @test_throws ArgumentError fdestroy(sites, sites)
+        @test_throws ArgumentError fdestroy(sites, 0)
+        @test_throws ArgumentError fdestroy(sites, sites + 1)
     end
 
     @testset "identity operator" begin


### PR DESCRIPTION
Summary of this PR:
- add `\hat{}` to all operators in docs
- modify `fcreate` and `fdestroy` to make them compatible with `qutip`