### PR TITLE
Introduce `PhysicalConstants` and new energy units

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -239,6 +239,7 @@ QuantumToolbox.versioninfo
 QuantumToolbox.about
 gaussian
 n_thermal
+PhysicalConstants
 convert_unit
 row_major_reshape
 meshgrid

--- a/test/core-test/utilities.jl
+++ b/test/core-test/utilities.jl
@@ -14,9 +14,21 @@
         @test typeof(n_thermal(Float32(2), Float64(3))) == Float64
     end
 
+    @testset "CODATA Physical Constants" begin
+        c = PhysicalConstants.c
+        h = PhysicalConstants.h
+        ħ = PhysicalConstants.ħ
+        μ0 = PhysicalConstants.μ0
+        ϵ0 = PhysicalConstants.ϵ0
+
+        @test h / ħ ≈ 2 * π
+        @test μ0 / (4e-7 * π) ≈ 1.0
+        @test c^2 * μ0 * ϵ0 ≈ 1.0
+    end
+
     @testset "convert unit" begin
         V = 100 * rand(Float64)
-        _unit_list = [:J, :eV, :meV, :GHz, :mK]
+        _unit_list = [:J, :eV, :meV, :MHz, :GHz, :K, :mK]
         for origin in _unit_list
             for middle in _unit_list
                 for target in _unit_list


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributor Covenant Code of Conduct](https://github.com/qutip/QuantumToolbox.jl/blob/main/CODE_OF_CONDUCT.md)
- [x] Any code changes were done in a way that does not break public API
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running `make docs`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Summary of this PR:
- Introduce `const PhysicalConstants::NamedTuple`, which stores some constant values listed in [*CODATA recommended values of the fundamental physical constants: 2022*](https://physics.nist.gov/cuu/pdf/wall_2022.pdf)
- Add new energy units for `convert_unit`