### PR TITLE
Improve `show` for `Qobj`/`QobjEvo` lists

### DIFF
--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -21,12 +21,14 @@ matrix ``\hat{\rho}``.
 Pure state:
 ```jldoctest
 julia> ψ = fock(2,0)
+
 Quantum Object:   type=Ket   dims=[2]   size=(2,)
 2-element Vector{ComplexF64}:
  1.0 + 0.0im
  0.0 + 0.0im
 
 julia> ρ = ket2dm(ψ)
+
 Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=true
 2×2 Matrix{ComplexF64}:
  1.0+0.0im  0.0+0.0im
@@ -39,6 +41,7 @@ julia> entropy_vn(ρ, base=2)
 Mixed state:
 ```jldoctest
 julia> ρ = maximally_mixed_dm(2)
+
 Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=true
 2×2 Diagonal{ComplexF64, Vector{ComplexF64}}:
  0.5-0.0im      ⋅    

--- a/src/negativity.jl
+++ b/src/negativity.jl
@@ -19,6 +19,7 @@ and ``\Vert \hat{X} \Vert_1=\textrm{Tr}\sqrt{\hat{X}^\dagger \hat{X}}`` is the t
 
 ```jldoctest
 julia> Ψ = bell_state(0, 0)
+
 Quantum Object:   type=Ket   dims=[2, 2]   size=(4,)
 4-element Vector{ComplexF64}:
  0.7071067811865475 + 0.0im
@@ -27,6 +28,7 @@ Quantum Object:   type=Ket   dims=[2, 2]   size=(4,)
  0.7071067811865475 + 0.0im
 
 julia> ρ = ket2dm(Ψ)
+
 Quantum Object:   type=Operator   dims=[2, 2]   size=(4, 4)   ishermitian=true
 4×4 Matrix{ComplexF64}:
  0.5+0.0im  0.0+0.0im  0.0+0.0im  0.5+0.0im

--- a/src/qobj/arithmetic_and_attributes.jl
+++ b/src/qobj/arithmetic_and_attributes.jl
@@ -246,6 +246,7 @@ Note that this function only supports for [`Operator`](@ref) and [`SuperOperator
 
 ```jldoctest
 julia> a = destroy(20)
+
 Quantum Object:   type=Operator   dims=[20]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 19 stored entries:
 ⎡⠈⠢⡀⠀⠀⠀⠀⠀⠀⠀⎤
@@ -286,6 +287,7 @@ Return the standard vector `p`-norm or [Schatten](https://en.wikipedia.org/wiki/
 
 ```jldoctest
 julia> ψ = fock(10, 2)
+
 Quantum Object:   type=Ket   dims=[10]   size=(10,)
 10-element Vector{ComplexF64}:
  0.0 + 0.0im
@@ -510,6 +512,7 @@ Note that this function will always return [`Operator`](@ref). No matter the inp
 Two qubits in the state ``\ket{\psi} = \ket{e,g}``:
 ```jldoctest
 julia> ψ = kron(fock(2,0), fock(2,1))
+
 Quantum Object:   type=Ket   dims=[2, 2]   size=(4,)
 4-element Vector{ComplexF64}:
  0.0 + 0.0im
@@ -518,6 +521,7 @@ Quantum Object:   type=Ket   dims=[2, 2]   size=(4,)
  0.0 + 0.0im
 
 julia> ptrace(ψ, 2)
+
 Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=true
 2×2 Matrix{ComplexF64}:
  0.0+0.0im  0.0+0.0im
@@ -527,6 +531,7 @@ Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=true
 or in an entangled state ``\ket{\psi} = \frac{1}{\sqrt{2}} \left( \ket{e,e} + \ket{g,g} \right)``:
 ```jldoctest
 julia> ψ = 1 / √2 * (kron(fock(2,0), fock(2,0)) + kron(fock(2,1), fock(2,1)))
+
 Quantum Object:   type=Ket   dims=[2, 2]   size=(4,)
 4-element Vector{ComplexF64}:
  0.7071067811865475 + 0.0im
@@ -535,6 +540,7 @@ Quantum Object:   type=Ket   dims=[2, 2]   size=(4,)
  0.7071067811865475 + 0.0im
 
 julia> ptrace(ψ, 1)
