### PR TITLE
Improve random number generation on mcsolve and ssesolve

### DIFF
--- a/src/QuantumToolbox.jl
+++ b/src/QuantumToolbox.jl
@@ -47,7 +47,7 @@ import FFTW: fft, fftshift
 import Graphs: connected_components, DiGraph
 import IncompleteLU: ilu
 import Pkg
-import Random
+import Random: AbstractRNG, default_rng, seed!
 import SpecialFunctions: loggamma
 import StaticArraysCore: MVector
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using Pkg
 using QuantumToolbox
 using QuantumToolbox: position, momentum
+using Random
 
 const GROUP = get(ENV, "GROUP", "All")
 


### PR DESCRIPTION
## Description
Reproducibility is a fundamental feature for Monte Carlo simulations and Stochastic Solvers. The previous implementation on `mcsolve` involved the explicit definition of the `seeds` vector as an argument. Now, instead, we just need to put the random number generator (together with some optional seed). Given this RNG, every trajectory is completely reproducible.

Moreover, I have also added this feature on `ssesolve`.
