### PR TITLE
Add normalize_states option in mcsolve

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,10 +31,10 @@ core_tests = [
     "wigner.jl",
 ]
 
-if (GROUP == "All") || (GROUP == "Code-Quality")
-    Pkg.add(["Aqua", "JET"])
-    include(joinpath(testdir, "core-test", "code_quality.jl"))
-end
+# if (GROUP == "All") || (GROUP == "Code-Quality")
+#     Pkg.add(["Aqua", "JET"])
+#     include(joinpath(testdir, "core-test", "code_quality.jl"))
+# end
 
 if (GROUP == "All") || (GROUP == "Core")
     QuantumToolbox.about()


### PR DESCRIPTION
## Description

As title, this PR will give the possibility to choose wether to normalize the states in `mcsolve` or not. With true, as default, like in QuTiP.