### PR TITLE
A lazy method to construct `QobjEvo`

### DIFF
--- a/src/qobj/quantum_object_evo.jl
+++ b/src/qobj/quantum_object_evo.jl
@@ -180,11 +180,8 @@ function QuantumObjectEvolution(
     return QuantumObjectEvolution(data, type, dims)
 end
 
-QuantumObjectEvolution(
-    op::QuantumObject,
-    f::Function;
-    type::Union{Nothing,QuantumObjectType} = nothing
-) = QuantumObjectEvolution(((op, f),); type = type)
+QuantumObjectEvolution(op::QuantumObject, f::Function; type::Union{Nothing,QuantumObjectType} = nothing) =
+    QuantumObjectEvolution(((op, f),); type = type)
 
 function QuantumObjectEvolution(
     op::QuantumObject,

--- a/src/qobj/quantum_object_evo.jl
+++ b/src/qobj/quantum_object_evo.jl
@@ -35,12 +35,9 @@ Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=tru
 ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20)
 ```
 
-If there are more than 2 operators, we need to put each set of operator and coefficient function into a two-element `Tuple`, and put all these sets together in a large `Tuple`:
+If there are more than 2 operators, we need to put each set of operator and coefficient function into a two-element `Tuple`, and put all these `Tuple`s together in a larger `Tuple`:
 
 ```
-julia> coef2(p, t) = sin(t)
-coef2 (generic function with 1 method)
-
 julia> σm = tensor(qeye(10), sigmam())
 Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 10 stored entries:
@@ -49,6 +46,9 @@ Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=fal
 ⎢⠀⠀⠀⠀⠂⡀⠀⠀⠀⠀⎥
 ⎢⠀⠀⠀⠀⠀⠀⠂⡀⠀⠀⎥
 ⎣⠀⠀⠀⠀⠀⠀⠀⠀⠂⡀⎦
+
+julia> coef2(p, t) = sin(t)
+coef2 (generic function with 1 method)
 
 julia> op1 = QuantumObjectEvolution(((a, coef1), (σm, coef2)))
 Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=true

--- a/src/qobj/quantum_object_evo.jl
+++ b/src/qobj/quantum_object_evo.jl
@@ -27,6 +27,20 @@ Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=fal
 ⎢⠀⠀⠀⠀⠀⠀⠀⠑⢄⠀⎥
 ⎣⠀⠀⠀⠀⠀⠀⠀⠀⠀⠑⎦
 
+julia> coef1(p, t) = exp(-1im * t)
+coef1 (generic function with 1 method)
+
+julia> op = QuantumObjectEvolution(a, coef1)
+Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=true
+ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20)
+```
+
+If there are more than 2 operators, we need to put each set of operator and coefficient function into a two-element `Tuple`, and put all these sets together in a large `Tuple`:
+
+```
+julia> coef2(p, t) = sin(t)
+coef2 (generic function with 1 method)
+
 julia> σm = tensor(qeye(10), sigmam())
 Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 10 stored entries:
@@ -35,12 +49,6 @@ Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=fal
 ⎢⠀⠀⠀⠀⠂⡀⠀⠀⠀⠀⎥
 ⎢⠀⠀⠀⠀⠀⠀⠂⡀⠀⠀⎥
 ⎣⠀⠀⠀⠀⠀⠀⠀⠀⠂⡀⎦
-
-julia> coef1(p, t) = exp(-1im * t)
-coef1 (generic function with 1 method)
-
-julia> coef2(p, t) = sin(t)
-coef2 (generic function with 1 method)
 
 julia> op1 = QuantumObjectEvolution(((a, coef1), (σm, coef2)))
 Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=true
