### PR TITLE
Fix dynamical fock dimension saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
+- Fix Dynamical Fock Dimension states saving due to wrong saving of dimensions. ([#375])
+
 ## [v0.25.0]
 Release date: 2025-01-20
 
@@ -83,3 +85,4 @@ Release date: 2024-11-13
 [#360]: https://github.com/qutip/QuantumToolbox.jl/issues/360
 [#370]: https://github.com/qutip/QuantumToolbox.jl/issues/370
 [#371]: https://github.com/qutip/QuantumToolbox.jl/issues/371
+[#375]: https://github.com/qutip/QuantumToolbox.jl/issues/375

--- a/test/core-test/dynamical_fock_dimension_mesolve.jl
+++ b/test/core-test/dynamical_fock_dimension_mesolve.jl
@@ -43,7 +43,9 @@
 
     @test sum(abs.((sol.expect[1, :] .- sol0.expect[1, :]) ./ (sol0.expect[1, :] .+ 1e-16))) < 0.01
     @test length(sol.states) == length(t_l)
-    @test all(diff(getindex.(QuantumToolbox.dimensions_to_dims.(QuantumToolbox.get_dimensions_to.(sol.states)), 1)) .>= 0)
+    @test all(
+        diff(getindex.(QuantumToolbox.dimensions_to_dims.(QuantumToolbox.get_dimensions_to.(sol.states)), 1)) .>= 0,
+    )
 
     ######################
 

--- a/test/core-test/dynamical_fock_dimension_mesolve.jl
+++ b/test/core-test/dynamical_fock_dimension_mesolve.jl
@@ -29,9 +29,21 @@
     maxdims = [150]
     ψ0 = fock(3, 0)
     dfd_params = (Δ = Δ, F = F, κ = κ)
-    sol = dfd_mesolve(H_dfd0, ψ0, t_l, c_ops_dfd0, maxdims, dfd_params, e_ops = e_ops_dfd0, progress_bar = Val(false))
+    sol = dfd_mesolve(
+        H_dfd0,
+        ψ0,
+        t_l,
+        c_ops_dfd0,
+        maxdims,
+        dfd_params,
+        e_ops = e_ops_dfd0,
+        progress_bar = Val(false),
+        saveat = t_l,
+    )
 
     @test sum(abs.((sol.expect[1, :] .- sol0.expect[1, :]) ./ (sol0.expect[1, :] .+ 1e-16))) < 0.01
+    @test length(sol.states) == length(t_l)
+    @test all(diff(getindex.(QuantumToolbox.dimensions_to_dims.(QuantumToolbox.get_dimensions_to.(sol.states)), 1)) .>= 0)
 
     ######################
 


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to QuantumToolbox.jl](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
The previous implementation was returning an error when using the `saveat` argument. This was caused by a wrong saving of the `dims` during the evolution.