### PR TITLE
Introduce `groundstate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for single `AbstractQuantumObject` in `sc_ops` for faster specific method in `ssesolve` and `smesolve`. ([#408])
 - Change save callbacks from `PresetTimeCallback` to `FunctionCallingCallback`. ([#410])
 - Align `eigenstates` and `eigenenergies` to QuTiP. ([#411])
+- Introduce `groundstate`. ([#412])
 
 ## [v0.27.0]
 Release date: 2025-02-14
@@ -147,3 +148,4 @@ Release date: 2024-11-13
 [#408]: https://github.com/qutip/QuantumToolbox.jl/issues/408
 [#410]: https://github.com/qutip/QuantumToolbox.jl/issues/410
 [#411]: https://github.com/qutip/QuantumToolbox.jl/issues/411
+[#412]: https://github.com/qutip/QuantumToolbox.jl/issues/412

--- a/docs/src/resources/api.md
+++ b/docs/src/resources/api.md
@@ -90,6 +90,7 @@ partial_transpose
 EigsolveResult
 eigenenergies
 eigenstates
+groundstate
 LinearAlgebra.eigen
 LinearAlgebra.eigvals
 eigsolve

--- a/docs/src/users_guide/QuantumObject/QuantumObject_functions.md
+++ b/docs/src/users_guide/QuantumObject/QuantumObject_functions.md
@@ -43,6 +43,7 @@ Here is a table that summarizes all the supported linear algebra functions and a
 
 - [`eigenenergies`](@ref): return eigenenergies (eigenvalues)
 - [`eigenstates`](@ref): return [`EigsolveResult`](@ref) (contains eigenvalues and eigenvectors)
+- [`groundstate`](@ref): return the ground state eigenvalue and corresponding eigenvector
 - [`eigvals`](@ref): return eigenvalues
 - [`eigen`](@ref): using dense eigen solver and return [`EigsolveResult`](@ref) (contains eigenvalues and eigenvectors)
 - [`eigsolve`](@ref): using sparse eigen solver and return [`EigsolveResult`](@ref) (contains eigenvalues and eigenvectors)

--- a/test/core-test/eigenvalues_and_operators.jl
+++ b/test/core-test/eigenvalues_and_operators.jl
@@ -92,6 +92,14 @@
     @test isapprox(vec2mat(vecs[1]).data * exp(-1im * angle(vecs[1][1])), vec2mat(vecs2[1]).data, atol = 1e-7)
     @test isapprox(vec2mat(vecs[1]).data * exp(-1im * angle(vecs[1][1])), vec2mat(state3[1]).data, atol = 1e-5)
 
+    # ground state # TODO: support for sparse eigsolve
+    U = rand_unitary(5)
+    M = U * Qobj(diagm([1, 1, 2, 3, 4])) * U'  # degenerate ground state
+    gval_1, gvec_1 = @test_logs (:warn,) groundstate(M)
+    # gval_2, gvec_2 = @test_logs (:warn,) groundstate(M, sparse = true)
+    @test gval_1 ≈ 1# ≈ gval_2
+    #@test isapprox(gvec_1, gvec_2, atol = 1e-6)
+
     @testset "Type Inference (eigen)" begin
         N = 5
         a = kron(destroy(N), qeye(N))
@@ -112,6 +120,8 @@
         @inferred eigenstates(H, sparse = false)
         @inferred eigenstates(H, sparse = true)
         @inferred eigenstates(L, sparse = true)
+        @inferred groundstate(H)#, sparse = false) # TODO: support for sparse eigsolve
+        #@inferred groundstate(H, sparse = true)  
         @inferred eigsolve_al(L, 1 \ (40 * κ), eigvals = 10)
     end
 end


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
This PR introduce a new function: `groundstate` to calculate the ground state eigenvalue and corresponding eigenvector.

This function currently doesn't support `sparse` eigsolve. Because it seems that `sparse` eigsolve doesn't find the smallest eigenvalue first.