+
 Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=true
 2×2 Matrix{ComplexF64}:
  0.5+0.0im  0.0+0.0im

--- a/src/qobj/eigsolve.jl
+++ b/src/qobj/eigsolve.jl
@@ -51,11 +51,13 @@ julia> λ
 
 julia> ψ
 2-element Vector{QuantumObject{Vector{ComplexF64}, KetQuantumObject, 1}}:
- Quantum Object:   type=Ket   dims=[2]   size=(2,)
+
+Quantum Object:   type=Ket   dims=[2]   size=(2,)
 2-element Vector{ComplexF64}:
  -0.7071067811865475 + 0.0im
   0.7071067811865475 + 0.0im
- Quantum Object:   type=Ket   dims=[2]   size=(2,)
+
+Quantum Object:   type=Ket   dims=[2]   size=(2,)
 2-element Vector{ComplexF64}:
  0.7071067811865475 + 0.0im
  0.7071067811865475 + 0.0im

--- a/src/qobj/functions.jl
+++ b/src/qobj/functions.jl
@@ -161,6 +161,7 @@ Returns the [Kronecker product](https://en.wikipedia.org/wiki/Kronecker_product)
 
 ```jldoctest
 julia> a = destroy(20)
+
 Quantum Object:   type=Operator   dims=[20]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 19 stored entries:
 ⎡⠈⠢⡀⠀⠀⠀⠀⠀⠀⠀⎤

--- a/src/qobj/operators.jl
+++ b/src/qobj/operators.jl
@@ -90,6 +90,7 @@ This operator acts on a fock state as ``\hat{a} \ket{n} = \sqrt{n} \ket{n-1}``.
 
 ```jldoctest
 julia> a = destroy(20)
+
 Quantum Object:   type=Operator   dims=[20]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 19 stored entries:
 ⎡⠈⠢⡀⠀⠀⠀⠀⠀⠀⠀⎤
@@ -115,6 +116,7 @@ This operator acts on a fock state as ``\hat{a}^\dagger \ket{n} = \sqrt{n+1} \ke
 
 ```jldoctest
 julia> a_d = create(20)
+
 Quantum Object:   type=Operator   dims=[20]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 19 stored entries:
 ⎡⠢⡀⠀⠀⠀⠀⠀⠀⠀⠀⎤
@@ -244,18 +246,21 @@ Note that if the parameter `which` is not specified, returns a set of Spin-`j` o
 # Examples
 ```jldoctest
 julia> jmat(0.5, :x)
+
 Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=true
 2×2 SparseMatrixCSC{ComplexF64, Int64} with 2 stored entries:
      ⋅      0.5+0.0im
  0.5+0.0im      ⋅
 
 julia> jmat(0.5, Val(:-))
+
 Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=false
 2×2 SparseMatrixCSC{ComplexF64, Int64} with 1 stored entry:
      ⋅          ⋅    
  1.0+0.0im      ⋅
 
 julia> jmat(1.5, Val(:z))
+
 Quantum Object:   type=Operator   dims=[4]   size=(4, 4)   ishermitian=true
 4×4 SparseMatrixCSC{ComplexF64, Int64} with 4 stored entries:
  1.5+0.0im      ⋅           ⋅           ⋅    

--- a/src/qobj/quantum_object.jl
+++ b/src/qobj/quantum_object.jl
@@ -21,6 +21,7 @@ Julia struct representing any quantum objects.
 
 ```jldoctest
 julia> a = destroy(20)
+
 Quantum Object:   type=Operator   dims=[20]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 19 stored entries:
 ⎡⠈⠢⡀⠀⠀⠀⠀⠀⠀⠀⎤

--- a/src/qobj/quantum_object.jl
+++ b/src/qobj/quantum_object.jl
@@ -145,7 +145,7 @@ function Base.show(
     },
 }
     op_data = QO.data
-    println(io, "Quantum Object:   type=", QO.type, "   dims=", QO.dims, "   size=", size(op_data))
+    println(io, "\nQuantum Object:   type=", QO.type, "   dims=", QO.dims, "   size=", size(op_data))
     return show(io, MIME("text/plain"), op_data)
 end
 
@@ -153,7 +153,7 @@ function Base.show(io::IO, QO::QuantumObject)
     op_data = QO.data
     println(
         io,
-        "Quantum Object:   type=",
+        "\nQuantum Object:   type=",
         QO.type,
         "   dims=",
         QO.dims,

--- a/src/qobj/quantum_object_evo.jl
+++ b/src/qobj/quantum_object_evo.jl
@@ -128,7 +128,7 @@ function Base.show(io::IO, QO::QuantumObjectEvolution)
     op_data = QO.data
     println(
         io,
-        "Quantum Object Evo.:   type=",
+        "\nQuantum Object Evo.:   type=",
         QO.type,
         "   dims=",
         QO.dims,

--- a/src/qobj/quantum_object_evo.jl
+++ b/src/qobj/quantum_object_evo.jl
@@ -23,6 +23,7 @@ where ``c_i(p, t)`` is a function that depends on the parameters `p` and time `t
 This operator can be initialized in the same way as the QuTiP `QobjEvo` object. For example
 ```jldoctest qobjevo
 julia> a = tensor(destroy(10), qeye(2))
+
 Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 18 stored entries:
 ⎡⠀⠑⢄⠀⠀⠀⠀⠀⠀⠀⎤
@@ -35,6 +36,7 @@ julia> coef1(p, t) = exp(-1im * t)
 coef1 (generic function with 1 method)
 
 julia> op = QobjEvo(a, coef1)
+
 Quantum Object Evo.:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=true   isconstant=false
 ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20)
 ```
@@ -43,6 +45,7 @@ If there are more than 2 operators, we need to put each set of operator and coef
 
 ```jldoctest qobjevo
 julia> σm = tensor(qeye(10), sigmam())
+
 Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 10 stored entries:
 ⎡⠂⡀⠀⠀⠀⠀⠀⠀⠀⠀⎤
@@ -55,6 +58,7 @@ julia> coef2(p, t) = sin(t)
 coef2 (generic function with 1 method)
 
 julia> op1 = QobjEvo(((a, coef1), (σm, coef2)))
+
 Quantum Object Evo.:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=true   isconstant=false
 (ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20) + ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20))
 ```
@@ -62,6 +66,7 @@ Quantum Object Evo.:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitia
 We can also concretize the operator at a specific time `t`
 ```jldoctest qobjevo
 julia> op1(0.1)
+
 Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 28 stored entries:
 ⎡⠂⡑⢄⠀⠀⠀⠀⠀⠀⠀⎤
@@ -80,6 +85,7 @@ julia> coef2(p, t) = sin(p.ω2 * t)
 coef2 (generic function with 1 method)
 
 julia> op1 = QobjEvo(((a, coef1), (σm, coef2)))
+
 Quantum Object Evo.:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=true   isconstant=false
 (ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20) + ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20))
 
@@ -87,6 +93,7 @@ julia> p = (ω1 = 1.0, ω2 = 0.5)
 (ω1 = 1.0, ω2 = 0.5)
 
 julia> op1(p, 0.1)
+
 Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 28 stored entries:
 ⎡⠂⡑⢄⠀⠀⠀⠀⠀⠀⠀⎤
@@ -190,6 +197,7 @@ Note that if `α` is provided, all the operators in `op_func_list` will be pre-m
 This operator can be initialized in the same way as the QuTiP `QobjEvo` object. For example
 ```jldoctest qobjevo
 julia> a = tensor(destroy(10), qeye(2))
+
 Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 18 stored entries:
 ⎡⠀⠑⢄⠀⠀⠀⠀⠀⠀⠀⎤
@@ -199,6 +207,7 @@ Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=fal
 ⎣⠀⠀⠀⠀⠀⠀⠀⠀⠀⠑⎦
 
 julia> σm = tensor(qeye(10), sigmam())
+
 Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 10 stored entries:
 ⎡⠂⡀⠀⠀⠀⠀⠀⠀⠀⠀⎤
@@ -214,6 +223,7 @@ julia> coef2(p, t) = sin(t)
 coef2 (generic function with 1 method)
 
 julia> op1 = QobjEvo(((a, coef1), (σm, coef2)))
+
 Quantum Object Evo.:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=true   isconstant=false
 (ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20) + ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20))
 ```
@@ -221,6 +231,7 @@ Quantum Object Evo.:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitia
 We can also concretize the operator at a specific time `t`
 ```jldoctest qobjevo
 julia> op1(0.1)
