### PR TITLE
Introduce `operator_to_vector` and `vector_to_operator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for single `AbstractQuantumObject` in `sc_ops` for faster specific method in `ssesolve` and `smesolve`. ([#408])
 - Change save callbacks from `PresetTimeCallback` to `FunctionCallingCallback`. ([#410])
 - Align `eigenstates` and `eigenenergies` to QuTiP. ([#411])
+- Introduce `vector_to_operator` and `operator_to_vector`. ([#413])
 
 ## [v0.27.0]
 Release date: 2025-02-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,3 +148,4 @@ Release date: 2024-11-13
 [#408]: https://github.com/qutip/QuantumToolbox.jl/issues/408
 [#410]: https://github.com/qutip/QuantumToolbox.jl/issues/410
 [#411]: https://github.com/qutip/QuantumToolbox.jl/issues/411
+[#413]: https://github.com/qutip/QuantumToolbox.jl/issues/413

--- a/docs/src/resources/api.md
+++ b/docs/src/resources/api.md
@@ -176,6 +176,8 @@ unit
 tensor
 ⊗
 qeye
+vector_to_operator
+operator_to_vector
 sqrtm
 logm
 expm

--- a/docs/src/users_guide/states_and_operators.md
+++ b/docs/src/users_guide/states_and_operators.md
@@ -314,7 +314,7 @@ Therefore, a given density matrix ``\hat{\rho}`` can then be vectorized, denoted
 |\hat{\rho}\rangle\rangle = \textrm{vec}(\hat{\rho}).
 ```
 
-`QuantumToolbox` uses the column-stacking convention for the isomorphism between ``\mathcal{L}(\mathcal{H})`` and ``\mathcal{H}\otimes\mathcal{H}``. This isomorphism is implemented by the functions [`mat2vec`](@ref) and [`vec2mat`](@ref):
+`QuantumToolbox` uses the column-stacking convention for the isomorphism between ``\mathcal{L}(\mathcal{H})`` and ``\mathcal{H}\otimes\mathcal{H}``. This isomorphism is implemented by the functions [`mat2vec`](@ref) (or [`operator_to_vector`](@ref)) and [`vec2mat`](@ref) (or [`vector_to_operator`](@ref)):
 
 ```@example states_and_operators
 rho = Qobj([1 2; 3 4])

--- a/src/qobj/functions.jl
+++ b/src/qobj/functions.jl
@@ -261,15 +261,23 @@ end
 
 @doc raw"""
     vec2mat(A::QuantumObject)
+    vector_to_operator(A::QuantumObject)
 
 Convert a quantum object from vector ([`OperatorKetQuantumObject`](@ref)-type) to matrix ([`OperatorQuantumObject`](@ref)-type)
+
+!!! note
+    `vector_to_operator` is a synonym of `vec2mat`.
 """
 vec2mat(A::QuantumObject{OperatorKetQuantumObject}) = QuantumObject(vec2mat(A.data), Operator, A.dimensions)
 
 @doc raw"""
     mat2vec(A::QuantumObject)
+    operator_to_vector(A::QuantumObject)
 
 Convert a quantum object from matrix ([`OperatorQuantumObject`](@ref)-type) to vector ([`OperatorKetQuantumObject`](@ref)-type)
+
+!!! note
+    `operator_to_vector` is a synonym of `mat2vec`.
 """
 mat2vec(A::QuantumObject{OperatorQuantumObject}) = QuantumObject(mat2vec(A.data), OperatorKet, A.dimensions)
 

--- a/src/qobj/synonyms.jl
+++ b/src/qobj/synonyms.jl
@@ -6,6 +6,7 @@ export Qobj, QobjEvo, shape, isherm
 export trans, dag, matrix_element, unit
 export tensor, ⊗
 export qeye
+export vector_to_operator, operator_to_vector
 export sqrtm, logm, expm, sinm, cosm
 
 @doc raw"""
@@ -51,6 +52,9 @@ const tensor = kron
 const ⊗ = kron
 
 const qeye = eye
+
+const vector_to_operator = vec2mat
+const operator_to_vector = mat2vec
 
 @doc raw"""
     sqrtm(A::QuantumObject)

--- a/test/core-test/quantum_objects.jl
+++ b/test/core-test/quantum_objects.jl
@@ -125,10 +125,10 @@
         H = 0.3 * sigmax() + 0.7 * sigmaz()
         L = liouvillian(H)
         ρ = Qobj(rand(ComplexF64, 2, 2))
-        ρ_ket = mat2vec(ρ)
+        ρ_ket = operator_to_vector(ρ)
         ρ_bra = ρ_ket'
-        @test ρ_bra == Qobj(mat2vec(ρ.data)', type = OperatorBra)
-        @test ρ == vec2mat(ρ_ket)
+        @test ρ_bra == Qobj(operator_to_vector(ρ.data)', type = OperatorBra)
+        @test ρ == vector_to_opeartor(ρ_ket)
         @test isket(ρ_ket) == false
         @test isbra(ρ_ket) == false
         @test isoper(ρ_ket) == false

--- a/test/core-test/quantum_objects.jl
+++ b/test/core-test/quantum_objects.jl
@@ -128,7 +128,7 @@
         ρ_ket = operator_to_vector(ρ)
         ρ_bra = ρ_ket'
         @test ρ_bra == Qobj(operator_to_vector(ρ.data)', type = OperatorBra)
-        @test ρ == vector_to_opeartor(ρ_ket)
+        @test ρ == vector_to_operator(ρ_ket)
         @test isket(ρ_ket) == false
         @test isbra(ρ_ket) == false
         @test isoper(ρ_ket) == false


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
The functions `mat2vec` and `vec2mat` are called `operator_to_vector` and `vector_to_operator`, respectively.

Therefore, I made them as synonyms.
