### PR TITLE
[Docs] Minor changes to contribute page

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 ## Checklist
 Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.
 
-- [ ] Please read [Contributing to QuantumToolbox.jl](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
+- [ ] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
 - [ ] Any code changes were done in a way that does not break public API.
 - [ ] Appropriate tests were added and tested locally by running: `make test`.
 - [ ] Any code changes should be `julia` formatted by running: `make format`.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Here we provide a brief performance comparison between `QuantumToolbox.jl` and o
 
 You are most welcome to contribute to `QuantumToolbox.jl` development by forking this repository and sending pull requests (PRs), or filing bug reports at the issues page. You can also help out with users' questions, or discuss proposed changes in the [QuTiP discussion group](https://groups.google.com/g/qutip).
 
-For more information about contribution, including technical advice, please see the [Contributing to QuantumToolbox.jl](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing) section of the documentation.
+For more information about contribution, including technical advice, please see the [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
 
 ## Acknowledgements
 

--- a/docs/src/resources/contributing.md
+++ b/docs/src/resources/contributing.md
@@ -1,4 +1,4 @@
-# [Contributing to QuantumToolbox.jl](@id doc-Contribute)
+# [Contributing to Quantum Toolbox in Julia](@id doc-Contribute)
 
 ## [Quick Start](@id doc-Contribute:Quick-Start)
 
@@ -31,6 +31,12 @@ make test
 ```
 
 This command will automatically rebuild `Julia` and run the script located in `test/runtests.jl` (should cover both the original tests and the new test(s) you add).
+
+The tests are divided into several test groups, where the group names are defined in the file `test/runtests.jl` with a variable `GROUP`. One can also run the test scripts just for a certain test group by adding an argument `GROUP=<test-group-name>` to the `make test` command. For example, to run the tests for group `Core`, one can use the following command:
+
+```shell
+make GROUP=Core test
+```
 
 ## [Julia Code Format](@id doc-Contribute:Julia-Code-Format)
 


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to QuantumToolbox.jl](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
I think the title of contribution page should change to `Contributing to Quantum Toolbox in Julia` instead of `QuantumToolbox.jl`. Since we also have `HEOM.jl` and tutorial repo. and maybe other sub-packages in the future.

Furthermore, this PR also improve the guidance of `make test` command with specifying `GROUP` argument.