+
 Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 28 stored entries:
 ⎡⠂⡑⢄⠀⠀⠀⠀⠀⠀⠀⎤
@@ -239,6 +250,7 @@ julia> coef2(p, t) = sin(p.ω2 * t)
 coef2 (generic function with 1 method)
 
 julia> op1 = QobjEvo(((a, coef1), (σm, coef2)))
+
 Quantum Object Evo.:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=true   isconstant=false
 (ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20) + ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20))
 
@@ -246,6 +258,7 @@ julia> p = (ω1 = 1.0, ω2 = 0.5)
 (ω1 = 1.0, ω2 = 0.5)
 
 julia> op1(p, 0.1)
+
 Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 28 stored entries:
 ⎡⠂⡑⢄⠀⠀⠀⠀⠀⠀⠀⎤
@@ -293,6 +306,7 @@ Generate [`QuantumObjectEvolution`](@ref).
 # Examples
 ```jldoctest
 julia> a = tensor(destroy(10), qeye(2))
+
 Quantum Object:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 18 stored entries:
 ⎡⠀⠑⢄⠀⠀⠀⠀⠀⠀⠀⎤
@@ -305,6 +319,7 @@ julia> coef(p, t) = exp(-1im * t)
 coef (generic function with 1 method)
 
 julia> op = QobjEvo(a, coef)
+
 Quantum Object Evo.:   type=Operator   dims=[10, 2]   size=(20, 20)   ishermitian=true   isconstant=false
 ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20)
 ```
