### PR TITLE
Introduce \`convert_unit\`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -239,6 +239,7 @@ QuantumToolbox.versioninfo
 QuantumToolbox.about
 gaussian
 n_thermal
+convert_unit
 row_major_reshape
 meshgrid
 _calculate_expectation!

--- a/test/core-test/utilities.jl
+++ b/test/core-test/utilities.jl
@@ -1,0 +1,45 @@
+@testset "Utilities" verbose = true begin
+    @testset "n_thermal" begin
+        ω1 = rand(Float64)
+        ω2 = rand(Float64)
+        @test n_thermal(0, ω2) == 0.0
+        @test n_thermal(ω1, 0) == 0.0
+        @test n_thermal(ω1, -ω2) == 0.0
+        @test n_thermal(ω1, ω2) == 1 / (exp(ω1 / ω2) - 1)
+        @test typeof(n_thermal(Int32(2), Int32(3))) == Float32
+        @test typeof(n_thermal(Float32(2), Float32(3))) == Float32
+        @test typeof(n_thermal(Int64(2), Int32(3))) == Float64
+        @test typeof(n_thermal(Int32(2), Int64(3))) == Float64
+        @test typeof(n_thermal(Float64(2), Float32(3))) == Float64
+        @test typeof(n_thermal(Float32(2), Float64(3))) == Float64
+    end
+
+    @testset "convert unit" begin
+        V = 100 * rand(Float64)
+        _unit_list = [:J, :eV, :meV, :GHz, :mK]
+        for origin in _unit_list
+            for middle in _unit_list
+                for target in _unit_list
+                    V_middle = convert_unit(V, origin, middle)
+                    V_target = convert_unit(V_middle, middle, target)
+                    V_origin = convert_unit(V_target, target, origin)
+                    @test V ≈ V_origin
+                end
+            end
+        end
+        @test_throws ArgumentError convert_unit(V, :bad_unit, :J)
+        @test_throws ArgumentError convert_unit(V, :J, :bad_unit)
+    end
+
+    @testset "Type Inference" begin
+        v1 = rand(Float64)
+        @inferred n_thermal(v1, Int32(123))
+
+        _unit_list = [:J, :eV, :meV, :GHz, :mK]
+        for u1 in _unit_list
+            for u2 in _unit_list
+                @inferred convert_unit(v1, u1, u2)
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ core_tests = [
     "states_and_operators.jl",
     "steady_state.jl",
     "time_evolution.jl",
+    "utilities.jl",
     "wigner.jl",
 ]
 


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [ ] Please read [Contributor Covenant Code of Conduct](https://github.com/qutip/QuantumToolbox.jl/blob/main/CODE_OF_CONDUCT.md)
- [ ] Any code changes were done in a way that does not break public API
- [ ] Appropriate tests were added and tested locally by running: `make test`.
- [ ] Any code changes should be `julia` formatted by running: `make format`.
- [ ] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running `make docs`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Summarize of this PR:
- Introduce `convert_unit`, which is the similar function in qutip (see [here](https://github.com/qutip/qutip/blob/0b4260e821cf4d095df6fa02ea5a71bc0655516c/qutip/utilities.py#L145) for the github code)
- add runtests (and also type inferrence tests) for utility functions