### PR TITLE
Fix incorrect `times` in time evolution solutions

### DIFF
--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -150,6 +150,7 @@ function mesolveProblem(
         e_ops = e_ops2,
         expvals = expvals,
         H_t = H_t,
+        times = t_l,
         is_empty_e_ops = is_empty_e_ops,
         params...,
     )
@@ -253,7 +254,7 @@ function mesolve(prob::ODEProblem, alg::OrdinaryDiffEqAlgorithm = Tsit5())
     ρt = map(ϕ -> QuantumObject(vec2mat(ϕ), type = Operator, dims = sol.prob.p.Hdims), sol.u)
 
     return TimeEvolutionSol(
-        sol.t,
+        sol.prob.p.times,
         ρt,
         sol.prob.p.expvals,
         sol.retcode,

--- a/src/time_evolution/sesolve.jl
+++ b/src/time_evolution/sesolve.jl
@@ -127,6 +127,7 @@ function sesolveProblem(
         progr = progr,
         Hdims = H.dims,
         H_t = H_t,
+        times = t_l,
         is_empty_e_ops = is_empty_e_ops,
         params...,
     )
@@ -215,7 +216,7 @@ function sesolve(prob::ODEProblem, alg::OrdinaryDiffEqAlgorithm = Tsit5())
     ψt = map(ϕ -> QuantumObject(ϕ, type = Ket, dims = sol.prob.p.Hdims), sol.u)
 
     return TimeEvolutionSol(
-        sol.t,
+        sol.prob.p.times,
         ψt,
         sol.prob.p.expvals,
         sol.retcode,

--- a/src/time_evolution/ssesolve.jl
+++ b/src/time_evolution/ssesolve.jl
@@ -180,6 +180,7 @@ function ssesolveProblem(
         progr = progr,
         Hdims = H.dims,
         H_t = H_t,
+        times = t_l,
         is_empty_e_ops = is_empty_e_ops,
         params...,
     )
@@ -404,7 +405,7 @@ function ssesolve(
 
     return TimeEvolutionSSESol(
         ntraj,
-        _sol_1.t,
+        _sol_1.prob.p.times,
         states,
         expvals,
         expvals_all,

--- a/src/time_evolution/time_evolution.jl
+++ b/src/time_evolution/time_evolution.jl
@@ -51,7 +51,7 @@ A structure storing the results and some information from solving quantum trajec
 # Fields (Attributes)
 
 - `ntraj::Int`: Number of trajectories
-- `times::AbstractVector`: The time list of the evolution in each trajectory.
+- `times::AbstractVector`: The time list of the evolution.
 - `states::Vector{Vector{QuantumObject}}`: The list of result states in each trajectory.
 - `expect::Matrix`: The expectation values (averaging all trajectories) corresponding to each time point in `times`.
 - `expect_all::Array`: The expectation values corresponding to each trajectory and each time point in `times`
@@ -63,7 +63,7 @@ A structure storing the results and some information from solving quantum trajec
 - `reltol::Real`: The relative tolerance which is used during the solving process.
 """
 struct TimeEvolutionMCSol{
-    TT<:Vector{<:Vector{<:Real}},
+    TT<:Vector{<:Real},
     TS<:AbstractVector,
     TE<:Matrix{ComplexF64},
     TEA<:Array{ComplexF64,3},
@@ -97,19 +97,22 @@ function Base.show(io::IO, sol::TimeEvolutionMCSol)
 end
 
 @doc raw"""
-     struct TimeEvolutionSSESol
- A structure storing the results and some information from solving trajectories of the Stochastic Shrodinger equation time evolution.
- # Fields (Attributes)
- - `ntraj::Int`: Number of trajectories
- - `times::AbstractVector`: The time list of the evolution in each trajectory.
- - `states::Vector{Vector{QuantumObject}}`: The list of result states in each trajectory.
- - `expect::Matrix`: The expectation values (averaging all trajectories) corresponding to each time point in `times`.
- - `expect_all::Array`: The expectation values corresponding to each trajectory and each time point in `times`
- - `converged::Bool`: Whether the solution is converged or not.
- - `alg`: The algorithm which is used during the solving process.
- - `abstol::Real`: The absolute tolerance which is used during the solving process.
- - `reltol::Real`: The relative tolerance which is used during the solving process.
- """
+    struct TimeEvolutionSSESol
+
+A structure storing the results and some information from solving trajectories of the Stochastic Shrodinger equation time evolution.
+
+# Fields (Attributes)
+
+- `ntraj::Int`: Number of trajectories
+- `times::AbstractVector`: The time list of the evolution.
+- `states::Vector{Vector{QuantumObject}}`: The list of result states in each trajectory.
+- `expect::Matrix`: The expectation values (averaging all trajectories) corresponding to each time point in `times`.
+- `expect_all::Array`: The expectation values corresponding to each trajectory and each time point in `times`
+- `converged::Bool`: Whether the solution is converged or not.
+- `alg`: The algorithm which is used during the solving process.
+- `abstol::Real`: The absolute tolerance which is used during the solving process.
+- `reltol::Real`: The relative tolerance which is used during the solving process.
+"""
 struct TimeEvolutionSSESol{
     TT<:Vector{<:Real},
     TS<:AbstractVector,

--- a/src/time_evolution/time_evolution_dynamical.jl
+++ b/src/time_evolution/time_evolution_dynamical.jl
@@ -248,7 +248,7 @@ function dfd_mesolve(
     )
 
     return TimeEvolutionSol(
-        sol.t,
+        sol.prob.p.times,
         ρt,
         sol.prob.p.expvals,
         sol.retcode,

--- a/test/core-test/time_evolution.jl
+++ b/test/core-test/time_evolution.jl
@@ -16,10 +16,13 @@
         sol3 = sesolve(H, psi0, t_l, e_ops = e_ops, saveat = t_l, progress_bar = Val(false))
         sol_string = sprint((t, s) -> show(t, "text/plain", s), sol)
         @test sum(abs.(sol.expect[1, :] .- sin.(η * t_l) .^ 2)) / length(t_l) < 0.1
+        @test length(sol.times) == length(t_l)
         @test length(sol.states) == 1
         @test size(sol.expect) == (length(e_ops), length(t_l))
+        @test length(sol2.times) == length(t_l)
         @test length(sol2.states) == length(t_l)
         @test size(sol2.expect) == (0, length(t_l))
+        @test length(sol3.times) == length(t_l)
         @test length(sol3.states) == length(t_l)
         @test size(sol3.expect) == (length(e_ops), length(t_l))
         @test sol_string ==
@@ -68,12 +71,21 @@
         @test sum(abs.(sol_mc.expect .- sol_me.expect)) / length(t_l) < 0.1
         @test sum(abs.(vec(expect_mc_states_mean) .- vec(sol_me.expect))) / length(t_l) < 0.1
         @test sum(abs.(sol_sse.expect .- sol_me.expect)) / length(t_l) < 0.1
+        @test length(sol_me.times) == length(t_l)
         @test length(sol_me.states) == 1
         @test size(sol_me.expect) == (length(e_ops), length(t_l))
+        @test length(sol_me2.times) == length(t_l)
         @test length(sol_me2.states) == length(t_l)
         @test size(sol_me2.expect) == (0, length(t_l))
+        @test length(sol_me3.times) == length(t_l)
         @test length(sol_me3.states) == length(t_l)
         @test size(sol_me3.expect) == (length(e_ops), length(t_l))
+        @test length(sol_mc.times) == length(t_l)
+        @test size(sol_mc.expect) == (length(e_ops), length(t_l))
+        @test length(sol_mc_states.times) == length(t_l)
+        @test size(sol_mc_states.expect) == (0, length(t_l))
+        @test length(sol_sse.times) == length(t_l)
+        @test size(sol_sse.expect) == (length(e_ops), length(t_l))
         @test sol_me_string ==
               "Solution of time evolution\n" *
               "(return code: $(sol_me.retcode))\n" *


### PR DESCRIPTION
## Description
The current `times` of different time evolution solutions are basically obtained from `sol.t`.
However, the length of `sol.t` actually depends on the keyword argument `saveat`.

To make it consistent with the docstrings, and also align with `QuTiP`, I put `t_l` into `p = (..., times = t_l, ...)`, and then pass it to different time evolution solutions with `sol.prob.p.times`.

After this PR, the type of `sol.times` are all the same as `Vector{<:Real}` for different time evolution solutions, and the length should be equal to the input `tlist`.