@@ -458,6 +473,7 @@ Apply the time-dependent [`QuantumObjectEvolution`](@ref) object `A` to the inpu
 # Examples
 ```jldoctest
 julia> a = destroy(20)
+
 Quantum Object:   type=Operator   dims=[20]   size=(20, 20)   ishermitian=false
 20×20 SparseMatrixCSC{ComplexF64, Int64} with 19 stored entries:
 ⎡⠈⠢⡀⠀⠀⠀⠀⠀⠀⠀⎤
@@ -473,6 +489,7 @@ julia> coef2(p, t) = cos(t)
 coef2 (generic function with 1 method)
 
 julia> A = QobjEvo(((a, coef1), (a', coef2)))
+
 Quantum Object Evo.:   type=Operator   dims=[20]   size=(20, 20)   ishermitian=true   isconstant=false
 (ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20) + ScalarOperator(0.0 + 0.0im) * MatrixOperator(20 × 20))
 

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -254,6 +254,7 @@ Here, `x = 1` (`z = 1`) means applying Pauli-``X`` ( Pauli-``Z``) unitary transf
 
 ```jldoctest
 julia> bell_state(0, 0)
+
 Quantum Object:   type=Ket   dims=[2, 2]   size=(4,)
 4-element Vector{ComplexF64}:
  0.7071067811865475 + 0.0im
@@ -262,6 +263,7 @@ Quantum Object:   type=Ket   dims=[2, 2]   size=(4,)
  0.7071067811865475 + 0.0im
 
 julia> bell_state(Val(1), Val(0))
+
 Quantum Object:   type=Ket   dims=[2, 2]   size=(4,)
 4-element Vector{ComplexF64}:
                 0.0 + 0.0im

