### PR TITLE
Support `zero` and `one` for `AbstractQuantumObject`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
 - Improve the construction of `QobjEvo`. ([#338], [#339])
+- Support `Base.zero` and `Base.one` for `AbstractQuantumObject`. ([#342], [#346])
 
 ## [v0.23.1]
 Release date: 2024-12-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,3 +56,5 @@ Release date: 2024-11-13
 [#335]: https://github.com/qutip/QuantumToolbox.jl/issues/335
 [#338]: https://github.com/qutip/QuantumToolbox.jl/issues/338
 [#339]: https://github.com/qutip/QuantumToolbox.jl/issues/339
+[#342]: https://github.com/qutip/QuantumToolbox.jl/issues/342
+[#346]: https://github.com/qutip/QuantumToolbox.jl/issues/346

--- a/docs/src/resources/api.md
+++ b/docs/src/resources/api.md
@@ -52,6 +52,8 @@ SciMLOperators.isconstant
 ## [Qobj arithmetic and attributes](@id doc-API:Qobj-arithmetic-and-attributes)
 
 ```@docs
+Base.zero
+Base.one
 Base.conj
 LinearAlgebra.transpose
 LinearAlgebra.adjoint

--- a/docs/src/users_guide/QuantumObject/QuantumObject_functions.md
+++ b/docs/src/users_guide/QuantumObject/QuantumObject_functions.md
@@ -10,6 +10,8 @@ Here is a table that summarizes all the supported linear algebra functions and a
 
 | **Description** | **Function call** | **Synonyms** |
 |:----------------|:------------------|:-------------|
+| zero-like array | [`zero(Q)`](@ref zero) | - |
+| identity-like matrix | [`one(Q)`](@ref one) | - |
 | conjugate | [`conj(Q)`](@ref conj) | - |
 | transpose | [`transpose(Q)`](@ref transpose) | [`trans(Q)`](@ref trans) |
 | conjugate transposition | [`adjoint(Q)`](@ref adjoint) | [`Q'`](@ref adjoint), [`dag(Q)`](@ref dag) |

--- a/src/qobj/arithmetic_and_attributes.jl
+++ b/src/qobj/arithmetic_and_attributes.jl
@@ -157,6 +157,25 @@ function LinearAlgebra.dot(
 end
 
 @doc raw"""
+    zero(A::AbstractQuantumObject)
+
+Return a similar [`AbstractQuantumObject`](@ref) with `dims` and `type` are same as `A`, but `data` is a zero-array.
+"""
+Base.zero(A::AbstractQuantumObject) = get_typename_wrapper(A)(zero(A.data), A.type, A.dims)
+
+@doc raw"""
+    one(A::AbstractQuantumObject)
+
+Return a similar [`AbstractQuantumObject`](@ref) with `dims` and `type` are same as `A`, but `data` is an identity matrix.
+
+Note that `A` must be [`Operator`](@ref) or [`SuperOperator`](@ref).
+"""
+Base.one(
+    A::AbstractQuantumObject{DT,OpType},
+) where {DT,OpType<:Union{OperatorQuantumObject,SuperOperatorQuantumObject}} =
+    get_typename_wrapper(A)(one(A.data), A.type, A.dims)
+
+@doc raw"""
     conj(A::AbstractQuantumObject)
 
 Return the element-wise complex conjugation of the [`AbstractQuantumObject`](@ref).

--- a/test/core-test/quantum_objects.jl
+++ b/test/core-test/quantum_objects.jl
@@ -166,6 +166,14 @@
         @test (a2 + 2).data == a2.data + 2 * I
         @test a2 * 2 == 2 * a2
 
+        zero_like = zero(a2)
+        iden_like = one(a3)
+        zero_array = spzeros(ComplexF64, 100, 100)
+        iden_array = sparse(1:100, 1:100, ones(ComplexF64, 100))
+        @test zero_like == Qobj(zero_array, type = a2.type, dims = a2.dims)
+        @test typeof(zero_like.data) == typeof(zero_array)
+        @test iden_like == Qobj(iden_array, type = a3.type, dims = a3.dims)
+        @test typeof(iden_like.data) == typeof(iden_array)
         @test trans(trans(a2)) == a2
         @test trans(a2).data == transpose(a2.data)
         @test adjoint(a2) ≈ trans(conj(a2))

--- a/test/core-test/quantum_objects_evo.jl
+++ b/test/core-test/quantum_objects_evo.jl
@@ -74,6 +74,14 @@
         @test (a2 + 2).data == a2.data + 2 * I
         @test a2 * 2 == 2 * a2
 
+        zero_like = zero(a2)
+        iden_like = one(a3)
+        zero_array = NullOperator(100)
+        iden_array = IdentityOperator(100)
+        @test zero_like == QobjEvo(zero_array, type = a2.type, dims = a2.dims)
+        @test typeof(zero_like.data) == typeof(zero_array)
+        @test iden_like == QobjEvo(iden_array, type = a3.type, dims = a3.dims)
+        @test typeof(iden_like.data) == typeof(iden_array)
         @test trans(trans(a2)) == a2
         @test trans(a2).data == transpose(a2.data)
         # @test adjoint(a2) ≈ trans(conj(a2)) # Currently doesn't work

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,7 @@ if (GROUP == "All") || (GROUP == "Core")
     using QuantumToolbox
     import QuantumToolbox: position, momentum
     import Random: MersenneTwister
-    import SciMLOperators: MatrixOperator
+    import SciMLOperators: MatrixOperator, NullOperator, IdentityOperator
 
     QuantumToolbox.about()
 


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to QuantumToolbox.jl](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
As title

## Related issues or PRs
close #342 
