### PR TITLE
Add spell check CI and fix typos

### DIFF
--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout Actions Repository
         uses: actions/checkout@v4
       - name: Check spelling
-        uses: crate-ci/typos@v1
+        uses: crate-ci/typos@v1.28.0

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout Actions Repository
         uses: actions/checkout@v4
       - name: Check spelling
-        uses: crate-ci/typos@v1.28.0
+        uses: crate-ci/typos@v1.27.0

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,13 @@
+name: Spell Check
+
+on: [pull_request]
+
+jobs:
+  typos-check:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v4
+      - name: Check spelling
+        uses: crate-ci/typos@v1

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+ket = "ket"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ QuantumToolbox.jl is equipped with a robust set of features:
 
 - **Quantum State and Operator Manipulation:** Easily handle quantum states and operators with a rich set of tools, with the same functionalities as QuTiP.
 - **Dynamical Evolution:** Advanced solvers for time evolution of quantum systems, thanks to the powerful [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl) package.
-- **GPU Computing:** Leverage GPU resources for high-performance computing. For example, you run the master equation direclty on the GPU with the same syntax as the CPU case.
+- **GPU Computing:** Leverage GPU resources for high-performance computing. For example, you run the master equation directly on the GPU with the same syntax as the CPU case.
 - **Distributed Computing:** Distribute the computation over multiple nodes (e.g., a cluster). For example, you can run hundreds of quantum trajectories in parallel on a cluster, with, again, the same syntax as the simple case.
 - **Easy Extension:** Easily extend the package, taking advantage of the Julia language features, like multiple dispatch and metaprogramming.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,7 +14,7 @@ QuantumToolbox.jl is equipped with a robust set of features:
 
 - **Quantum State and Operator Manipulation:** Easily handle quantum states and operators with a rich set of tools, with the same functionalities as QuTiP.
 - **Dynamical Evolution:** Advanced solvers for time evolution of quantum systems, thanks to the powerful [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl) package.
-- **GPU Computing:** Leverage GPU resources for high-performance computing. For example, you run the master equation direclty on the GPU with the same syntax as the CPU case.
+- **GPU Computing:** Leverage GPU resources for high-performance computing. For example, you run the master equation directly on the GPU with the same syntax as the CPU case.
 - **Distributed Computing:** Distribute the computation over multiple nodes (e.g., a cluster). For example, you can run undreds of quantum trajectories in parallel on a cluster, with, again, the same syntax as the simple case.
 - **Easy Extension:** Easily extend the package, taking advantage of the Julia language features, like multiple dispatch and metaprogramming.
 

--- a/docs/src/tutorials/lowrank.md
+++ b/docs/src/tutorials/lowrank.md
@@ -1,6 +1,6 @@
 # [Low rank master equation](@id doc-tutor:Low-rank-master-equation)
 
-In this tutorial, we will show how to solve the master equation using the low-rank method. For a detailed explaination of the method, we recommend to read the article [gravina2024adaptive](@cite).
+In this tutorial, we will show how to solve the master equation using the low-rank method. For a detailed explanation of the method, we recommend to read the article [gravina2024adaptive](@cite).
 
 As a test, we will consider the dissipative Ising model with a transverse field. The Hamiltonian is given by
 

--- a/docs/src/users_guide/states_and_operators.md
+++ b/docs/src/users_guide/states_and_operators.md
@@ -99,7 +99,7 @@ We can also create superpositions of states:
 ket = normalize(basis(5, 0) + basis(5, 1))
 ```
 
-where we have used the `normalize` function again to normalize the state. Apply the number opeartor again:
+where we have used the `normalize` function again to normalize the state. Apply the number operator again:
 
 ```@example states_and_operators
 n * ket