--- a/src/wigner.jl
+++ b/src/wigner.jl
@@ -37,6 +37,7 @@ The `method` parameter can be either `WignerLaguerre()` or `WignerClenshaw()`. T
 # Example
 ```jldoctest wigner
 julia> ψ = fock(10, 0) + fock(10, 1) |> normalize
+
 Quantum Object:   type=Ket   dims=[10]   size=(10,)
 10-element Vector{ComplexF64}:
  0.7071067811865475 + 0.0im

--- a/test/core-test/quantum_objects.jl
+++ b/test/core-test/quantum_objects.jl
@@ -233,7 +233,7 @@
         a_size = size(a)
         a_isherm = isherm(a)
         @test opstring ==
-              "Quantum Object:   type=Operator   dims=$a_dims   size=$a_size   ishermitian=$a_isherm\n$datastring"
+              "\nQuantum Object:   type=Operator   dims=$a_dims   size=$a_size   ishermitian=$a_isherm\n$datastring"
 
         a = spre(a)
         opstring = sprint((t, s) -> show(t, "text/plain", s), a)
@@ -241,34 +241,34 @@
         a_dims = a.dims
         a_size = size(a)
         a_isherm = isherm(a)
-        @test opstring == "Quantum Object:   type=SuperOperator   dims=$a_dims   size=$a_size\n$datastring"
+        @test opstring == "\nQuantum Object:   type=SuperOperator   dims=$a_dims   size=$a_size\n$datastring"
 
         opstring = sprint((t, s) -> show(t, "text/plain", s), ψ)
         datastring = sprint((t, s) -> show(t, "text/plain", s), ψ.data)
         ψ_dims = ψ.dims
         ψ_size = size(ψ)
-        @test opstring == "Quantum Object:   type=Ket   dims=$ψ_dims   size=$ψ_size\n$datastring"
+        @test opstring == "\nQuantum Object:   type=Ket   dims=$ψ_dims   size=$ψ_size\n$datastring"
 
         ψ = ψ'
         opstring = sprint((t, s) -> show(t, "text/plain", s), ψ)
         datastring = sprint((t, s) -> show(t, "text/plain", s), ψ.data)
         ψ_dims = ψ.dims
         ψ_size = size(ψ)
-        @test opstring == "Quantum Object:   type=Bra   dims=$ψ_dims   size=$ψ_size\n$datastring"
+        @test opstring == "\nQuantum Object:   type=Bra   dims=$ψ_dims   size=$ψ_size\n$datastring"
 
         ψ2 = Qobj(rand(ComplexF64, 4), type = OperatorKet)
         opstring = sprint((t, s) -> show(t, "text/plain", s), ψ2)
         datastring = sprint((t, s) -> show(t, "text/plain", s), ψ2.data)
         ψ2_dims = ψ2.dims
         ψ2_size = size(ψ2)
-        @test opstring == "Quantum Object:   type=OperatorKet   dims=$ψ2_dims   size=$ψ2_size\n$datastring"
+        @test opstring == "\nQuantum Object:   type=OperatorKet   dims=$ψ2_dims   size=$ψ2_size\n$datastring"
 
         ψ2 = ψ2'
         opstring = sprint((t, s) -> show(t, "text/plain", s), ψ2)
         datastring = sprint((t, s) -> show(t, "text/plain", s), ψ2.data)
         ψ2_dims = ψ2.dims
         ψ2_size = size(ψ2)
-        @test opstring == "Quantum Object:   type=OperatorBra   dims=$ψ2_dims   size=$ψ2_size\n$datastring"
+        @test opstring == "\nQuantum Object:   type=OperatorBra   dims=$ψ2_dims   size=$ψ2_size\n$datastring"
     end
 
     @testset "matrix element" begin

--- a/test/core-test/quantum_objects_evo.jl
+++ b/test/core-test/quantum_objects_evo.jl
@@ -114,7 +114,7 @@
         H_isherm = isherm(H)
         H_isconst = isconstant(H)
         @test opstring ==
-              "Quantum Object Evo.:   type=Operator   dims=$H_dims   size=$H_size   ishermitian=$H_isherm   isconstant=$H_isconst\n$datastring"
+              "\nQuantum Object Evo.:   type=Operator   dims=$H_dims   size=$H_size   ishermitian=$H_isherm   isconstant=$H_isconst\n$datastring"
 
         L = QobjEvo(spre(a))
         opstring = sprint((t, s) -> show(t, "text/plain", s), L)
@@ -124,7 +124,7 @@
         L_isherm = isherm(L)
         L_isconst = isconstant(L)
         @test opstring ==
-              "Quantum Object Evo.:   type=SuperOperator   dims=$L_dims   size=$L_size   ishermitian=$L_isherm   isconstant=$L_isconst\n$datastring"
+              "\nQuantum Object Evo.:   type=SuperOperator   dims=$L_dims   size=$L_size   ishermitian=$L_isherm   isconstant=$L_isconst\n$datastring"
     end
 
     @testset "Type Inference (QobjEvo)" begin


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to QuantumToolbox.jl](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
The current `show` for `Qobj` tuples print as the following style:
```julia-repl
julia> a = destroy(2);
julia> (a, a', a + a')
(Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=false
2×2 SparseMatrixCSC{ComplexF64, Int64} with 1 stored entry:
     ⋅      1.0+0.0im
     ⋅          ⋅    , Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=false
2×2 Adjoint{ComplexF64, SparseMatrixCSC{ComplexF64, Int64}} with 1 stored entry:
     ⋅          ⋅    
 1.0-0.0im      ⋅    , Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=true
2×2 SparseMatrixCSC{ComplexF64, Int64} with 2 stored entries:
     ⋅      1.0+0.0im
 1.0+0.0im      ⋅    )
