### PR TITLE
Bump version to `v0.21.5`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *__We will start to write changelog once we have the first standard release.__*
 
+## [v0.21.5] (2024-11-15)
+
+- This is a demonstration of how to bump version number and also modify `CHANGELOG.md` before new release. ([#309])
+
 ## [v0.21.4] (2024-11-13)
 
 - This is just a demonstration about [`Changelog.jl`](https://github.com/JuliaDocs/Changelog.jl). ([#139], [#306])
@@ -19,3 +23,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.21.4]: https://github.com/qutip/QuantumToolbox.jl/releases/tag/v0.21.4
 [#139]: https://github.com/qutip/QuantumToolbox.jl/issues/139
 [#306]: https://github.com/qutip/QuantumToolbox.jl/issues/306
+[#309]: https://github.com/qutip/QuantumToolbox.jl/issues/309

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumToolbox"
 uuid = "6c2fb7c5-b903-41d2-bc5e-5a7c320b9fab"
 authors = ["Alberto Mercurio", "Yi-Te Huang"]
-version = "0.21.4"
+version = "0.21.5"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
## Description
As title, this PR is also a demonstration of bumping version number together with updating `CHANGELOG.md` before a new release.