@@ -134,7 +142,7 @@ function QuantumObjectEvolution(data::AbstractSciMLOperator, type::QuantumObject
     return QuantumObjectEvolution(data, type, SVector{1,Int}(dims))
 end
 
-"""
+@doc raw"""
     QuantumObjectEvolution(data::AbstractSciMLOperator; type::QuantumObjectType = Operator, dims = nothing)
 
 Generate a [`QuantumObjectEvolution`](@ref) object from a [`SciMLOperator`](https://github.com/SciML/SciMLOperators.jl), in the same way as [`QuantumObject`](@ref) for `AbstractArray` inputs.
@@ -171,6 +179,12 @@ function QuantumObjectEvolution(
 
     return QuantumObjectEvolution(data, type, dims)
 end
+
+QuantumObjectEvolution(
+    op::QuantumObject,
+    f::Function;
+    type::Union{Nothing,QuantumObjectType} = nothing
+) = QuantumObjectEvolution(((op, f),); type = type)
 
 function QuantumObjectEvolution(
     op::QuantumObject,

--- a/src/qobj/synonyms.jl
+++ b/src/qobj/synonyms.jl
@@ -18,6 +18,38 @@ Note that this functions is same as `QuantumObject(A; type=type, dims=dims)`.
 Qobj(A; kwargs...) = QuantumObject(A; kwargs...)
 
 @doc raw"""
+    QobjEvo(op::QuantumObject, f::Function; type::Union{Nothing,QuantumObjectType} = nothing)
+
+Generate [`QuantumObjectEvolution`](@ref).
+
+Note that this functions is same as `QuantumObjectEvolution(op, f; type = type)`. The `f` parameter is used to pre-apply a function to the operators before converting them to SciML operators. The `type` parameter is used to specify the type of the [`QuantumObject`](@ref), either `Operator` or `SuperOperator`.
+
+# Examples
+```
+julia> a = tensor(destroy(10), qeye(2))
+Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=false
+20×20 SparseMatrixCSC{ComplexF64, Int64} with 18 stored entries:
+⎡⠀⠑⢄⠀⠀⠀⠀⠀⠀⠀⎤
+⎢⠀⠀⠀⠑⢄⠀⠀⠀⠀⠀⎥
+⎢⠀⠀⠀⠀⠀⠑⢄⠀⠀⠀⎥
+⎢⠀⠀⠀⠀⠀⠀⠀⠑⢄⠀⎥
+⎣⠀⠀⠀⠀⠀⠀⠀⠀⠀⠑⎦
+
+julia> coef(p, t) = exp(-1im * t)
+coef1 (generic function with 1 method)
+
+julia> op = QobjEvo(a, coef)
+Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=true
+ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20)
+```
+"""
+QobjEvo(
+    op::QuantumObject,
+    f::Function;
+    type::Union{Nothing,QuantumObjectType} = nothing
+) = QobjEvo(((op, f),); type = type)
+
+@doc raw"""
     QobjEvo(op_func_list::Union{Tuple,AbstractQuantumObject}, α::Union{Nothing,Number}=nothing; type::Union{Nothing, QuantumObjectType}=nothing)
 
 Generate [`QuantumObjectEvolution`](@ref).

--- a/src/qobj/synonyms.jl
+++ b/src/qobj/synonyms.jl
@@ -43,11 +43,8 @@ Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=tru
 ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20)
 ```
 """
-QobjEvo(
-    op::QuantumObject,
-    f::Function;
-    type::Union{Nothing,QuantumObjectType} = nothing
-) = QobjEvo(((op, f),); type = type)
+QobjEvo(op::QuantumObject, f::Function; type::Union{Nothing,QuantumObjectType} = nothing) =
+    QobjEvo(((op, f),); type = type)
 
 @doc raw"""
     QobjEvo(op_func_list::Union{Tuple,AbstractQuantumObject}, α::Union{Nothing,Number}=nothing; type::Union{Nothing, QuantumObjectType}=nothing)

--- a/src/qobj/synonyms.jl
+++ b/src/qobj/synonyms.jl
@@ -44,7 +44,7 @@ ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20)
 ```
 """
 QobjEvo(op::QuantumObject, f::Function; type::Union{Nothing,QuantumObjectType} = nothing) =
-    QobjEvo(((op, f),); type = type)
+    QuantumObjectEvolution(op, f; type = type)
 
 @doc raw"""
     QobjEvo(op_func_list::Union{Tuple,AbstractQuantumObject}, α::Union{Nothing,Number}=nothing; type::Union{Nothing, QuantumObjectType}=nothing)

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -119,16 +119,15 @@ function _mcsolve_generate_statistics(sol, i, states, expvals_all, jump_times, j
     return jump_which[i] = sol_i.prob.p.jump_which
 end
 
-function _mcsolve_make_H_eff(H::QuantumObject, c_ops)
-    # this will be convert to QobjEvo in sesolveProblem (avoid extra ScalarOperator)
-    c_ops isa Nothing && return H
-    return H - 1im * mapreduce(op -> op' * op, +, c_ops) / 2
+function _mcsolve_make_Heff_QobjEvo(H::QuantumObject, c_ops)
+    c_ops isa Nothing && return QobjEvo(H)
+    return QobjEvo(H - 1im * mapreduce(op -> op' * op, +, c_ops) / 2)
 end
-function _mcsolve_make_H_eff(H::Tuple, c_ops)
+function _mcsolve_make_Heff_QobjEvo(H::Tuple, c_ops)
     c_ops isa Nothing && return QobjEvo(H)
     return QobjEvo((H..., -1im * mapreduce(op -> op' * op, +, c_ops) / 2))
 end
-function _mcsolve_make_H_eff(H::QuantumObjectEvolution, c_ops)
+function _mcsolve_make_Heff_QobjEvo(H::QuantumObjectEvolution, c_ops)
     c_ops isa Nothing && return H
     return H + QobjEvo(mapreduce(op -> op' * op, +, c_ops), -1im / 2)
 end
@@ -222,7 +221,7 @@ function mcsolveProblem(
 
     tlist = convert(Vector{_FType(ψ0)}, tlist) # Convert it to support GPUs and avoid type instabilities for OrdinaryDiffEq.jl
 
-    H_eff = _mcsolve_make_H_eff(H, c_ops)
+    H_eff_evo = _mcsolve_make_Heff_QobjEvo(H, c_ops)
 
     if e_ops isa Nothing
         expvals = Array{ComplexF64}(undef, 0, length(tlist))
@@ -268,11 +267,11 @@ function mcsolveProblem(
         params...,
     )
 
-    return mcsolveProblem(H_eff, ψ0, tlist, params2, jump_callback; kwargs2...)
+    return mcsolveProblem(H_eff_evo, ψ0, tlist, params2, jump_callback; kwargs2...)
 end
 
 function mcsolveProblem(
-    H_eff::AbstractQuantumObject{DT1,OperatorQuantumObject},
+    H_eff_evo::QuantumObjectEvolution{DT1,OperatorQuantumObject},
     ψ0::QuantumObject{DT2,KetQuantumObject},
     tlist::AbstractVector,
     params::NamedTuple,
@@ -286,11 +285,11 @@ function mcsolveProblem(
         haskey(kwargs2, :callback) ? merge(kwargs2, (callback = CallbackSet(cb1, cb2, kwargs2.callback),)) :
         merge(kwargs2, (callback = CallbackSet(cb1, cb2),))
 
-    return sesolveProblem(H_eff, ψ0, tlist; params = params, kwargs2...)
+    return sesolveProblem(H_eff_evo, ψ0, tlist; params = params, kwargs2...)
 end
 
 function mcsolveProblem(
-    H_eff::AbstractQuantumObject{DT1,OperatorQuantumObject},
+    H_eff_evo::QuantumObjectEvolution{DT1,OperatorQuantumObject},
     ψ0::QuantumObject{DT2,KetQuantumObject},
     tlist::AbstractVector,
     params::NamedTuple,
@@ -310,7 +309,7 @@ function mcsolveProblem(
         haskey(kwargs2, :callback) ? merge(kwargs2, (callback = CallbackSet(cb1, cb2, kwargs2.callback),)) :
         merge(kwargs2, (callback = CallbackSet(cb1, cb2),))
 
-    return sesolveProblem(H_eff, ψ0, tlist; params = params, kwargs2...)
+    return sesolveProblem(H_eff_evo, ψ0, tlist; params = params, kwargs2...)
 end
 
 @doc raw"""

--- a/test/core-test/quantum_objects_evo.jl
+++ b/test/core-test/quantum_objects_evo.jl
@@ -185,7 +185,7 @@
 
         # SuperOperator
         X = a * a'
-        c_op1 = QobjEvo(((a', coef1),))
+        c_op1 = QobjEvo(a', coef1)
         c_op2 = QobjEvo(((a, coef2), (X, coef3)))
         c_ops = [c_op1, c_op2]
         D1_ti = abs2(coef1(p, t)) * lindblad_dissipator(a')
@@ -213,7 +213,7 @@
         @test_throws ArgumentError cache_operator(L_td, ψ)
 
         @testset "Type Inference" begin
-            @inferred liouvillian(H_td, (a, QobjEvo(((a', coef1),))))
+            @inferred liouvillian(H_td, (a, QobjEvo(a', coef1)))
         end
     end
 end

--- a/test/core-test/time_evolution.jl
+++ b/test/core-test/time_evolution.jl
@@ -230,7 +230,7 @@
 
         @testset "Type Inference mesolve" begin
             coef(p, t) = exp(-t)
-            ad_t = QobjEvo(((a', coef),))
+            ad_t = QobjEvo(a', coef)
             @inferred mesolveProblem(H, ψ0, tlist, c_ops, e_ops = e_ops, progress_bar = Val(false))
             @inferred mesolveProblem(H, ψ0, [0, 10], c_ops, e_ops = e_ops, progress_bar = Val(false))
             @inferred mesolveProblem(

--- a/test/core-test/time_evolution.jl
+++ b/test/core-test/time_evolution.jl
@@ -84,7 +84,6 @@
             progress_bar = Val(false),
             jump_callback = DiscreteLindbladJumpCallback(),
         )
-        prob_sse = ssesolveProblem(H, psi0, t_l, c_ops, e_ops = e_ops, progress_bar = Val(false))
         sol_sse = ssesolve(H, psi0, t_l, c_ops, ntraj = 500, e_ops = e_ops, progress_bar = Val(false))
 
         ρt_mc = [ket2dm.(normalize.(states)) for states in sol_mc_states.states]
@@ -100,7 +99,6 @@
         sol_sse_string = sprint((t, s) -> show(t, "text/plain", s), sol_sse)
         @test prob_me.f.f isa MatrixOperator
         @test prob_mc.f.f isa MatrixOperator
-        @test prob_sse.f.f isa MatrixOperator
         @test sum(abs.(sol_mc.expect .- sol_me.expect)) / length(t_l) < 0.1
         @test sum(abs.(sol_mc2.expect .- sol_me.expect)) / length(t_l) < 0.1
         @test sum(abs.(vec(expect_mc_states_mean) .- vec(sol_me.expect))) / length(t_l) < 0.1

--- a/test/core-test/time_evolution.jl
+++ b/test/core-test/time_evolution.jl
@@ -11,10 +11,12 @@
         psi0 = kron(fock(N, 0), fock(2, 0))
         t_l = LinRange(0, 1000, 1000)
         e_ops = [a_d * a]
-        sol = sesolve(H, psi0, t_l, e_ops = e_ops, progress_bar = Val(false))
+        prob = sesolveProblem(H, psi0, t_l, e_ops = e_ops, progress_bar = Val(false))
+        sol = sesolve(prob)
         sol2 = sesolve(H, psi0, t_l, progress_bar = Val(false))
         sol3 = sesolve(H, psi0, t_l, e_ops = e_ops, saveat = t_l, progress_bar = Val(false))
         sol_string = sprint((t, s) -> show(t, "text/plain", s), sol)
+        @test prob.f.f isa MatrixOperator
         @test sum(abs.(sol.expect[1, :] .- sin.(η * t_l) .^ 2)) / length(t_l) < 0.1
         @test length(sol.times) == length(t_l)
         @test length(sol.states) == 1
@@ -55,9 +57,11 @@
         e_ops = [a_d * a]
         psi0 = basis(N, 3)
         t_l = LinRange(0, 100, 1000)
-        sol_me = mesolve(H, psi0, t_l, c_ops, e_ops = e_ops, progress_bar = Val(false))
+        prob_me = mesolveProblem(H, psi0, t_l, c_ops, e_ops = e_ops, progress_bar = Val(false))
+        sol_me = mesolve(prob_me)
         sol_me2 = mesolve(H, psi0, t_l, c_ops, progress_bar = Val(false))
         sol_me3 = mesolve(H, psi0, t_l, c_ops, e_ops = e_ops, saveat = t_l, progress_bar = Val(false))
+        prob_mc = mcsolveProblem(H, psi0, t_l, c_ops, e_ops = e_ops, progress_bar = Val(false))
         sol_mc = mcsolve(H, psi0, t_l, c_ops, ntraj = 500, e_ops = e_ops, progress_bar = Val(false))
         sol_mc2 = mcsolve(
             H,
@@ -80,6 +84,7 @@
             progress_bar = Val(false),
             jump_callback = DiscreteLindbladJumpCallback(),
         )
+        prob_sse = ssesolveProblem(H, psi0, t_l, c_ops, e_ops = e_ops, progress_bar = Val(false))
         sol_sse = ssesolve(H, psi0, t_l, c_ops, ntraj = 500, e_ops = e_ops, progress_bar = Val(false))
 
         ρt_mc = [ket2dm.(normalize.(states)) for states in sol_mc_states.states]
@@ -93,6 +98,9 @@
         sol_me_string = sprint((t, s) -> show(t, "text/plain", s), sol_me)
         sol_mc_string = sprint((t, s) -> show(t, "text/plain", s), sol_mc)
         sol_sse_string = sprint((t, s) -> show(t, "text/plain", s), sol_sse)
+        @test prob_me.f.f isa MatrixOperator
+        @test prob_mc.f.f isa MatrixOperator
+        @test prob_sse.f.f isa MatrixOperator
         @test sum(abs.(sol_mc.expect .- sol_me.expect)) / length(t_l) < 0.1
         @test sum(abs.(sol_mc2.expect .- sol_me.expect)) / length(t_l) < 0.1
         @test sum(abs.(vec(expect_mc_states_mean) .- vec(sol_me.expect))) / length(t_l) < 0.1

--- a/test/core-test/time_evolution.jl
+++ b/test/core-test/time_evolution.jl
@@ -98,7 +98,7 @@
         sol_mc_string = sprint((t, s) -> show(t, "text/plain", s), sol_mc)
         sol_sse_string = sprint((t, s) -> show(t, "text/plain", s), sol_sse)
         @test prob_me.f.f isa MatrixOperator
-        @test prob_mc.f.f isa MatrixOperator
+        @test prob_mc.f.f isa ScaledOperator # TODO: can be optimized as MatrixOperator
         @test sum(abs.(sol_mc.expect .- sol_me.expect)) / length(t_l) < 0.1
         @test sum(abs.(sol_mc2.expect .- sol_me.expect)) / length(t_l) < 0.1
         @test sum(abs.(vec(expect_mc_states_mean) .- vec(sol_me.expect))) / length(t_l) < 0.1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using QuantumToolbox
 using QuantumToolbox: position, momentum
 using Random
 using SciMLOperators
+import SciMLOperators: ScaledOperator
 
 const GROUP = get(ENV, "GROUP", "All")
 


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributor Covenant Code of Conduct](https://github.com/qutip/QuantumToolbox.jl/blob/main/CODE_OF_CONDUCT.md)
- [x] Any code changes were done in a way that does not break public API
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running `make docs`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Summary of this PR:
- Add a lazy method to construct `QobjEvo`
- ~make `mcsolveProblem` accept `H_eff::AbstractQuantumObject` to fix extra `ScalarOperator` for time-independent `mcsolve`.~ This breaks many things in dynamical solvers
- improve runtests to make sure time-independent problems are `MatrixOperator`

## Related issues or PRs
Please mention the related issues or PRs here. If the PR fixes an issue, use the keyword close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved followed by the issue id, e.g. fix #[id]
close #281 
