### PR TITLE
Improve the construction of `QobjEvo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
-
+- Improve the construction of `QobjEvo` ([#338], [#339]):
+    - add new methods to generate `QobjEvo` with input type `Tuple{QuantumObject,Function}`.
+    - add argument checks for each coefficient `Function`.
 
 ## [v0.23.1]
 Release date: 2024-12-06
@@ -53,3 +55,5 @@ Release date: 2024-11-13
 [#324]: https://github.com/qutip/QuantumToolbox.jl/issues/324
 [#330]: https://github.com/qutip/QuantumToolbox.jl/issues/330
 [#335]: https://github.com/qutip/QuantumToolbox.jl/issues/335
+[#338]: https://github.com/qutip/QuantumToolbox.jl/issues/338
+[#339]: https://github.com/qutip/QuantumToolbox.jl/issues/339

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
-- Improve the construction of `QobjEvo` ([#338], [#339]):
-    - add new methods to generate `QobjEvo` with input type `Tuple{QuantumObject,Function}`.
-    - add argument checks for each coefficient `Function`.
+- Improve the construction of `QobjEvo`. ([#338], [#339])
 
 ## [v0.23.1]
 Release date: 2024-12-06

--- a/src/qobj/quantum_object_evo.jl
+++ b/src/qobj/quantum_object_evo.jl
@@ -181,11 +181,18 @@ function QuantumObjectEvolution(
 end
 
 # this is a extra method if user accidentally specify `QuantumObjectEvolution( (op, func) )` or `QuantumObjectEvolution( ((op, func)) )`
-QuantumObjectEvolution(op_func::Tuple{QuantumObject,Function}, α::Union{Nothing,Number} = nothing; type::Union{Nothing,QuantumObjectType} = nothing) =
-    QuantumObjectEvolution((op_func,), α; type = type)
+QuantumObjectEvolution(
+    op_func::Tuple{QuantumObject,Function},
+    α::Union{Nothing,Number} = nothing;
+    type::Union{Nothing,QuantumObjectType} = nothing,
+) = QuantumObjectEvolution((op_func,), α; type = type)
 
-QuantumObjectEvolution(op::QuantumObject, f::Function, α::Union{Nothing,Number} = nothing; type::Union{Nothing,QuantumObjectType} = nothing) =
-    QuantumObjectEvolution(((op, f),), α; type = type)
+QuantumObjectEvolution(
+    op::QuantumObject,
+    f::Function,
+    α::Union{Nothing,Number} = nothing;
+    type::Union{Nothing,QuantumObjectType} = nothing,
+) = QuantumObjectEvolution(((op, f),), α; type = type)
 
 function QuantumObjectEvolution(
     op::QuantumObject,
@@ -281,7 +288,11 @@ Parse the `op_func_list` and generate the data for the `QuantumObjectEvolution` 
         # check if each func accepts 2 arguments
         func_methods = tuple($(func_methods_expr...))
         for f_method in func_methods
-            length(f_method.ms) == 0 && throw(ArgumentError("The following function must accept two arguments: `$(f_method.mt.name)(p, t)` with t<:Real"))
+            length(f_method.ms) == 0 && throw(
+                ArgumentError(
+                    "The following function must accept two arguments: `$(f_method.mt.name)(p, t)` with t<:Real",
+                ),
+            )
         end
 
         data_expr_const = $qobj_expr_const isa Integer ? $qobj_expr_const : _make_SciMLOperator($qobj_expr_const, α)

--- a/src/time_evolution/sesolve.jl
+++ b/src/time_evolution/sesolve.jl
@@ -2,7 +2,7 @@ export sesolveProblem, sesolve
 
 _sesolve_make_U_QobjEvo(H::QuantumObjectEvolution{<:MatrixOperator}) =
     QobjEvo(MatrixOperator(-1im * H.data.A), dims = H.dims, type = Operator)
-_sesolve_make_U_QobjEvo(H) = QobjEvo(H, -1im)
+_sesolve_make_U_QobjEvo(H::Union{QuantumObjectEvolution,Tuple}) = QobjEvo(H, -1im)
 
 @doc raw"""
     sesolveProblem(

--- a/src/time_evolution/sesolve.jl
+++ b/src/time_evolution/sesolve.jl
@@ -2,6 +2,7 @@ export sesolveProblem, sesolve
 
 _sesolve_make_U_QobjEvo(H::QuantumObjectEvolution{<:MatrixOperator}) =
     QobjEvo(MatrixOperator(-1im * H.data.A), dims = H.dims, type = Operator)
+_sesolve_make_U_QobjEvo(H::QuantumObject) = QobjEvo(MatrixOperator(-1im * H.data), dims = H.dims, type = Operator)
 _sesolve_make_U_QobjEvo(H::Union{QuantumObjectEvolution,Tuple}) = QobjEvo(H, -1im)
 
 @doc raw"""

--- a/test/core-test/quantum_objects_evo.jl
+++ b/test/core-test/quantum_objects_evo.jl
@@ -182,6 +182,7 @@
         @test isconstant(H_td) == false
         @test isconstant(QobjEvo(a)) == true
         @test isoper(H_td) == true
+        @test QobjEvo(a, coef1) == QobjEvo((a, coef1))
 
         # SuperOperator
         X = a * a'
@@ -205,7 +206,9 @@
         @test isconstant(L_td) == false
         @test issuper(L_td) == true
 
+        coef_wrong(t) = exp(-t)
         @test_logs (:warn,) (:warn,) liouvillian(H_td * H_td) # warnings from lazy tensor
+        @test_throws ArgumentError QobjEvo(a, coef_wrong)
         @test_throws MethodError QobjEvo([[a, coef1], a' * a, [a', coef2]])
         @test_throws ArgumentError H_td(ρvec, p, t)
         @test_throws ArgumentError cache_operator(H_td, ρvec)

--- a/test/core-test/quantum_objects_evo.jl
+++ b/test/core-test/quantum_objects_evo.jl
@@ -119,15 +119,23 @@
               "Quantum Object Evo.:   type=SuperOperator   dims=$L_dims   size=$L_size   ishermitian=$L_isherm   isconstant=$L_isconst\n$datastring"
     end
 
-    @testset "Type Inference (QuantumObject)" begin
+    @testset "Type Inference (QobjEvo)" begin
+        N = 4
         for T in [ComplexF32, ComplexF64]
-            N = 4
             a = MatrixOperator(rand(T, N, N))
             @inferred QobjEvo(a)
             for type in [Operator, SuperOperator]
                 @inferred QobjEvo(a, type = type)
             end
         end
+
+        a = destroy(N)
+        coef1(p, t) = exp(-t)
+        coef2(p::Vector, t) = sin(p[1] * t)
+        coef3(p::NamedTuple, t) = cos(p.ω * t)
+        @inferred QobjEvo(a, coef1)
+        @inferred QobjEvo((a', coef2))
+        @inferred QobjEvo((a' * a, (a, coef1), (a', coef2), (a + a', coef3)))
 
         @testset "Math Operation" begin
             a = QobjEvo(destroy(20))
@@ -206,9 +214,11 @@
         @test isconstant(L_td) == false
         @test issuper(L_td) == true
 
-        coef_wrong(t) = exp(-t)
+        coef_wrong1(t) = nothing
+        coef_wrong2(p, t::ComplexF64) = nothing
         @test_logs (:warn,) (:warn,) liouvillian(H_td * H_td) # warnings from lazy tensor
-        @test_throws ArgumentError QobjEvo(a, coef_wrong)
+        @test_throws ArgumentError QobjEvo(a, coef_wrong1)
+        @test_throws ArgumentError QobjEvo(a, coef_wrong2)
         @test_throws MethodError QobjEvo([[a, coef1], a' * a, [a', coef2]])
         @test_throws ArgumentError H_td(ρvec, p, t)
         @test_throws ArgumentError cache_operator(H_td, ρvec)


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to QuantumToolbox.jl](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Summary of this PR:
- add new methods to generate `QobjEvo` with input type `Tuple{QuantumObject,Function}`.
- add argument checks for each coefficient `Function` by using `Base.methods`.

## Related issues or PRs
close #338