### PR TITLE
Add Wigner plotting via CairoMakie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
+- Introduce `plot_wigner` function for easy plotting of Wigner functions. ([#86], [#292])
 
 
 ## [v0.23.1]
@@ -44,7 +45,9 @@ Release date: 2024-11-13
 [v0.22.0]: https://github.com/qutip/QuantumToolbox.jl/releases/tag/v0.22.0
 [v0.23.0]: https://github.com/qutip/QuantumToolbox.jl/releases/tag/v0.23.0
 [v0.23.1]: https://github.com/qutip/QuantumToolbox.jl/releases/tag/v0.23.1
+[#86]: https://github.com/qutip/QuantumToolbox.jl/issues/86
 [#139]: https://github.com/qutip/QuantumToolbox.jl/issues/139
+[#292]: https://github.com/qutip/QuantumToolbox.jl/issues/292
 [#306]: https://github.com/qutip/QuantumToolbox.jl/issues/306
 [#309]: https://github.com/qutip/QuantumToolbox.jl/issues/309
 [#311]: https://github.com/qutip/QuantumToolbox.jl/issues/311

--- a/Project.toml
+++ b/Project.toml
@@ -28,14 +28,17 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 
 [extensions]
 QuantumToolboxCUDAExt = "CUDA"
+QuantumToolboxCairoMakieExt = "CairoMakie"
 
 [compat]
 Aqua = "0.8"
 ArrayInterface = "6, 7"
 CUDA = "5"
+CairoMakie = "0.12.15"
 DiffEqBase = "6"
 DiffEqCallbacks = "4.2.1 - 4"
 DiffEqNoiseProcess = "5"

--- a/Project.toml
+++ b/Project.toml
@@ -38,7 +38,7 @@ QuantumToolboxCairoMakieExt = "CairoMakie"
 Aqua = "0.8"
 ArrayInterface = "6, 7"
 CUDA = "5"
-CairoMakie = "0.12.15"
+CairoMakie = "0.12"
 DiffEqBase = "6"
 DiffEqCallbacks = "4.2.1 - 4"
 DiffEqNoiseProcess = "5"
@@ -65,8 +65,9 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "JET", "Test"]
+test = ["Aqua", "CairoMakie", "JET", "Test"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,6 +7,9 @@ using DocumenterVitepress
 using DocumenterCitations
 using Changelog
 
+# Load of packages required to compile the extension documentation
+using CairoMakie
+
 DocMeta.setdocmeta!(QuantumToolbox, :DocTestSetup, :(using QuantumToolbox); recursive = true)
 
 # some options for `makedocs`
@@ -76,7 +79,10 @@ const PAGES = [
 ]
 
 makedocs(;
-    modules = [QuantumToolbox],
+    modules = [
+        QuantumToolbox, 
+        Base.get_extension(QuantumToolbox, :QuantumToolboxCairoMakieExt),
+        ],
     authors = "Alberto Mercurio and Yi-Te Huang",
     repo = Remotes.GitHub("qutip", "QuantumToolbox.jl"),
     sitename = "QuantumToolbox.jl",

--- a/docs/src/resources/api.md
+++ b/docs/src/resources/api.md
@@ -281,3 +281,9 @@ convert_unit
 row_major_reshape
 meshgrid
 ```
+
+## [Visualization](@id doc-API:Visualization)
+
+```@docs
+plot_wigner
+```

--- a/docs/src/tutorials/logo.md
+++ b/docs/src/tutorials/logo.md
@@ -76,7 +76,7 @@ xvec = range(-ρ, ρ, 500) .* 1.5
 yvec = xvec .+ (abs(imag(α1)) - abs(imag(α2))) / 2
 
 fig = Figure(size = (250, 250), figure_padding = 0)
-fig, ax, hm = plot_wigner(ψ, library = Val(:CairoMakie), xvec = xvec, yvec = yvec, g = 2, location = fig[1,1])
+fig, ax, hm = plot_wigner(ψ, xvec = xvec, yvec = yvec, g = 2, library = Val(:CairoMakie), location = fig[1,1])
 hidespines!(ax)
 hidexdecorations!(ax)
 hideydecorations!(ax)
@@ -110,7 +110,7 @@ And the Wigner function becomes more uniform:
 
 ```@example logo
 fig = Figure(size = (250, 250), figure_padding = 0)
-fig, ax, hm = plot_wigner(sol.states[end], library = Val(:CairoMakie), xvec = xvec, yvec = yvec, g = 2, location = fig[1,1])
+fig, ax, hm = plot_wigner(sol.states[end], xvec = xvec, yvec = yvec, g = 2, library = Val(:CairoMakie), location = fig[1,1])
 hidespines!(ax)
 hidexdecorations!(ax)
 hideydecorations!(ax)

--- a/docs/src/tutorials/logo.md
+++ b/docs/src/tutorials/logo.md
@@ -67,25 +67,16 @@ Next, we construct the triangular cat state as a normalized superposition of thr
 normalize!(ψ)
 ```
 
-### Defining the Grid and calculating the Wigner function
+### Defining the Grid and plotting the Wigner function
 
-We define the grid for the Wigner function and calculate it using the [`wigner`](@ref) function. We shift the grid in the imaginary direction to ensure that the Wigner function is centered around the origin of the figure. The [`wigner`](@ref) function also supports the `g` scaling factor, which we put here equal to ``2``.
+We define the grid for the Wigner function and plot it using the [`plot_wigner`](@ref) function. This, internally calls the [`wigner`](@ref) function for the computation. We shift the grid in the imaginary direction to ensure that the Wigner function is centered around the origin of the figure. The [`wigner`](@ref) function also supports the `g` scaling factor, which we put here equal to ``2``.
 
 ```@example logo
 xvec = range(-ρ, ρ, 500) .* 1.5
 yvec = xvec .+ (abs(imag(α1)) - abs(imag(α2))) / 2
 
-wig = wigner(ψ, xvec, yvec, g = 2)
-```
-
-### Plotting the Wigner function
-
-Finally, we plot the Wigner function using the `heatmap` function from the `CairoMakie` package.
-
-```@example logo
 fig = Figure(size = (250, 250), figure_padding = 0)
-ax = Axis(fig[1, 1])
-heatmap!(ax, xvec, yvec, wig', colormap = :RdBu, interpolate = true, rasterize = 1)
+fig, ax, hm = plot_wigner(ψ, library = Val(:CairoMakie), xvec = xvec, yvec = yvec, g = 2, location = fig[1,1])
 hidespines!(ax)
 hidexdecorations!(ax)
 hideydecorations!(ax)
@@ -118,12 +109,8 @@ nothing # hide
 And the Wigner function becomes more uniform:
 
 ```@example logo
-wig = wigner(sol.states[end], xvec, yvec, g = 2)
-
 fig = Figure(size = (250, 250), figure_padding = 0)
-ax = Axis(fig[1, 1])
-
-img_wig = heatmap!(ax, xvec, yvec, wig', colormap = :RdBu, interpolate = true, rasterize = 1)
+fig, ax, hm = plot_wigner(sol.states[end], library = Val(:CairoMakie), xvec = xvec, yvec = yvec, g = 2, location = fig[1,1])
 hidespines!(ax)
 hidexdecorations!(ax)
 hideydecorations!(ax)
@@ -135,7 +122,7 @@ At this stage, we have finished to use the `QuantumToolbox` package. From now on
 
 ### Custom Colormap
 
-We define a custom colormap that changes depending on the Wigner function and spatial coordinates. Indeed, we want the three different colormaps, in the regions corresponding to the three coherent states, to match the colors of the Julia logo. We also want the colormap change to be smooth, so we use a Gaussian function to blend the colors. We introduce also a Wigner function dependent transparency to make the logo more appealing.
+We define a custom colormap that changes depending on the Wigner function and spatial coordinates. Indeed, we want the three different colormaps, in the regions corresponding to the three coherent states, to match the colors of the Julia logo. We also want the colormap change to be smooth, so we use a Gaussian function to blend the colors. We introduce also a Wigner function dependent transparency to make the logo more appealing. In order to do so, we are going to need the value of the wigner function at each point of the grid, rather than its plot. We will thus call the [`wigner`](@ref) function directly.
 
 ```@example logo
 function set_color_julia(x, y, wig::T, α1, α2, α3, cmap1, cmap2, cmap3, δ) where {T}
@@ -156,6 +143,7 @@ function set_color_julia(x, y, wig::T, α1, α2, α3, cmap1, cmap2, cmap3, δ) w
     return RGBAf(c_tot.r, c_tot.g, c_tot.b, alpha)
 end
 
+wig = wigner(sol.states[end], xvec, yvec, g = 2)
 X, Y = meshgrid(xvec, yvec)
 δ = 1.25 # Smoothing parameter for the Gaussian functions
 ```

--- a/ext/QuantumToolboxCairoMakieExt.jl
+++ b/ext/QuantumToolboxCairoMakieExt.jl
@@ -3,6 +3,44 @@ module QuantumToolboxCairoMakieExt
 using QuantumToolbox
 using CairoMakie
 
+@doc raw"""
+    plot_wigner(
+        library::Val{:CairoMakie},
+        state::QuantumObject{<:AbstractArray{T},OpType};
+        xvec::Union{Nothing,AbstractVector} = nothing,
+        yvec::Union{Nothing,AbstractVector} = nothing,
+        g::Real = √2,
+        method::WignerSolver = WignerClenshaw(),
+        projection::Union{Val,Symbol} = Val(:two_dim),
+        location::Union{GridPosition,Nothing} = nothing,
+        colorbar::Bool = false,
+        kwargs...
+    )
+
+Plot the [Wigner quasipropability distribution](https://en.wikipedia.org/wiki/Wigner_quasiprobability_distribution) of `state` using the [CairoMakie](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie) plotting library.
+
+Note that CairoMakie must first be imported before using this function.
+
+# Arguments
+- `library::Val{:CairoMakie}`: The plotting library to use.
+- `state::QuantumObject`: The quantum state for which the Wigner function is calculated. It can be either a [`KetQuantumObject`](@ref), [`BraQuantumObject`](@ref), or [`OperatorQuantumObject`](@ref).
+- `xvec::AbstractVector`: The x-coordinates of the phase space grid. Default is # TODO
+- `yvec::AbstractVector`: The y-coordinates of the phase space grid. Default is # TODO
+- `g::Real`: The scaling factor related to the value of ``\hbar`` in the commutation relation ``[x, y] = i \hbar`` via ``\hbar=2/g^2``.
+- `method::WignerSolver`: The method used to calculate the Wigner function. It can be either `WignerLaguerre()` or `WignerClenshaw()`, with `WignerClenshaw()` as default. The `WignerLaguerre` method has the optional `parallel` and `tol` parameters, with default values `true` and `1e-14`, respectively.
+- `projection::Union{Val,Symbol}`: Wheather to plot the Wigner function in 2D or 3D. It can be either `Val(:two_dim)` or `Val(:three_dim)`, with `Val(:two_dim)` as default.
+- `location::Union{GridPosition,Nothing}`: The location of the plot in the layout. If `nothing`, the plot is created in a new figure. Default is `nothing`.
+- `colorbar::Bool`: Whether to include a colorbar in the plot. Default is `false`.
+- `kwargs...`: Additional keyword arguments to pass to the plotting function. 
+
+# Returns
+- `fig`: The figure object.
+- `ax`: The axis object.
+- `hm`: Either the heatmap or surface object, depending on the projection.
+
+!!! warning "Beware of type-stability!"
+    If you want to keep type stability, it is recommended to use `Val(:two_dim)` and `Val(:three_dim)` instead of `:two_dim` and `:three_dim`, respectively. Also, specify the library as `Val(:CairoMakie)` See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
+"""
 function QuantumToolbox.plot_wigner(
     library::Val{:CairoMakie},
     state::QuantumObject{<:AbstractArray{T},OpType};
@@ -54,8 +92,8 @@ function _plot_wigner(
     wig = wigner(state, xvec, yvec; g = g, method = method)
     wlim = maximum(abs, wig)
 
-    kwargs = merge(Dict(:colormap => :RdBu, :colorrange => (-wlim, wlim)), kwargs)
-    hm = heatmap!(ax, xvec, yvec, wig; kwargs...)
+    kwargs = merge(Dict(:colormap => Reverse(:RdBu), :colorrange => (-wlim, wlim)), kwargs)
+    hm = heatmap!(ax, xvec, yvec, wig'; kwargs...)
 
     if colorbar
         Colorbar(lyt[1, 2], hm)
@@ -88,7 +126,7 @@ function _plot_wigner(
     wlim = maximum(abs, wig)
 
     kwargs = merge(Dict(:colormap => :RdBu, :colorrange => (-wlim, wlim)), kwargs)
-    surf = surface!(ax, xvec, yvec, wig; kwargs...)
+    surf = surface!(ax, xvec, yvec, wig'; kwargs...)
 
     if colorbar
         Colorbar(lyt[1, 2], surf)

--- a/ext/QuantumToolboxCairoMakieExt.jl
+++ b/ext/QuantumToolboxCairoMakieExt.jl
@@ -28,7 +28,7 @@ Note that CairoMakie must first be imported before using this function.
 - `yvec::AbstractVector`: The y-coordinates of the phase space grid. Defaults to a linear range from -7.5 to 7.5 with 200 points.
 - `g::Real`: The scaling factor related to the value of ``\hbar`` in the commutation relation ``[x, y] = i \hbar`` via ``\hbar=2/g^2``.
 - `method::WignerSolver`: The method used to calculate the Wigner function. It can be either `WignerLaguerre()` or `WignerClenshaw()`, with `WignerClenshaw()` as default. The `WignerLaguerre` method has the optional `parallel` and `tol` parameters, with default values `true` and `1e-14`, respectively.
-- `projection::Union{Val,Symbol}`: Wheather to plot the Wigner function in 2D or 3D. It can be either `Val(:two_dim)` or `Val(:three_dim)`, with `Val(:two_dim)` as default.
+- `projection::Union{Val,Symbol}`: Whether to plot the Wigner function in 2D or 3D. It can be either `Val(:two_dim)` or `Val(:three_dim)`, with `Val(:two_dim)` as default.
 - `location::Union{GridPosition,Nothing}`: The location of the plot in the layout. If `nothing`, the plot is created in a new figure. Default is `nothing`.
 - `colorbar::Bool`: Whether to include a colorbar in the plot. Default is `false`.
 - `kwargs...`: Additional keyword arguments to pass to the plotting function. 

--- a/ext/QuantumToolboxCairoMakieExt.jl
+++ b/ext/QuantumToolboxCairoMakieExt.jl
@@ -6,7 +6,7 @@ using CairoMakie
 @doc raw"""
     plot_wigner(
         library::Val{:CairoMakie},
-        state::QuantumObject{<:AbstractArray{T},OpType};
+        state::QuantumObject{DT,OpType};
         xvec::Union{Nothing,AbstractVector} = nothing,
         yvec::Union{Nothing,AbstractVector} = nothing,
         g::Real = √2,
@@ -15,7 +15,7 @@ using CairoMakie
         location::Union{GridPosition,Nothing} = nothing,
         colorbar::Bool = false,
         kwargs...
-    )
+    ) where {DT,OpType}
 
 Plot the [Wigner quasipropability distribution](https://en.wikipedia.org/wiki/Wigner_quasiprobability_distribution) of `state` using the [CairoMakie](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie) plotting library.
 
@@ -43,7 +43,7 @@ Note that CairoMakie must first be imported before using this function.
 """
 function QuantumToolbox.plot_wigner(
     library::Val{:CairoMakie},
-    state::QuantumObject{<:AbstractArray{T},OpType};
+    state::QuantumObject{DT,OpType};
     xvec::Union{Nothing,AbstractVector} = LinRange(-7.5, 7.5, 200),
     yvec::Union{Nothing,AbstractVector} = LinRange(-7.5, 7.5, 200),
     g::Real = √2,
@@ -52,7 +52,7 @@ function QuantumToolbox.plot_wigner(
     location::Union{GridPosition,Nothing} = nothing,
     colorbar::Bool = false,
     kwargs...,
-) where {T,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}}
+) where {DT,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}}
     QuantumToolbox.getVal(projection) == :two_dim ||
         QuantumToolbox.getVal(projection) == :three_dim ||
         throw(ArgumentError("Unsupported projection: $projection"))
@@ -73,7 +73,7 @@ end
 
 function _plot_wigner(
     ::Val{:CairoMakie},
-    state::QuantumObject{<:AbstractArray{T},OpType},
+    state::QuantumObject{DT,OpType},
     xvec::AbstractVector,
     yvec::AbstractVector,
     projection::Val{:two_dim},
@@ -82,7 +82,7 @@ function _plot_wigner(
     location::Union{GridPosition,Nothing},
     colorbar::Bool;
     kwargs...,
-) where {T,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}}
+) where {DT,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}}
     fig, location = _getFigAndLocation(location)
 
     lyt = GridLayout(location)
@@ -106,7 +106,7 @@ end
 
 function _plot_wigner(
     ::Val{:CairoMakie},
-    state::QuantumObject{<:AbstractArray{T},OpType},
+    state::QuantumObject{DT,OpType},
     xvec::AbstractVector,
     yvec::AbstractVector,
     projection::Val{:three_dim},
@@ -115,7 +115,7 @@ function _plot_wigner(
     location::Union{GridPosition,Nothing},
     colorbar::Bool;
     kwargs...,
-) where {T,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}}
+) where {DT,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}}
     fig, location = _getFigAndLocation(location)
 
     lyt = GridLayout(location)
@@ -138,7 +138,7 @@ function _plot_wigner(
     return fig, ax, surf
 end
 
-@doc raw"""
+raw"""
     _getFigAndLocation(location::Nothing)
     
     Create a new figure and return it, together with the GridPosition object pointing to the first cell.
@@ -155,7 +155,7 @@ function _getFigAndLocation(location::Nothing)
     return fig, fig[1, 1]
 end
 
-@doc raw"""
+raw"""
     _getFigAndLocation(location::GridPosition)
     
     Compute which figure does the location belong to and return it, together with the location itself.
@@ -172,7 +172,7 @@ function _getFigAndLocation(location::GridPosition)
     return fig, location
 end
 
-@doc raw"""
+raw"""
     _figFromChildren(children::GridLayout)
 
     Recursively find the figure object from the children layout.
@@ -185,7 +185,7 @@ end
 """
 _figFromChildren(children) = _figFromChildren(children.parent)
 
-@doc raw"""
+raw"""
     _figFromChildren(fig::Figure)
 
     Return the figure object
@@ -198,7 +198,7 @@ _figFromChildren(children) = _figFromChildren(children.parent)
 """
 _figFromChildren(fig::Figure) = fig
 
-@doc raw"""
+raw"""
     _figFromChildren(::Nothing)
 
     Throw an error if no figure has been found.

--- a/ext/QuantumToolboxCairoMakieExt.jl
+++ b/ext/QuantumToolboxCairoMakieExt.jl
@@ -24,8 +24,8 @@ Note that CairoMakie must first be imported before using this function.
 # Arguments
 - `library::Val{:CairoMakie}`: The plotting library to use.
 - `state::QuantumObject`: The quantum state for which the Wigner function is calculated. It can be either a [`KetQuantumObject`](@ref), [`BraQuantumObject`](@ref), or [`OperatorQuantumObject`](@ref).
-- `xvec::AbstractVector`: The x-coordinates of the phase space grid. Default is # TODO
-- `yvec::AbstractVector`: The y-coordinates of the phase space grid. Default is # TODO
+- `xvec::AbstractVector`: The x-coordinates of the phase space grid. Defaults to a linear range from -7.5 to 7.5 with 200 points.
+- `yvec::AbstractVector`: The y-coordinates of the phase space grid. Defaults to a linear range from -7.5 to 7.5 with 200 points.
 - `g::Real`: The scaling factor related to the value of ``\hbar`` in the commutation relation ``[x, y] = i \hbar`` via ``\hbar=2/g^2``.
 - `method::WignerSolver`: The method used to calculate the Wigner function. It can be either `WignerLaguerre()` or `WignerClenshaw()`, with `WignerClenshaw()` as default. The `WignerLaguerre` method has the optional `parallel` and `tol` parameters, with default values `true` and `1e-14`, respectively.
 - `projection::Union{Val,Symbol}`: Wheather to plot the Wigner function in 2D or 3D. It can be either `Val(:two_dim)` or `Val(:three_dim)`, with `Val(:two_dim)` as default.
@@ -44,8 +44,8 @@ Note that CairoMakie must first be imported before using this function.
 function QuantumToolbox.plot_wigner(
     library::Val{:CairoMakie},
     state::QuantumObject{<:AbstractArray{T},OpType};
-    xvec::Union{Nothing,AbstractVector} = nothing,
-    yvec::Union{Nothing,AbstractVector} = nothing,
+    xvec::Union{Nothing,AbstractVector} = LinRange(-7.5, 7.5, 200),
+    yvec::Union{Nothing,AbstractVector} = LinRange(-7.5, 7.5, 200),
     g::Real = √2,
     method::WignerSolver = WignerClenshaw(),
     projection::Union{Val,Symbol} = Val(:two_dim),
@@ -138,17 +138,77 @@ function _plot_wigner(
     return fig, ax, surf
 end
 
+@doc raw"""
+    _getFigAndLocation(location::Nothing)
+    
+    Create a new figure and return it, together with the GridPosition object pointing to the first cell.
+
+    # Arguments
+    - `location::Nothing`
+
+    # Returns
+    - `fig`: The figure object.
+    - `location`: The GridPosition object pointing to the first cell.
+"""
 function _getFigAndLocation(location::Nothing)
     fig = Figure()
     return fig, fig[1, 1]
 end
+
+@doc raw"""
+    _getFigAndLocation(location::GridPosition)
+    
+    Compute which figure does the location belong to and return it, together with the location itself.
+
+    # Arguments
+    - `location::GridPosition`
+
+    # Returns
+    - `fig`: The figure object.
+    - `location`: The GridPosition object.
+"""
 function _getFigAndLocation(location::GridPosition)
     fig = _figFromChildren(location.layout)
     return fig, location
 end
 
+@doc raw"""
+    _figFromChildren(children::GridLayout)
+
+    Recursively find the figure object from the children layout.
+
+    # Arguments
+    - `children::GridLayout`
+
+    # Returns
+    - Union{Nothing, Figure, GridLayout}: The children's parent object.
+"""
 _figFromChildren(children) = _figFromChildren(children.parent)
+
+@doc raw"""
+    _figFromChildren(fig::Figure)
+
+    Return the figure object
+
+    # Arguments
+    - `fig::Figure`
+
+    # Returns
+    - `fig`: The figure object.
+"""
 _figFromChildren(fig::Figure) = fig
+
+@doc raw"""
+    _figFromChildren(::Nothing)
+
+    Throw an error if no figure has been found.
+
+    # Arguments
+    - `::Nothing`
+
+    # Throws
+    - `ArgumentError`: If no figure has been found.
+"""
 _figFromChildren(::Nothing) = throw(ArgumentError("No Figure has been found at the top of the layout hierarchy."))
 
 end

--- a/ext/QuantumToolboxCairoMakieExt.jl
+++ b/ext/QuantumToolboxCairoMakieExt.jl
@@ -1,0 +1,127 @@
+module QuantumToolboxCairoMakieExt
+
+using QuantumToolbox
+using CairoMakie
+
+function QuantumToolbox.plot_wigner(
+    library::Val{:CairoMakie},
+    state::QuantumObject{<:AbstractArray{T},OpType},
+    xvec::Union{Nothing,AbstractVector} = nothing,
+    yvec::Union{Nothing,AbstractVector} = nothing;
+    g::Real = √2,
+    method::WignerSolver = WignerClenshaw(),
+    projection::String = "2d",
+    fig::Union{Figure,Nothing} = nothing,
+    ax::Union{Axis,Nothing} = nothing,
+    colorbar::Bool = false,
+    kwargs...,
+) where {T,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}}
+    projection == "2d" || projection == "3d" || throw(ArgumentError("Unsupported projection: $projection"))
+
+    return _plot_wigner(
+        library,
+        state,
+        xvec,
+        yvec,
+        Val(Symbol(projection)),
+        g,
+        method,
+        fig,
+        ax,
+        colorbar;
+        kwargs...
+    )
+end
+
+function _plot_wigner(
+    ::Val{:CairoMakie},
+    state::QuantumObject{<:AbstractArray{T},OpType},
+    xvec::AbstractVector,
+    yvec::AbstractVector,
+    projection::Val{Symbol("2d")},
+    g::Real,
+    method::WignerSolver,
+    fig::Union{Figure,Nothing},
+    ax::Union{Axis,Nothing},
+    colorbar::Bool;
+    kwargs...,
+) where {T,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}}
+    fig, ax = _getFigAx(fig, ax)
+
+    gridPos = _gridPosFromAx(ax)
+    CairoMakie.delete!(ax)
+
+    lyt = GridLayout(gridPos)
+    ax = Axis(lyt[1, 1])
+
+    wig = wigner(state, xvec, yvec; g = g, method = method)
+    wlim = maximum(abs, wig)
+
+    kwargs = merge(Dict(:colormap => :RdBu, :colorrange => (-wlim, wlim)), kwargs)
+    hm = heatmap!(ax, xvec, yvec, wig; kwargs...)
+
+    if colorbar
+        Colorbar(lyt[1, 2], hm)
+    end
+
+    ax.xlabel = L"\Re(\alpha)"
+    ax.ylabel = L"\Im(\alpha)"
+    return fig, ax, hm
+end
+
+function _plot_wigner(
+    ::Val{:CairoMakie},
+    state::QuantumObject{<:AbstractArray{T},OpType},
+    xvec::AbstractVector,
+    yvec::AbstractVector,
+    projection::Val{Symbol("3d")},
+    g::Real,
+    method::WignerSolver,
+    fig::Union{Figure,Nothing},
+    ax::Union{Axis,Nothing},
+    colorbar::Bool;
+    kwargs...,
+) where {T,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}}
+    fig, ax = _getFigAx(fig, ax)
+
+    gridPos = _gridPosFromAx(ax)
+    CairoMakie.delete!(ax)
+
+    lyt = GridLayout(gridPos)
+    ax = Axis3(lyt[1, 1], azimuth = 1.775pi, elevation = pi / 16, protrusions = (30, 90, 30, 30), viewmode = :stretch)
+
+    wig = wigner(state, xvec, yvec; g = g, method = method)
+    wlim = maximum(abs, wig)
+
+    kwargs = merge(Dict(:colormap => :RdBu, :colorrange => (-wlim, wlim)), kwargs)
+    surf = surface!(ax, xvec, yvec, wig; kwargs...)
+
+    if colorbar
+        Colorbar(lyt[1, 2], surf)
+    end
+
+    ax.xlabel = L"\Re(\alpha)"
+    ax.ylabel = L"\Im(\alpha)"
+    ax.zlabel = "Wigner function"
+    return fig, ax, surf
+end
+
+_getFigAx(fig::Figure, ax::Axis) = fig, ax
+_getFigAx(fig::Figure, ::Nothing) = fig, Axis(fig[1, 1])
+_getFigAx(::Nothing, ax::Axis) = _figFromChildren(ax), ax
+function _getFigAx(::Nothing, ::Nothing)
+    fig = Figure()
+    ax = Axis(fig[1, 1])
+    return fig, ax
+end
+
+_figFromChildren(children) = _figFromChildren(children.parent)
+_figFromChildren(fig::Figure) = fig
+
+function _gridPosFromAx(ax::Axis)
+    content = CairoMakie.Makie.GridLayoutBase.gridcontent(ax)
+    gl, sp, si = content.parent, content.span, content.side
+    return GridPosition(gl, sp, si)
+end
+
+end

--- a/ext/QuantumToolboxCairoMakieExt.jl
+++ b/ext/QuantumToolboxCairoMakieExt.jl
@@ -17,13 +17,11 @@ using CairoMakie
         kwargs...
     ) where {DT,OpType}
 
-Plot the [Wigner quasipropability distribution](https://en.wikipedia.org/wiki/Wigner_quasiprobability_distribution) of `state` using the [CairoMakie](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie) plotting library.
-
-Note that CairoMakie must first be imported before using this function.
+Plot the [Wigner quasipropability distribution](https://en.wikipedia.org/wiki/Wigner_quasiprobability_distribution) of `state` using the [`CairoMakie`](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie) plotting library.
 
 # Arguments
 - `library::Val{:CairoMakie}`: The plotting library to use.
-- `state::QuantumObject`: The quantum state for which the Wigner function is calculated. It can be either a [`KetQuantumObject`](@ref), [`BraQuantumObject`](@ref), or [`OperatorQuantumObject`](@ref).
+- `state::QuantumObject`: The quantum state for which the Wigner function is calculated. It can be either a [`Ket`](@ref), [`Bra`](@ref), or [`Operator`](@ref).
 - `xvec::AbstractVector`: The x-coordinates of the phase space grid. Defaults to a linear range from -7.5 to 7.5 with 200 points.
 - `yvec::AbstractVector`: The y-coordinates of the phase space grid. Defaults to a linear range from -7.5 to 7.5 with 200 points.
 - `g::Real`: The scaling factor related to the value of ``\hbar`` in the commutation relation ``[x, y] = i \hbar`` via ``\hbar=2/g^2``.
@@ -37,6 +35,9 @@ Note that CairoMakie must first be imported before using this function.
 - `fig`: The figure object.
 - `ax`: The axis object.
 - `hm`: Either the heatmap or surface object, depending on the projection.
+
+!!! note "Import library first"
+    [`CairoMakie`](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie) must first be imported before using this function.
 
 !!! warning "Beware of type-stability!"
     If you want to keep type stability, it is recommended to use `Val(:two_dim)` and `Val(:three_dim)` instead of `:two_dim` and `:three_dim`, respectively. Also, specify the library as `Val(:CairoMakie)` See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.

--- a/ext/QuantumToolboxCairoMakieExt.jl
+++ b/ext/QuantumToolboxCairoMakieExt.jl
@@ -1,7 +1,7 @@
 module QuantumToolboxCairoMakieExt
 
 using QuantumToolbox
-using CairoMakie
+using CairoMakie: Axis, Axis3, Colorbar, Figure, GridLayout, heatmap!, surface!, GridPosition, @L_str, Reverse
 
 @doc raw"""
     plot_wigner(
@@ -100,8 +100,8 @@ function _plot_wigner(
         Colorbar(lyt[1, 2], hm)
     end
 
-    ax.xlabel = L"\Re(\alpha)"
-    ax.ylabel = L"\Im(\alpha)"
+    ax.xlabel = L"\textrm{Re}(\alpha)"
+    ax.ylabel = L"\textrm{Im}(\alpha)"
     return fig, ax, hm
 end
 
@@ -133,8 +133,8 @@ function _plot_wigner(
         Colorbar(lyt[1, 2], surf)
     end
 
-    ax.xlabel = L"\Re(\alpha)"
-    ax.ylabel = L"\Im(\alpha)"
+    ax.xlabel = L"\textrm{Re}(\alpha)"
+    ax.ylabel = L"\textrm{Im}(\alpha)"
     ax.zlabel = "Wigner function"
     return fig, ax, surf
 end

--- a/src/QuantumToolbox.jl
+++ b/src/QuantumToolbox.jl
@@ -114,6 +114,7 @@ include("arnoldi.jl")
 include("metrics.jl")
 include("negativity.jl")
 include("steadystate.jl")
+include("visualization.jl")
 
 # deprecated functions
 include("deprecated.jl")

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,5 +1,21 @@
 export plot_wigner
 
+@doc raw"""
+    plot_wigner(
+        state::QuantumObject{<:AbstractArray{T},OpType}; 
+        library::Union{Val,Symbol}=Val(:CairoMakie), 
+        kwargs...
+    )
+
+Plot the [Wigner quasipropability distribution](https://en.wikipedia.org/wiki/Wigner_quasiprobability_distribution) of `state` using the [`wigner`](@ref) function. 
+    
+The `library` keyword argument specifies the plotting library to use, defaulting to `CairoMakie`. Note that plotting libraries must first be imported before using them with this function.
+
+# Arguments
+- `state::QuantumObject{<:AbstractArray{T},OpType}`: The quantum state for which to plot the Wigner distribution.
+- `library::Union{Val,Symbol}`: The plotting library to use. Default is `Val(:CairoMakie)`.
+- `kwargs...`: Additional keyword arguments to pass to the plotting function. See the documentation for the specific plotting library for more information.
+"""
 plot_wigner(
     state::QuantumObject{<:AbstractArray{T},OpType};
     library::Union{Val,Symbol} = Val(:CairoMakie),

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,5 +1,8 @@
 export plot_wigner
 
-plot_wigner(library::Val{T}, args...; kwargs...) where {T} =
-    throw(ArgumentError("Unsupported visualization library: $(getVal(library))"))
-plot_wigner(library::Symbol, args...; kwargs...) = plot_wigner(Val(library), args...; kwargs...)
+plot_wigner(
+    state::QuantumObject{<:AbstractArray{T},OpType};
+    library::Union{Val,Symbol} = Val(:CairoMakie),
+    kwargs...,
+) where {T,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}} =
+    plot_wigner(makeVal(library), state; kwargs...)

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -15,6 +15,9 @@ The `library` keyword argument specifies the plotting library to use, defaulting
 - `state::QuantumObject{<:AbstractArray{T},OpType}`: The quantum state for which to plot the Wigner distribution.
 - `library::Union{Val,Symbol}`: The plotting library to use. Default is `Val(:CairoMakie)`.
 - `kwargs...`: Additional keyword arguments to pass to the plotting function. See the documentation for the specific plotting library for more information.
+
+!!! warning "Beware of type-stability!"
+    If you want to keep type stability, it is recommended to use `Val(:CairoMakie)` instead of `:CairoMakie` as the plotting library. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
 """
 plot_wigner(
     state::QuantumObject{<:AbstractArray{T},OpType};

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -2,17 +2,17 @@ export plot_wigner
 
 @doc raw"""
     plot_wigner(
-        state::QuantumObject{<:AbstractArray{T},OpType}; 
+        state::QuantumObject{DT,OpType}; 
         library::Union{Val,Symbol}=Val(:CairoMakie), 
         kwargs...
-    )
+    ) where {DT,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}
 
 Plot the [Wigner quasipropability distribution](https://en.wikipedia.org/wiki/Wigner_quasiprobability_distribution) of `state` using the [`wigner`](@ref) function. 
     
 The `library` keyword argument specifies the plotting library to use, defaulting to `CairoMakie`. Note that plotting libraries must first be imported before using them with this function.
 
 # Arguments
-- `state::QuantumObject{<:AbstractArray{T},OpType}`: The quantum state for which to plot the Wigner distribution.
+- `state::QuantumObject{DT,OpType}`: The quantum state for which to plot the Wigner distribution.
 - `library::Union{Val,Symbol}`: The plotting library to use. Default is `Val(:CairoMakie)`.
 - `kwargs...`: Additional keyword arguments to pass to the plotting function. See the documentation for the specific plotting library for more information.
 
@@ -20,17 +20,17 @@ The `library` keyword argument specifies the plotting library to use, defaulting
     If you want to keep type stability, it is recommended to use `Val(:CairoMakie)` instead of `:CairoMakie` as the plotting library. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
 """
 plot_wigner(
-    state::QuantumObject{<:AbstractArray{T},OpType};
+    state::QuantumObject{DT,OpType};
     library::Union{Val,Symbol} = Val(:CairoMakie),
     kwargs...,
-) where {T,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}} =
+) where {DT,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}} =
     plot_wigner(makeVal(library), state; kwargs...)
 
 plot_wigner(
     ::Val{T},
-    state::QuantumObject{<:AbstractArray{T1},OpType};
+    state::QuantumObject{DT,OpType};
     kwargs...,
-) where {T,T1,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}} = throw(
+) where {T,DT,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}} = throw(
     ArgumentError(
         "The specified plotting library $T is not available. Try running `using $T` first.",
     ),

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -25,3 +25,13 @@ plot_wigner(
     kwargs...,
 ) where {T,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}} =
     plot_wigner(makeVal(library), state; kwargs...)
+
+plot_wigner(
+    ::Val{T},
+    state::QuantumObject{<:AbstractArray{T1},OpType};
+    kwargs...,
+) where {T,T1,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}} = throw(
+    ArgumentError(
+        "The specified plotting library $T is not available. Try running `using $T` first.",
+    ),
+)

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -9,12 +9,15 @@ export plot_wigner
 
 Plot the [Wigner quasipropability distribution](https://en.wikipedia.org/wiki/Wigner_quasiprobability_distribution) of `state` using the [`wigner`](@ref) function. 
     
-The `library` keyword argument specifies the plotting library to use, defaulting to `CairoMakie`. Note that plotting libraries must first be imported before using them with this function.
+The `library` keyword argument specifies the plotting library to use, defaulting to [`CairoMakie`](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie). 
 
 # Arguments
 - `state::QuantumObject{DT,OpType}`: The quantum state for which to plot the Wigner distribution.
 - `library::Union{Val,Symbol}`: The plotting library to use. Default is `Val(:CairoMakie)`.
 - `kwargs...`: Additional keyword arguments to pass to the plotting function. See the documentation for the specific plotting library for more information.
+
+!!! note "Import library first"
+    The plotting libraries must first be imported before using them with this function.
 
 !!! warning "Beware of type-stability!"
     If you want to keep type stability, it is recommended to use `Val(:CairoMakie)` instead of `:CairoMakie` as the plotting library. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,0 +1,5 @@
+export plot_wigner
+
+plot_wigner(library::Val{T}, args...; kwargs...) where {T} =
+    throw(ArgumentError("Unsupported visualization library: $(getVal(library))"))
+plot_wigner(library::Symbol, args...; kwargs...) = plot_wigner(Val(library), args...; kwargs...)

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -30,8 +30,5 @@ plot_wigner(
     ::Val{T},
     state::QuantumObject{DT,OpType};
     kwargs...,
-) where {T,DT,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}} = throw(
-    ArgumentError(
-        "The specified plotting library $T is not available. Try running `using $T` first.",
-    ),
-)
+) where {T,DT,OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}} =
+    throw(ArgumentError("The specified plotting library $T is not available. Try running `using $T` first."))

--- a/test/ext-test/cairomakie/cairomakie_ext.jl
+++ b/test/ext-test/cairomakie/cairomakie_ext.jl
@@ -2,7 +2,7 @@
     ψ = normalize(coherent(50, 5.0) + coherent(50, -5.0))
     xvec = yvec = -15.0:0.1:15.0
     wig = wigner(ψ, xvec, yvec)'
-    
+
     @test_throws ArgumentError plot_wigner(ψ; library = :CairoMakie, xvec = xvec, yvec = yvec)
 
     using CairoMakie

--- a/test/ext-test/cairomakie/cairomakie_ext.jl
+++ b/test/ext-test/cairomakie/cairomakie_ext.jl
@@ -1,0 +1,63 @@
+@testset "CairoMakie Extension" verbose = true begin
+    ψ = normalize(coherent(50, 5.0) + coherent(50, -5.0))
+    xvec = yvec = -15.0:0.1:15.0
+    wig = wigner(ψ, xvec, yvec)'
+    
+    @test_throws ArgumentError plot_wigner(ψ; library = :CairoMakie, xvec = xvec, yvec = yvec)
+
+    using CairoMakie
+
+    fig, ax, hm = plot_wigner(
+        ψ;
+        library = Val(:CairoMakie),
+        xvec = xvec,
+        yvec = yvec,
+        projection = Val(:two_dim),
+        colorbar = true,
+    )
+    @test fig isa Figure
+    @test ax isa Axis
+    @test hm isa Heatmap
+    @test all(isapprox.(hm[3].val, wig, atol = 1e-6))
+
+    fig, ax, surf = plot_wigner(
+        ψ;
+        library = Val(:CairoMakie),
+        xvec = xvec,
+        yvec = yvec,
+        projection = Val(:three_dim),
+        colorbar = true,
+    )
+    @test fig isa Figure
+    @test ax isa Axis3
+    @test surf isa Surface
+    @test all(isapprox.(surf[3].val, wig, atol = 1e-6))
+
+    fig = Figure()
+    pos = fig[2, 3]
+    fig1, ax, hm = plot_wigner(
+        ψ;
+        library = Val(:CairoMakie),
+        xvec = xvec,
+        yvec = yvec,
+        projection = Val(:two_dim),
+        colorbar = true,
+        location = pos,
+    )
+    @test fig1 === fig
+    @test fig[2, 3].layout.content[1].content[1, 1].layout.content[1].content === ax
+
+    fig = Figure()
+    pos = fig[2, 3]
+    fig1, ax, surf = plot_wigner(
+        ψ;
+        library = Val(:CairoMakie),
+        xvec = xvec,
+        yvec = yvec,
+        projection = Val(:three_dim),
+        colorbar = true,
+        location = pos,
+    )
+    @test fig1 === fig
+    @test fig[2, 3].layout.content[1].content[1, 1].layout.content[1].content === ax
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,9 +26,7 @@ core_tests = [
     "wigner.jl",
 ]
 
-ext_tests = [
-    joinpath("cairomakie", "cairomakie_ext.jl"),
-]
+ext_tests = [joinpath("cairomakie", "cairomakie_ext.jl")]
 
 if (GROUP == "All") || (GROUP == "Code-Quality")
     using QuantumToolbox

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,10 @@ core_tests = [
     "wigner.jl",
 ]
 
+ext_tests = [
+    joinpath("cairomakie", "cairomakie_ext.jl"),
+]
+
 if (GROUP == "All") || (GROUP == "Code-Quality")
     using QuantumToolbox
     using Aqua, JET
@@ -43,6 +47,10 @@ if (GROUP == "All") || (GROUP == "Core")
 
     for test in core_tests
         include(joinpath(testdir, "core-test", test))
+    end
+
+    for test in ext_tests
+        include(joinpath(testdir, "ext-test", test))
     end
 end
 


### PR DESCRIPTION
## Checklist
- [x] Please read [Contributor Covenant Code of Conduct](https://github.com/qutip/QuantumToolbox.jl/blob/main/CODE_OF_CONDUCT.md)
- [x] Any code changes were done in a way that does not break public API
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running `make docs`.

## Description
This PR introduces plotting capabilities in QuantumToolbox (starting from the `plot_wigner` function implemented in QuTip). 
To reduce the impact on loading time, I wrote an extension for the CairoMakie library, such that the necessary code is not loaded by default. Moreover, this allows extending the scheme to additional plotting libraries like PyPlot or Plots (although I haven't done it).

The `plot_wigner` function implements 2D and 3D projections of the Wigner and reproduces QuTip's output as faithfully as possible.

## Related issues or PRs
fix #86 
