### PR TITLE
Fix release date format in `CHANGELOG`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,25 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-## [v0.23.1] (2024-12-06)
+## [v0.23.1]
+Release date: 2024-12-06
 
 - Update `[compat]` to fix the incompatibility between `QuantumToolbox v0.22.0+` and `DiffEqCallbacks < v4.2.1`. ([#335])
 
-## [v0.23.0] (2024-12-04)
+## [v0.23.0]
+Release date: 2024-12-04
 
 - Change `SingleSiteOperator` with the more general `MultiSiteOperator`. ([#324])
 - Make `spectrum` and `correlation` functions align with `Python QuTiP`, introduce spectrum solver `PseudoInverse`, remove spectrum solver `FFTCorrelation`, and introduce `spectrum_correlation_fft`. ([#330])
 
-## [v0.22.0] (2024-11-20)
+## [v0.22.0]
+Release date: 2024-11-20
 
 - Change the parameters structure of `sesolve`, `mesolve` and `mcsolve` functions to possibly support automatic differentiation. ([#311])
 - Fix type instability and reduce extra memory allocation in `liouvillian`. ([#315], [#318])
 
-## [v0.21.5] (2024-11-15)
+## [v0.21.5]
+Release date: 2024-11-15
 
 - This is a demonstration of how to bump version number and also modify `CHANGELOG.md` before new release. ([#309])
 
-## [v0.21.4] (2024-11-13)
+## [v0.21.4]
+Release date: 2024-11-13
 
 - This is just a demonstration about [`Changelog.jl`](https://github.com/JuliaDocs/Changelog.jl). ([#139], [#306])
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,8 @@ using Changelog
 
 DocMeta.setdocmeta!(QuantumToolbox, :DocTestSetup, :(using QuantumToolbox); recursive = true)
 
-const DRAFT = false # set `true` to disable cell evaluation
+const DRAFT = false  # set `true`  to disable cell evaluation
+const DOCTEST = true # set `false` to skip doc tests
 
 # generate bibliography
 bib = CitationBibliography(
@@ -83,6 +84,7 @@ makedocs(;
         repo = "github.com/qutip/QuantumToolbox.jl",
     ),
     draft = DRAFT,
+    doctest = DOCTEST,
     plugins = [bib],
 )
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,7 @@ using Changelog
 
 DocMeta.setdocmeta!(QuantumToolbox, :DocTestSetup, :(using QuantumToolbox); recursive = true)
 
+# some options for `makedocs`
 const DRAFT = false  # set `true`  to disable cell evaluation
 const DOCTEST = true # set `false` to skip doc tests
 


### PR DESCRIPTION
## Description
The documentation Changelog page's each release tag is broken. This PR will fix it.