### PR TITLE
Improve performance for `mcsolve`

### DIFF
--- a/src/QuantumToolbox.jl
+++ b/src/QuantumToolbox.jl
@@ -47,7 +47,7 @@ import FFTW: fft, fftshift
 import Graphs: connected_components, DiGraph
 import IncompleteLU: ilu
 import Pkg
-import Random
+import Random: AbstractRNG, default_rng, seed!
 import SpecialFunctions: loggamma
 import StaticArraysCore: MVector
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using Pkg
 using QuantumToolbox
 using QuantumToolbox: position, momentum
+using Random
 
 const GROUP = get(ENV, "GROUP", "All")
 


### PR DESCRIPTION
## Description
This PR improves the performance of `mcsolve`. This changes the way to compute which collapse operator is acting of the state. To do this, I preallocate the list of hermitian collapse operators $\hat{C}^\dagger \hat{C}$, making much easier to compute $\langle \psi \vert \hat{C}^\dagger \hat{C} \vert \psi \rangle$.

I already see some performance improvement in the benchmarks, and I expect more improvements when the initialization overhead is much less than the integration time.