### PR TITLE
Add support for `OperatorKet` state input for `mesolve` and `smesolve`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
+- Add support for `OperatorKet` state input for `mesolve` and `smesolve`. ([#423])
+
 ## [v0.28.0]
 Release date: 2025-02-22
 
@@ -171,3 +173,4 @@ Release date: 2024-11-13
 [#419]: https://github.com/qutip/QuantumToolbox.jl/issues/419
 [#420]: https://github.com/qutip/QuantumToolbox.jl/issues/420
 [#421]: https://github.com/qutip/QuantumToolbox.jl/issues/421
+[#423]: https://github.com/qutip/QuantumToolbox.jl/issues/423

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -33,7 +33,7 @@ where
 # Arguments
 
 - `H`: Hamiltonian of the system ``\hat{H}``. It can be either a [`QuantumObject`](@ref), a [`QuantumObjectEvolution`](@ref), or a `Tuple` of operator-function pairs.
-- `ψ0`: Initial state of the system ``|\psi(0)\rangle``. It can be either a [`Ket`](@ref) or a [`Operator`](@ref).
+- `ψ0`: Initial state of the system ``|\psi(0)\rangle``. It can be either a [`Ket`](@ref), [`Operator`](@ref) or [`OperatorKet`](@ref).
 - `tlist`: List of times at which to save either the state or the expectation values of the system.
 - `c_ops`: List of collapse operators ``\{\hat{C}_n\}_n``. It can be either a `Vector` or a `Tuple`.
 - `e_ops`: List of operators for which to calculate expectation values. It can be either a `Vector` or a `Tuple`.
@@ -65,7 +65,7 @@ function mesolveProblem(
     kwargs...,
 ) where {
     HOpType<:Union{OperatorQuantumObject,SuperOperatorQuantumObject},
-    StateOpType<:Union{KetQuantumObject,OperatorQuantumObject},
+    StateOpType<:Union{KetQuantumObject,OperatorQuantumObject,OperatorKetQuantumObject},
 }
     haskey(kwargs, :save_idxs) &&
         throw(ArgumentError("The keyword argument \"save_idxs\" is not supported in QuantumToolbox."))
@@ -76,7 +76,11 @@ function mesolveProblem(
     check_dimensions(L_evo, ψ0)
 
     T = Base.promote_eltype(L_evo, ψ0)
-    ρ0 = to_dense(_CType(T), mat2vec(ket2dm(ψ0).data)) # Convert it to dense vector with complex element type
+    ρ0 = if isoperket(ψ0) # Convert it to dense vector with complex element type
+        to_dense(_CType(T), copy(ψ0.data))
+    else
+        to_dense(_CType(T), mat2vec(ket2dm(ψ0).data)) 
+    end
     L = L_evo.data
 
     kwargs2 = _merge_saveat(tlist, e_ops, DEFAULT_ODE_SOLVER_OPTIONS; kwargs...)
@@ -85,7 +89,7 @@ function mesolveProblem(
     tspan = (tlist[1], tlist[end])
     prob = ODEProblem{getVal(inplace),FullSpecialize}(L, ρ0, tspan, params; kwargs3...)
 
-    return TimeEvolutionProblem(prob, tlist, L_evo.dimensions)
+    return TimeEvolutionProblem(prob, tlist, L_evo.dimensions, (isoperket=Val(isoperket(ψ0)),))
 end
 
 @doc raw"""
@@ -117,7 +121,7 @@ where
 # Arguments
 
 - `H`: Hamiltonian of the system ``\hat{H}``. It can be either a [`QuantumObject`](@ref), a [`QuantumObjectEvolution`](@ref), or a `Tuple` of operator-function pairs.
-- `ψ0`: Initial state of the system ``|\psi(0)\rangle``. It can be either a [`Ket`](@ref) or a [`Operator`](@ref).
+- `ψ0`: Initial state of the system ``|\psi(0)\rangle``. It can be either a [`Ket`](@ref), [`Operator`](@ref) or [`OperatorKet`](@ref).
 - `tlist`: List of times at which to save either the state or the expectation values of the system.
 - `c_ops`: List of collapse operators ``\{\hat{C}_n\}_n``. It can be either a `Vector` or a `Tuple`.
 - `alg`: The algorithm for the ODE solver. The default value is `Tsit5()`.
@@ -152,7 +156,7 @@ function mesolve(
     kwargs...,
 ) where {
     HOpType<:Union{OperatorQuantumObject,SuperOperatorQuantumObject},
-    StateOpType<:Union{KetQuantumObject,OperatorQuantumObject},
+    StateOpType<:Union{KetQuantumObject,OperatorQuantumObject,OperatorKetQuantumObject},
 }
     prob = mesolveProblem(
         H,
@@ -173,7 +177,12 @@ end
 function mesolve(prob::TimeEvolutionProblem, alg::OrdinaryDiffEqAlgorithm = Tsit5())
     sol = solve(prob.prob, alg)
 
-    ρt = map(ϕ -> QuantumObject(vec2mat(ϕ), type = Operator, dims = prob.dimensions), sol.u)
+    # No type instabilities since `isoperket` is a Val, and so it is known at compile time
+    if getVal(prob.kwargs.isoperket)
+        ρt = map(ϕ -> QuantumObject(ϕ, type = OperatorKet, dims = prob.dimensions), sol.u)
+    else
+        ρt = map(ϕ -> QuantumObject(vec2mat(ϕ), type = Operator, dims = prob.dimensions), sol.u)
+    end
 
     return TimeEvolutionSol(
         prob.times,

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -79,7 +79,7 @@ function mesolveProblem(
     ρ0 = if isoperket(ψ0) # Convert it to dense vector with complex element type
         to_dense(_CType(T), copy(ψ0.data))
     else
-        to_dense(_CType(T), mat2vec(ket2dm(ψ0).data)) 
+        to_dense(_CType(T), mat2vec(ket2dm(ψ0).data))
     end
     L = L_evo.data
 
@@ -89,7 +89,7 @@ function mesolveProblem(
     tspan = (tlist[1], tlist[end])
     prob = ODEProblem{getVal(inplace),FullSpecialize}(L, ρ0, tspan, params; kwargs3...)
 
-    return TimeEvolutionProblem(prob, tlist, L_evo.dimensions, (isoperket=Val(isoperket(ψ0)),))
+    return TimeEvolutionProblem(prob, tlist, L_evo.dimensions, (isoperket = Val(isoperket(ψ0)),))
 end
 
 @doc raw"""

--- a/src/time_evolution/smesolve.jl
+++ b/src/time_evolution/smesolve.jl
@@ -104,7 +104,7 @@ function smesolveProblem(
     ρ0 = if isoperket(ψ0) # Convert it to dense vector with complex element type
         to_dense(_CType(T), copy(ψ0.data))
     else
-        to_dense(_CType(T), mat2vec(ket2dm(ψ0).data)) 
+        to_dense(_CType(T), mat2vec(ket2dm(ψ0).data))
     end
 
     progr = ProgressBar(length(tlist), enable = getVal(progress_bar))
@@ -148,7 +148,7 @@ function smesolveProblem(
         kwargs3...,
     )
 
-    return TimeEvolutionProblem(prob, tlist, dims, (isoperket=Val(isoperket(ψ0)),))
+    return TimeEvolutionProblem(prob, tlist, dims, (isoperket = Val(isoperket(ψ0)),))
 end
 
 @doc raw"""

--- a/test/core-test/time_evolution.jl
+++ b/test/core-test/time_evolution.jl
@@ -158,6 +158,11 @@
         )
         sol_sme3 = smesolve(H, ψ0, tlist, c_ops_sme2, sc_ops_sme2, e_ops = e_ops, progress_bar = Val(false))
 
+        # For testing the `OperatorKet` input
+        sol_me4 = mesolve(H, operator_to_vector(ket2dm(ψ0)), tlist, c_ops, saveat=saveat, progress_bar = Val(false))
+        sol_sme4 = smesolve(H, ψ0, tlist, c_ops_sme, sc_ops_sme, saveat=saveat, ntraj=10, progress_bar = Val(false), rng = MersenneTwister(12))
+        sol_sme5 = smesolve(H, operator_to_vector(ket2dm(ψ0)), tlist, c_ops_sme, sc_ops_sme, saveat=saveat, ntraj=10, progress_bar = Val(false), rng = MersenneTwister(12))
+
         ρt_mc = [ket2dm.(normalize.(states)) for states in sol_mc_states.states]
         expect_mc_states = mapreduce(states -> expect.(Ref(e_ops[1]), states), hcat, ρt_mc)
         expect_mc_states_mean = sum(expect_mc_states, dims = 2) / size(expect_mc_states, 2)
@@ -190,6 +195,7 @@
         @test length(sol_me3.states) == length(saveat)
         @test size(sol_me3.expect) == (length(e_ops), length(tlist))
         @test sol_me3.expect[1, saveat_idxs] ≈ expect(e_ops[1], sol_me3.states) atol = 1e-6
+        @test all([sol_me3.states[i] ≈ vector_to_operator(sol_me4.states[i]) for i in eachindex(saveat)])
         @test length(sol_mc.times) == length(tlist)
         @test size(sol_mc.expect) == (length(e_ops), length(tlist))
         @test length(sol_mc_states.times) == length(tlist)
@@ -202,6 +208,7 @@
         @test isnothing(sol_sme.measurement)
         @test size(sol_sse2.measurement) == (length(c_ops), 20, length(tlist) - 1)
         @test size(sol_sme2.measurement) == (length(sc_ops_sme), 20, length(tlist) - 1)
+        @test all([sol_sme4.states[j][i] ≈ vector_to_operator(sol_sme5.states[j][i]) for i in eachindex(saveat), j in 1:10])
 
         @test sol_me_string ==
               "Solution of time evolution\n" *

--- a/test/core-test/time_evolution.jl
+++ b/test/core-test/time_evolution.jl
@@ -159,9 +159,29 @@
         sol_sme3 = smesolve(H, ψ0, tlist, c_ops_sme2, sc_ops_sme2, e_ops = e_ops, progress_bar = Val(false))
 
         # For testing the `OperatorKet` input
-        sol_me4 = mesolve(H, operator_to_vector(ket2dm(ψ0)), tlist, c_ops, saveat=saveat, progress_bar = Val(false))
-        sol_sme4 = smesolve(H, ψ0, tlist, c_ops_sme, sc_ops_sme, saveat=saveat, ntraj=10, progress_bar = Val(false), rng = MersenneTwister(12))
-        sol_sme5 = smesolve(H, operator_to_vector(ket2dm(ψ0)), tlist, c_ops_sme, sc_ops_sme, saveat=saveat, ntraj=10, progress_bar = Val(false), rng = MersenneTwister(12))
+        sol_me4 = mesolve(H, operator_to_vector(ket2dm(ψ0)), tlist, c_ops, saveat = saveat, progress_bar = Val(false))
+        sol_sme4 = smesolve(
+            H,
+            ψ0,
+            tlist,
+            c_ops_sme,
+            sc_ops_sme,
+            saveat = saveat,
+            ntraj = 10,
+            progress_bar = Val(false),
+            rng = MersenneTwister(12),
+        )
+        sol_sme5 = smesolve(
+            H,
+            operator_to_vector(ket2dm(ψ0)),
+            tlist,
+            c_ops_sme,
+            sc_ops_sme,
+            saveat = saveat,
+            ntraj = 10,
+            progress_bar = Val(false),
+            rng = MersenneTwister(12),
+        )
 
         ρt_mc = [ket2dm.(normalize.(states)) for states in sol_mc_states.states]
         expect_mc_states = mapreduce(states -> expect.(Ref(e_ops[1]), states), hcat, ρt_mc)
@@ -208,7 +228,9 @@
         @test isnothing(sol_sme.measurement)
         @test size(sol_sse2.measurement) == (length(c_ops), 20, length(tlist) - 1)
         @test size(sol_sme2.measurement) == (length(sc_ops_sme), 20, length(tlist) - 1)
-        @test all([sol_sme4.states[j][i] ≈ vector_to_operator(sol_sme5.states[j][i]) for i in eachindex(saveat), j in 1:10])
+        @test all([
+            sol_sme4.states[j][i] ≈ vector_to_operator(sol_sme5.states[j][i]) for i in eachindex(saveat), j in 1:10
+        ])
 
         @test sol_me_string ==
               "Solution of time evolution\n" *


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Add the support for `OperatorKet` state input for `mesolve` and `smesolve`.