```
```julia-repl
julia> (a, QobjEvo(a))
(Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=false
2×2 SparseMatrixCSC{ComplexF64, Int64} with 1 stored entry:
     ⋅      1.0+0.0im
     ⋅          ⋅    , Quantum Object Evo.:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=false   isconstant=true
MatrixOperator(2 × 2))
```

With this PR, every `Qobj` / `QobjEvo` prints from a new line, that is:

```julia-repl
julia> (a, a', a + a')
(
Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=false
2×2 SparseMatrixCSC{ComplexF64, Int64} with 1 stored entry:
     ⋅      1.0+0.0im
     ⋅          ⋅    , 
Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=false
2×2 Adjoint{ComplexF64, SparseMatrixCSC{ComplexF64, Int64}} with 1 stored entry:
     ⋅          ⋅    
 1.0-0.0im      ⋅    , 
Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=true
2×2 SparseMatrixCSC{ComplexF64, Int64} with 2 stored entries:
     ⋅      1.0+0.0im
 1.0+0.0im      ⋅    )
```
```julia-repl
julia> (a, QobjEvo(a))
(
Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=false
2×2 SparseMatrixCSC{ComplexF64, Int64} with 1 stored entry:
     ⋅      1.0+0.0im
     ⋅          ⋅    , 
Quantum Object Evo.:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=false   isconstant=true
MatrixOperator(2 × 2))
```

This is useful when checking the `c_ops`, `e_ops`, and so on, when they are in `Tuple` type.

Also, for `Vector` and `SVector`:

```julia-repl
julia> [a, a', a + a']
3-element Vector{QuantumObject{MT, OperatorQuantumObject, 1} where MT<:AbstractArray}:
 
Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=false
2×2 SparseMatrixCSC{ComplexF64, Int64} with 1 stored entry:
     ⋅      1.0+0.0im
     ⋅          ⋅    
 
Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=false
2×2 Adjoint{ComplexF64, SparseMatrixCSC{ComplexF64, Int64}} with 1 stored entry:
     ⋅          ⋅    
 1.0-0.0im      ⋅    
 
Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=true
2×2 SparseMatrixCSC{ComplexF64, Int64} with 2 stored entries:
     ⋅      1.0+0.0im
 1.0+0.0im      ⋅
```
```julia-repl
julia> SVector{3}([a, a', a + a'])
3-element SVector{3, QuantumObject{MT, OperatorQuantumObject, 1} where MT<:AbstractArray} with indices SOneTo(3):
 
Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=false
2×2 SparseMatrixCSC{ComplexF64, Int64} with 1 stored entry:
     ⋅      1.0+0.0im
     ⋅          ⋅    
 
Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=false
2×2 Adjoint{ComplexF64, SparseMatrixCSC{ComplexF64, Int64}} with 1 stored entry:
     ⋅          ⋅    
 1.0-0.0im      ⋅    
 
Quantum Object:   type=Operator   dims=[2]   size=(2, 2)   ishermitian=true
2×2 SparseMatrixCSC{ComplexF64, Int64} with 2 stored entries:
     ⋅      1.0+0.0im
 1.0+0.0im      ⋅
```