--- a/src/linear_maps.jl
+++ b/src/linear_maps.jl
@@ -18,7 +18,7 @@ A **linear map** is a transformation `L` that satisfies:
     L(cu) = cL(u)
     ```
 
-It is typically represented as a matrix with dimensions given by `size`, and this abtract type helps to define this map when the matrix is not explicitly available.
+It is typically represented as a matrix with dimensions given by `size`, and this abstract type helps to define this map when the matrix is not explicitly available.
 
 ## Methods
 

--- a/src/qobj/boolean_functions.jl
+++ b/src/qobj/boolean_functions.jl
@@ -100,6 +100,6 @@ SciMLOperators.iscached(A::AbstractQuantumObject) = iscached(A.data)
 @doc raw"""
     SciMLOperators.isconstant(A::AbstractQuantumObject)
 
-Test whether the [`AbstractQuantumObject`](@ref) `A` is constant in time. For a [`QuantumObject`](@ref), this function returns `true`, while for a [`QuantumObjectEvolution`](@ref), this function returns `true` if the operator is contant in time.
+Test whether the [`AbstractQuantumObject`](@ref) `A` is constant in time. For a [`QuantumObject`](@ref), this function returns `true`, while for a [`QuantumObjectEvolution`](@ref), this function returns `true` if the operator is constant in time.
 """
 SciMLOperators.isconstant(A::AbstractQuantumObject) = isconstant(A.data)

--- a/src/qobj/superoperators.jl
+++ b/src/qobj/superoperators.jl
@@ -20,7 +20,7 @@ function _sprepost(A, B) # for any other input types
 end
 
 ## if input is AbstractSciMLOperator 
-## some of them are optimzed to speed things up
+## some of them are optimized to speed things up
 ## the rest of the SciMLOperators will just use lazy tensor (and prompt a warning)
 _spre(A::MatrixOperator, Id::AbstractMatrix) = MatrixOperator(_spre(A.A, Id))
 _spre(A::ScaledOperator, Id::AbstractMatrix) = ScaledOperator(A.λ, _spre(A.L, Id))

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -106,11 +106,11 @@ function _steadystate(
     idx_range = collect(1:N)
     rows = _get_dense_similar(L_tmp, N)
     cols = _get_dense_similar(L_tmp, N)
-    datas = _get_dense_similar(L_tmp, N)
+    _data = _get_dense_similar(L_tmp, N)
     fill!(rows, 1)
     copyto!(cols, N .* (idx_range .- 1) .+ idx_range)
-    fill!(datas, weight)
-    Tn = sparse(rows, cols, datas, N^2, N^2)
+    fill!(_data, weight)
+    Tn = sparse(rows, cols, _data, N^2, N^2)
     L_tmp = L_tmp + Tn
 
     (haskey(kwargs, :Pl) || haskey(kwargs, :Pr)) && error("The use of preconditioners must be defined in the solver.")
@@ -160,11 +160,11 @@ function _steadystate(
     idx_range = collect(1:N)
     rows = _get_dense_similar(L_tmp, N)
     cols = _get_dense_similar(L_tmp, N)
-    datas = _get_dense_similar(L_tmp, N)
+    _data = _get_dense_similar(L_tmp, N)
     fill!(rows, 1)
     copyto!(cols, N .* (idx_range .- 1) .+ idx_range)
-    fill!(datas, weight)
-    Tn = sparse(rows, cols, datas, N^2, N^2)
+    fill!(_data, weight)
+    Tn = sparse(rows, cols, _data, N^2, N^2)
     L_tmp = L_tmp + Tn
 
     ρss_vec = L_tmp \ v0 # This is still not supported on GPU, yet

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -106,11 +106,11 @@ function _steadystate(
     idx_range = collect(1:N)
     rows = _get_dense_similar(L_tmp, N)
     cols = _get_dense_similar(L_tmp, N)
-    _data = _get_dense_similar(L_tmp, N)
+    vals = _get_dense_similar(L_tmp, N)
     fill!(rows, 1)
     copyto!(cols, N .* (idx_range .- 1) .+ idx_range)
-    fill!(_data, weight)
-    Tn = sparse(rows, cols, _data, N^2, N^2)
+    fill!(vals, weight)
+    Tn = sparse(rows, cols, vals, N^2, N^2)
     L_tmp = L_tmp + Tn
 
     (haskey(kwargs, :Pl) || haskey(kwargs, :Pr)) && error("The use of preconditioners must be defined in the solver.")
@@ -160,11 +160,11 @@ function _steadystate(
     idx_range = collect(1:N)
     rows = _get_dense_similar(L_tmp, N)
     cols = _get_dense_similar(L_tmp, N)
-    _data = _get_dense_similar(L_tmp, N)
+    vals = _get_dense_similar(L_tmp, N)
     fill!(rows, 1)
     copyto!(cols, N .* (idx_range .- 1) .+ idx_range)
-    fill!(_data, weight)
-    Tn = sparse(rows, cols, _data, N^2, N^2)
+    fill!(vals, weight)
+    Tn = sparse(rows, cols, vals, N^2, N^2)
     L_tmp = L_tmp + Tn
 
     ρss_vec = L_tmp \ v0 # This is still not supported on GPU, yet

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -38,14 +38,14 @@ function LindbladJumpAffect!(integrator)
     end
     cumsum!(cumsum_weights_mc, weights_mc)
     r = rand(traj_rng) * sum(weights_mc)
-    collaps_idx = getindex(1:length(weights_mc), findfirst(>(r), cumsum_weights_mc))
-    mul!(cache_mc, c_ops[collaps_idx], ψ)
+    collapse_idx = getindex(1:length(weights_mc), findfirst(>(r), cumsum_weights_mc))
+    mul!(cache_mc, c_ops[collapse_idx], ψ)
     normalize!(cache_mc)
     copyto!(integrator.u, cache_mc)
 
     random_n[] = rand(traj_rng)
     jump_times[internal_params.jump_times_which_idx[]] = integrator.t
-    jump_which[internal_params.jump_times_which_idx[]] = collaps_idx
+    jump_which[internal_params.jump_times_which_idx[]] = collapse_idx
     internal_params.jump_times_which_idx[] += 1
     if internal_params.jump_times_which_idx[] > length(jump_times)
         resize!(jump_times, length(jump_times) + internal_params.jump_times_which_init_size)

--- a/src/time_evolution/ssesolve.jl
+++ b/src/time_evolution/ssesolve.jl
@@ -5,11 +5,11 @@ export ssesolveProblem, ssesolveEnsembleProblem, ssesolve
 
 A struct to represent the diffusion operator. This is used to perform the diffusion process on N different Wiener processes.
 =#
-struct DiffusionOperator{T,OT<:Tuple{Vararg{AbstractSciMLOperator}}} <: AbstractSciMLOperator{T}
-    ops::OT
-    function DiffusionOperator(ops::OT) where {OT}
+struct DiffusionOperator{T,OpType<:Tuple{Vararg{AbstractSciMLOperator}}} <: AbstractSciMLOperator{T}
+    ops::OpType
+    function DiffusionOperator(ops::OpType) where {OpType}
         T = mapreduce(eltype, promote_type, ops)
-        return new{T,OT}(ops)
+        return new{T,OpType}(ops)
     end
 end
 

--- a/src/time_evolution/time_evolution_dynamical.jl
+++ b/src/time_evolution/time_evolution_dynamical.jl
@@ -8,12 +8,12 @@ function _reduce_dims(
     sel,
     reduce,
 ) where {T,N,DT<:Integer}
-    nd = length(dims)
+    n_d = length(dims)
     dims_new = zero(dims)
     dims_new[sel] .= reduce
     @. dims_new = dims - dims_new
 
-    if nd == 1
+    if n_d == 1
         ρmat = similar(QO, dims_new[1], dims_new[1])
         copyto!(ρmat, view(QO, 1:dims_new[1], 1:dims_new[1]))
     else
@@ -32,12 +32,12 @@ function _increase_dims(
     sel,
     increase,
 ) where {T,N,DT<:Integer}
-    nd = length(dims)
+    n_d = length(dims)
     dims_new = MVector(zero(dims)) # Mutable SVector
     dims_new[sel] .= increase
     @. dims_new = dims + dims_new
 
-    if nd == 1
+    if n_d == 1
         ρmat = similar(QO, dims_new[1], dims_new[1])
         fill!(selectdim(ρmat, 1, dims[1]+1:dims_new[1]), 0)
         fill!(selectdim(ρmat, 2, dims[1]+1:dims_new[1]), 0)
@@ -46,8 +46,8 @@ function _increase_dims(
         ρmat2 = similar(QO, reverse(vcat(dims_new, dims_new))...)
         ρmat = reshape(QO, reverse(vcat(dims, dims))...)
         for i in eachindex(sel)
-            fill!(selectdim(ρmat2, nd - sel[i] + 1, dims[sel[i]]+1:dims_new[sel[i]]), 0)
-            fill!(selectdim(ρmat2, 2 * nd - sel[i] + 1, dims[sel[i]]+1:dims_new[sel[i]]), 0)
+            fill!(selectdim(ρmat2, n_d - sel[i] + 1, dims[sel[i]]+1:dims_new[sel[i]]), 0)
+            fill!(selectdim(ρmat2, 2 * n_d - sel[i] + 1, dims[sel[i]]+1:dims_new[sel[i]]), 0)
         end
         copyto!(view(ρmat2, reverse!(repeat([1:n for n in dims], 2))...), ρmat)
         ρmat = reshape(ρmat2, prod(dims_new), prod(dims_new))


### PR DESCRIPTION
## Description
As title.

"[typos](https://github.com/crate-ci/typos)" will check our spelling, tell us where each typo is located, and give us suggestions.

I also add the ignore file for the word: `ket`, since we use it a lot.

@albertomercurio 
If you agree with this, I will fix all the typos detected by this CI.