### PR TITLE
Add Zulip sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,3 +176,18 @@ Here we provide a brief performance comparison between `QuantumToolbox.jl` and o
 You are most welcome to contribute to `QuantumToolbox.jl` development by forking this repository and sending pull requests (PRs), or filing bug reports at the issues page. You can also help out with users' questions, or discuss proposed changes in the [QuTiP discussion group](https://groups.google.com/g/qutip).
 
 For more information about contribution, including technical advice, please see the [Contributing to QuantumToolbox.jl](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing) section of the documentation.
+
+## Acknowledgements
+
+`QuantumToolbox.jl` is supported by the [Unitary Fund](https://unitary.fund), a grant program for quantum technology projects. We are also grateful to the [Zulip](https://zulip.com) team for providing a free chat service for open-source projects.
+
+<!-- Acknowledgement Logos -->
+<div align="center">
+  <a href="https://unitary.fund">
+    <img src="https://raw.githubusercontent.com/unitaryfund/unitary.fund/refs/heads/main/src/assets/svg/logo.svg" alt="Unitary Fund logo" width="200">
+  </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://zulip.com">
+    <img src="https://zulip.com/static/images/logo/zulip-org-logo.svg" alt="Zulip logo" width="200">
+  </a>
+</div>

--- a/README.md
+++ b/README.md
@@ -179,7 +179,13 @@ For more information about contribution, including technical advice, please see 
 
 ## Acknowledgements
 
-`QuantumToolbox.jl` is supported by the [Unitary Fund](https://unitary.fund), a grant program for quantum technology projects. We are also grateful to the [Zulip](https://zulip.com) team for providing a free chat service for open-source projects.
+### Fundings
+
+`QuantumToolbox.jl` is supported by the [Unitary Fund](https://unitary.fund), a grant program for quantum technology projects.
+
+### Other Acknowledgements
+
+We are also grateful to the [Zulip](https://zulip.com) team for providing a free chat service for open-source projects.
 
 <!-- Acknowledgement Logos -->
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -183,16 +183,17 @@ For more information about contribution, including technical advice, please see 
 
 `QuantumToolbox.jl` is supported by the [Unitary Fund](https://unitary.fund), a grant program for quantum technology projects.
 
-### Other Acknowledgements
-
-We are also grateful to the [Zulip](https://zulip.com) team for providing a free chat service for open-source projects.
-
-<!-- Acknowledgement Logos -->
 <div align="center">
   <a href="https://unitary.fund">
     <img src="https://raw.githubusercontent.com/unitaryfund/unitary.fund/refs/heads/main/src/assets/svg/logo.svg" alt="Unitary Fund logo" width="200">
   </a>
-  &nbsp;&nbsp;&nbsp;&nbsp;
+</div>
+
+### Other Acknowledgements
+
+We are also grateful to the [Zulip](https://zulip.com) team for providing a free chat service for open-source projects.
+
+<div align="center">
   <a href="https://zulip.com">
     <img src="https://zulip.com/static/images/logo/zulip-org-logo.svg" alt="Zulip logo" width="200">
   </a>

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -76,6 +76,7 @@ const PAGES = [
         "Bibliography" => "resources/bibliography.md",
         "ChangeLog" => "resources/changelog.md",
         "Contributing to QuantumToolbox.jl" => "resources/contributing.md",
+        "Acknowledgements" => "resources/acknowledgements.md",
     ],
 ]
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -71,18 +71,3 @@ using QuantumToolbox
 QuantumToolbox.versioninfo()
 QuantumToolbox.about()
 ```
-
-# [Acknowledgements](@id doc:Acknowledgements)
-
-`QuantumToolbox.jl` is supported by the [Unitary Fund](https://unitary.fund), a grant program for quantum technology projects. We are also grateful to the [Zulip](https://zulip.com) team for providing a free chat service for open-source projects.
-
-<!-- Acknowledgement Logos -->
-<div align="center">
-  <a href="https://unitary.fund">
-    <img src="https://raw.githubusercontent.com/unitaryfund/unitary.fund/refs/heads/main/src/assets/svg/logo.svg" alt="Unitary Fund logo" width="200">
-  </a>
-  &nbsp;&nbsp;&nbsp;&nbsp;
-  <a href="https://zulip.com">
-    <img src="https://zulip.com/static/images/logo/zulip-org-logo.svg" alt="Zulip logo" width="200">
-  </a>
-</div>

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -71,3 +71,18 @@ using QuantumToolbox
 QuantumToolbox.versioninfo()
 QuantumToolbox.about()
 ```
+
+# [Acknowledgements](@id doc:Acknowledgements)
+
+`QuantumToolbox.jl` is supported by the [Unitary Fund](https://unitary.fund), a grant program for quantum technology projects. We are also grateful to the [Zulip](https://zulip.com) team for providing a free chat service for open-source projects.
+
+<!-- Acknowledgement Logos -->
+<div align="center">
+  <a href="https://unitary.fund">
+    <img src="https://raw.githubusercontent.com/unitaryfund/unitary.fund/refs/heads/main/src/assets/svg/logo.svg" alt="Unitary Fund logo" width="200">
+  </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://zulip.com">
+    <img src="https://zulip.com/static/images/logo/zulip-org-logo.svg" alt="Zulip logo" width="200">
+  </a>
+</div>

--- a/docs/src/resources/acknowledgements.md
+++ b/docs/src/resources/acknowledgements.md
@@ -1,0 +1,20 @@
+# [Acknowledgements](@id doc:Acknowledgements)
+
+## [Fundings](@id doc:Fundings)
+
+`QuantumToolbox.jl` is supported by the [Unitary Fund](https://unitary.fund), a grant program for quantum technology projects.
+
+## [Other Acknowledgements](@id doc:Other-Acknowledgements)
+
+We are also grateful to the [Zulip](https://zulip.com) team for providing a free chat service for open-source projects.
+
+<!-- Acknowledgement Logos -->
+<div align="center">
+  <a href="https://unitary.fund">
+    <img src="https://raw.githubusercontent.com/unitaryfund/unitary.fund/refs/heads/main/src/assets/svg/logo.svg" alt="Unitary Fund logo" width="200">
+  </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://zulip.com">
+    <img src="https://zulip.com/static/images/logo/zulip-org-logo.svg" alt="Zulip logo" width="200">
+  </a>
+</div>

--- a/docs/src/resources/acknowledgements.md
+++ b/docs/src/resources/acknowledgements.md
@@ -4,16 +4,17 @@
 
 `QuantumToolbox.jl` is supported by the [Unitary Fund](https://unitary.fund), a grant program for quantum technology projects.
 
-## [Other Acknowledgements](@id doc:Other-Acknowledgements)
-
-We are also grateful to the [Zulip](https://zulip.com) team for providing a free chat service for open-source projects.
-
-<!-- Acknowledgement Logos -->
 <div align="center">
   <a href="https://unitary.fund">
     <img src="https://raw.githubusercontent.com/unitaryfund/unitary.fund/refs/heads/main/src/assets/svg/logo.svg" alt="Unitary Fund logo" width="200">
   </a>
-  &nbsp;&nbsp;&nbsp;&nbsp;
+</div>
+
+## [Other Acknowledgements](@id doc:Other-Acknowledgements)
+
+We are also grateful to the [Zulip](https://zulip.com) team for providing a free chat service for open-source projects.
+
+<div align="center">
   <a href="https://zulip.com">
     <img src="https://zulip.com/static/images/logo/zulip-org-logo.svg" alt="Zulip logo" width="200">
   </a>


### PR DESCRIPTION
Zulip has recently approved our request for a free upgrade to the Zulip Cloud Standard subscription. As requested, we are encouraged to acknowledge their sponsorship on our main page.