### PR TITLE
Change SingleSiteOperator with MultiSiteOperator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Change `SingleSiteOperator` with the more general `MultiSiteOperator`. ([#324])
+
 ## [v0.22.0] (2024-11-20)
 
 - Change the parameters structure of `sesolve`, `mesolve` and `mcsolve` functions to possibly support automatic differentiation. ([#311])
@@ -33,3 +35,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#311]: https://github.com/qutip/QuantumToolbox.jl/issues/311
 [#315]: https://github.com/qutip/QuantumToolbox.jl/issues/315
 [#318]: https://github.com/qutip/QuantumToolbox.jl/issues/318
+[#324]: https://github.com/qutip/QuantumToolbox.jl/issues/324

--- a/docs/src/resources/api.md
+++ b/docs/src/resources/api.md
@@ -248,7 +248,7 @@ fidelity
 
 ```@docs
 Lattice
-SingleSiteOperator
+MultiSiteOperator
 DissipativeIsing
 ```
 

--- a/docs/src/tutorials/cluster.md
+++ b/docs/src/tutorials/cluster.md
@@ -11,7 +11,7 @@ We will consider two examples:
 
 ### Monte Carlo Quantum Trajectories
 
-Let's consider a 2-dimensional transferse field Ising model with 4x3 spins. The Hamiltonian is given by
+Let's consider a 2-dimensional transverse field Ising model with 4x3 spins. The Hamiltonian is given by
 
 ```math
 \hat{H} = \frac{J_z}{2} \sum_{\langle i,j \rangle} \hat{\sigma}_i^z \hat{\sigma}_j^z + h_x \sum_i \hat{\sigma}_i^x \, ,
@@ -91,9 +91,9 @@ hy = 0.0
 hz = 0.0
 γ = 1
 
-Sx = mapreduce(i->SingleSiteOperator(sigmax(), i, latt), +, 1:latt.N)
-Sy = mapreduce(i->SingleSiteOperator(sigmay(), i, latt), +, 1:latt.N)
-Sz = mapreduce(i->SingleSiteOperator(sigmaz(), i, latt), +, 1:latt.N)
+Sx = mapreduce(i -> MultiSiteOperator(latt, i=>sigmax()), +, 1:latt.N)
+Sy = mapreduce(i -> MultiSiteOperator(latt, i=>sigmay()), +, 1:latt.N)
+Sz = mapreduce(i -> MultiSiteOperator(latt, i=>sigmaz()), +, 1:latt.N)
 
 H, c_ops = DissipativeIsing(Jx, Jy, Jz, hx, hy, hz, γ, latt; boundary_condition = Val(:periodic_bc), order = 1)
 e_ops = [Sx, Sy, Sz]

--- a/docs/src/tutorials/lowrank.md
+++ b/docs/src/tutorials/lowrank.md
@@ -47,12 +47,12 @@ Define lr states. Take as initial state all spins up. All other N states are tak
 i = 1
 for j in 1:N_modes
     global i += 1
-    i <= M && (ϕ[i] = SingleSiteOperator(sigmap(), j, latt) * ϕ[1])
+    i <= M && (ϕ[i] = MultiSiteOperator(latt, j=>sigmap()) * ϕ[1])
 end
 for k in 1:N_modes-1
     for l in k+1:N_modes
         global i += 1
-        i <= M && (ϕ[i] = SingleSiteOperator(sigmap(), k, latt) * SingleSiteOperator(sigmap(), l, latt) * ϕ[1])
+        i <= M && (ϕ[i] = MultiSiteOperator(latt, k=>sigmap(), l=>sigmap()) * ϕ[1])
     end
 end
 for i in i+1:M
@@ -85,9 +85,9 @@ hy = 0.0
 hz = 0.0
 γ = 1
 
-Sx = mapreduce(i->SingleSiteOperator(sigmax(), i, latt), +, 1:latt.N)
-Sy = mapreduce(i->SingleSiteOperator(sigmay(), i, latt), +, 1:latt.N)
-Sz = mapreduce(i->SingleSiteOperator(sigmaz(), i, latt), +, 1:latt.N)
+Sx = mapreduce(i->MultiSiteOperator(latt, i=>sigmax()), +, 1:latt.N)
+Sy = mapreduce(i->MultiSiteOperator(latt, i=>sigmay()), +, 1:latt.N)
+Sz = mapreduce(i->MultiSiteOperator(latt, i=>sigmaz()), +, 1:latt.N)
 
 H, c_ops = DissipativeIsing(Jx, Jy, Jz, hx, hy, hz, γ, latt; boundary_condition = Val(:periodic_bc), order = 1)
 e_ops = (Sx, Sy, Sz)

--- a/test/core-test/low_rank_dynamics.jl
+++ b/test/core-test/low_rank_dynamics.jl
@@ -15,12 +15,12 @@
     i = 1
     for j in 1:N_modes
         i += 1
-        i <= M && (ϕ[i] = SingleSiteOperator(sigmap(), j, latt) * ϕ[1])
+        i <= M && (ϕ[i] = MultiSiteOperator(latt, j => sigmap()) * ϕ[1])
     end
     for k in 1:N_modes-1
         for l in k+1:N_modes
             i += 1
-            i <= M && (ϕ[i] = SingleSiteOperator(sigmap(), k, latt) * SingleSiteOperator(sigmap(), l, latt) * ϕ[1])
+            i <= M && (ϕ[i] = MultiSiteOperator(latt, k => sigmap(), l => sigmap()) * ϕ[1])
         end
     end
     for i in i+1:M
@@ -43,11 +43,11 @@
     hz = 0.0
     γ = 1
 
-    Sx = mapreduce(i -> SingleSiteOperator(sigmax(), i, latt), +, 1:latt.N)
-    Sy = mapreduce(i -> SingleSiteOperator(sigmay(), i, latt), +, 1:latt.N)
-    Sz = mapreduce(i -> SingleSiteOperator(sigmaz(), i, latt), +, 1:latt.N)
+    Sx = mapreduce(i -> MultiSiteOperator(latt, i => sigmax()), +, 1:latt.N)
+    Sy = mapreduce(i -> MultiSiteOperator(latt, i => sigmay()), +, 1:latt.N)
+    Sz = mapreduce(i -> MultiSiteOperator(latt, i => sigmaz()), +, 1:latt.N)
     SFxx = mapreduce(
-        x -> SingleSiteOperator(sigmax(), x[1], latt) * SingleSiteOperator(sigmax(), x[2], latt),
+        x -> MultiSiteOperator(latt, x[1] => sigmax(), x[2] => sigmax()),
         +,
         Iterators.product(1:latt.N, 1:latt.N),
     )


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to QuantumToolbox.jl](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Here I change the `SingleSiteOperator` with a more general one `MultiSiteOperator`, allowing to generate an arbitrary product operator of a multipartite system.

## Related issues or PRs
This PR fixes #322.
