### PR TITLE
Fix of erroneous definition of stochastic term in  `smesolve`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
 - Rename `sparse_to_dense` as `to_dense` and `dense_to_sparse` as `to_sparse`. ([#392])
+- Fix erroneous definition of the stochastic term in `smesolve`. ([#393])
 
 ## [v0.26.0]
 Release date: 2025-02-09
@@ -118,3 +119,4 @@ Release date: 2024-11-13
 [#388]: https://github.com/qutip/QuantumToolbox.jl/issues/388
 [#389]: https://github.com/qutip/QuantumToolbox.jl/issues/389
 [#392]: https://github.com/qutip/QuantumToolbox.jl/issues/392
+[#393]: https://github.com/qutip/QuantumToolbox.jl/issues/393

--- a/src/time_evolution/smesolve.jl
+++ b/src/time_evolution/smesolve.jl
@@ -107,7 +107,10 @@ function smesolveProblem(
         # Also, the u state may become non-hermitian, so Tr[Sn * ρ + ρ * Sn'] != real(Tr[Sn * ρ]) / 2
         op_vec = mat2vec(adjoint(op.A))
         op_vec_dag = mat2vec(op.A)
-        return _spre(op, Id) + _spost(op', Id) + _smesolve_ScalarOperator(op_vec) * Id_op + _smesolve_ScalarOperator(op_vec_dag) * Id_op
+        return _spre(op, Id) +
+               _spost(op', Id) +
+               _smesolve_ScalarOperator(op_vec) * Id_op +
+               _smesolve_ScalarOperator(op_vec_dag) * Id_op
     end
     D = DiffusionOperator(D_l)
 

--- a/src/time_evolution/smesolve.jl
+++ b/src/time_evolution/smesolve.jl
@@ -3,7 +3,7 @@ export smesolveProblem, smesolveEnsembleProblem, smesolve
 _smesolve_generate_state(u, dims) = QuantumObject(vec2mat(u), type = Operator, dims = dims)
 
 function _smesolve_update_coeff(u, p, t, op_vec)
-    return real(dot(u, op_vec)) / 2 #this is Tr[Sn * ρ + ρ * Sn']
+    return dot(op_vec, u) #this is Tr[Sn * ρ]
 end
 
 _smesolve_ScalarOperator(op_vec) =
@@ -100,11 +100,13 @@ function smesolveProblem(
     K = get_data(L_evo)
 
     Id = I(prod(dims))
+    Id_op = IdentityOperator(prod(dims)^2)
     D_l = map(sc_ops_evo_data) do op
-        # TODO: Implement the three-argument dot function for SciMLOperators.jl
-        # Currently, we are assuming a time-independent MatrixOperator
+        # TODO: # Currently, we are assuming a time-independent MatrixOperator
+        # Also, the u state may become non-hermitian, so Tr[Sn * ρ + ρ * Sn'] != real(Tr[Sn * ρ]) / 2
         op_vec = mat2vec(adjoint(op.A))
-        return _spre(op, Id) + _spost(op', Id) + _smesolve_ScalarOperator(op_vec) * IdentityOperator(prod(dims)^2)
+        op_vec_dag = mat2vec(op.A)
+        return _spre(op, Id) + _spost(op', Id) + _smesolve_ScalarOperator(op_vec) * Id_op + _smesolve_ScalarOperator(op_vec_dag) * Id_op
     end
     D = DiffusionOperator(D_l)
 

--- a/src/time_evolution/smesolve.jl
+++ b/src/time_evolution/smesolve.jl
@@ -106,9 +106,7 @@ function smesolveProblem(
         # TODO: # Currently, we are assuming a time-independent MatrixOperator
         # Also, the u state may become non-hermitian, so Tr[Sn * ρ + ρ * Sn'] != real(Tr[Sn * ρ]) / 2
         op_vec = mat2vec(adjoint(op.A))
-        return _spre(op, Id) +
-               _spost(op', Id) +
-               _smesolve_ScalarOperator(op_vec) * Id_op
+        return _spre(op, Id) + _spost(op', Id) + _smesolve_ScalarOperator(op_vec) * Id_op
     end
     D = DiffusionOperator(D_l)
 

--- a/src/time_evolution/smesolve.jl
+++ b/src/time_evolution/smesolve.jl
@@ -3,7 +3,7 @@ export smesolveProblem, smesolveEnsembleProblem, smesolve
 _smesolve_generate_state(u, dims) = QuantumObject(vec2mat(u), type = Operator, dims = dims)
 
 function _smesolve_update_coeff(u, p, t, op_vec)
-    return dot(op_vec, u) #this is Tr[Sn * ρ]
+    return 2 * real(dot(op_vec, u)) #this is Tr[Sn * ρ + ρ * Sn']
 end
 
 _smesolve_ScalarOperator(op_vec) =
@@ -106,11 +106,9 @@ function smesolveProblem(
         # TODO: # Currently, we are assuming a time-independent MatrixOperator
         # Also, the u state may become non-hermitian, so Tr[Sn * ρ + ρ * Sn'] != real(Tr[Sn * ρ]) / 2
         op_vec = mat2vec(adjoint(op.A))
-        op_vec_dag = mat2vec(op.A)
         return _spre(op, Id) +
                _spost(op', Id) +
-               _smesolve_ScalarOperator(op_vec) * Id_op +
-               _smesolve_ScalarOperator(op_vec_dag) * Id_op
+               _smesolve_ScalarOperator(op_vec) * Id_op
     end
     D = DiffusionOperator(D_l)
 

--- a/src/time_evolution/smesolve.jl
+++ b/src/time_evolution/smesolve.jl
@@ -39,6 +39,7 @@ is the Lindblad superoperator, and
 
 ```math
 \mathcal{H}[\hat{O}] \rho = \hat{O} \rho + \rho \hat{O}^\dagger - \mathrm{Tr}[\hat{O} \rho + \rho \hat{O}^\dagger] \rho,
+```
 
 Above, ``\hat{C}_n`` represent the operators related to pure dissipation, while ``\hat{S}_n`` are the measurement operators. The ``dW_n(t)`` term is the real Wiener increment associated to ``\hat{S}_n``. See [Wiseman2009Quantum](@cite) for more details.
 
@@ -162,6 +163,7 @@ is the Lindblad superoperator, and
 
 ```math
 \mathcal{H}[\hat{O}] \rho = \hat{O} \rho + \rho \hat{O}^\dagger - \mathrm{Tr}[\hat{O} \rho + \rho \hat{O}^\dagger] \rho,
+```
 
 Above, ``\hat{C}_n`` represent the operators related to pure dissipation, while ``\hat{S}_n`` are the measurement operators. The ``dW_n(t)`` term is the real Wiener increment associated to ``\hat{S}_n``. See [Wiseman2009Quantum](@cite) for more details.
 
@@ -273,6 +275,7 @@ is the Lindblad superoperator, and
 
 ```math
 \mathcal{H}[\hat{O}] \rho = \hat{O} \rho + \rho \hat{O}^\dagger - \mathrm{Tr}[\hat{O} \rho + \rho \hat{O}^\dagger] \rho,
+```
 
 Above, ``\hat{C}_n`` represent the operators related to pure dissipation, while ``\hat{S}_n`` are the measurement operators. The ``dW_n(t)`` term is the real Wiener increment associated to ``\hat{S}_n``. See [Wiseman2009Quantum](@cite) for more details.
 

--- a/test/core-test/time_evolution.jl
+++ b/test/core-test/time_evolution.jl
@@ -407,7 +407,7 @@
                 ntraj = 100,
                 progress_bar = Val(false),
             )
-            @test allocs_tot < 2710000 # TODO: Fix this high number of allocations
+            @test allocs_tot < 2750000 # TODO: Fix this high number of allocations
 
             allocs_tot = @allocations smesolve(
                 H,


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
This PR fixes a erroneous definition of the stochastic term in `smesolve`, improving its stability. 