### PR TITLE
Introduce `Makefile` to make development more convenient

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,8 @@ Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have fin
 
 - [ ] Please read [Contributor Covenant Code of Conduct](https://github.com/qutip/QuantumToolbox.jl/blob/main/CODE_OF_CONDUCT.md)
 - [ ] Any code changes were done in a way that does not break public API
-- [ ] Appropriate tests were added.
-- [ ] Any code changes should be formatted by running: `julia -e 'using JuliaFormatter; format(".")'`
+- [ ] Appropriate tests were added and has been tested locally by running: `make test`.
+- [ ] Any code changes should be `julia` formatted by running: `make format`
 - [ ] All documentation (in `docs/` folder) related to code changes were updated.
 
 Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,9 +3,9 @@ Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have fin
 
 - [ ] Please read [Contributor Covenant Code of Conduct](https://github.com/qutip/QuantumToolbox.jl/blob/main/CODE_OF_CONDUCT.md)
 - [ ] Any code changes were done in a way that does not break public API
-- [ ] Appropriate tests were added and has been tested locally by running: `make test`.
-- [ ] Any code changes should be `julia` formatted by running: `make format`
-- [ ] All documentation (in `docs/` folder) related to code changes were updated.
+- [ ] Appropriate tests were added and tested locally by running: `make test`.
+- [ ] Any code changes should be `julia` formatted by running: `make format`.
+- [ ] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running `make docs`.
 
 Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.
 
@@ -13,6 +13,6 @@ Request for a review after you have completed all the tasks. If you have not fin
 Describe the proposed change here.
 
 ## Related issues or PRs
-Please mention the related issues or PRs here. If the PR fixes an issue, use the keyword close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved followed by the issue id, e.g. fix #1234
+Please mention the related issues or PRs here. If the PR fixes an issue, use the keyword close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved followed by the issue id, e.g. fix #[id]
 
 ## Additional context

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -45,6 +45,6 @@ jobs:
                 write(stdout, output)
                 write(stdout, "-----\n")
                 write(stdout, "Please format them by running the following command:\n")
-                write(stdout, "julia -e \"using JuliaFormatter; format(\\\".\\\")\"")
+                write(stdout, "make format")
                 exit(1)
             end'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+JULIA:=julia
+
+default: help
+
+docs:
+	${JULIA} --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+	${JULIA} --project=docs docs/make.jl
+
+format:
+	${JULIA} -e 'using JuliaFormatter; format(".")'
+
+test:
+	${JULIA} --project -e 'using Pkg; Pkg.resolve(); Pkg.test()'
+
+help:
+	@echo "The following make commands are available:"
+	@echo " - make docs: instantiate and build the documentation"
+	@echo " - make format: format codes with JuliaFormatter"
+	@echo " - make test: run the tests"
+
+.PHONY: default docs format test help

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,16 +3,25 @@
 ## Working Directory
 All the commands should be run under the root folder of the package: `/path/to/QuantumToolbox.jl/`
 
-## Build Pkg
+The document pages will be generated in the directory: `/path/to/QuantumToolbox.jl/docs/build/` (which is ignored by git).
+
+## Method 1: Run with `make` command
+Run the following command:
+```shell
+make docs
+```
+
+## Method 2: Run `julia` command manually
+
+### Build Pkg
 Run the following command:
 ```shell
 julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
 ```
 > **_NOTE:_** `Pkg.develop(PackageSpec(path=pwd()))` adds the local version of `QuantumToolbox` as dev-dependency instead of pulling from the registered version.
 
-## Build Documentation
+### Build Documentation
 Run the following command:
 ```shell
 julia --project=docs docs/make.jl
 ```
-The document pages will be generated in the directory: `/path/to/QuantumToolbox.jl/docs/build/` (which is ignored by git).


### PR DESCRIPTION
This PR introduces `Makefile` to support `make` commands.

In this way, we can simplify several commands during development:

For example:
```
make docs   # build documentation
make test   # run tests
make format # format files with JuliaFormatter
```