### PR TITLE
move and rename eltype conversion

### DIFF
--- a/ext/QuantumToolboxCUDAExt.jl
+++ b/ext/QuantumToolboxCUDAExt.jl
@@ -2,7 +2,7 @@ module QuantumToolboxCUDAExt
 
 using QuantumToolbox
 using QuantumToolbox: makeVal, getVal
-import QuantumToolbox: _sparse_similar
+import QuantumToolbox: _sparse_similar, _convert_eltype_wordsize
 import CUDA: cu, CuArray, allowscalar
 import CUDA.CUSPARSE: CuSparseVector, CuSparseMatrixCSC, CuSparseMatrixCSR, AbstractCuSparseArray
 import SparseArrays: SparseVector, SparseMatrixCSC
@@ -81,26 +81,19 @@ function cu(A::QuantumObject; word_size::Union{Val,Int} = Val(64))
 
     return cu(A, makeVal(word_size))
 end
-cu(A::QuantumObject, word_size::Union{Val{32},Val{64}}) = CuArray{_change_eltype(eltype(A), word_size)}(A)
+cu(A::QuantumObject, word_size::Union{Val{32},Val{64}}) = CuArray{_convert_eltype_wordsize(eltype(A), word_size)}(A)
 function cu(
     A::QuantumObject{ObjType,DimsType,<:SparseVector},
     word_size::Union{Val{32},Val{64}},
 ) where {ObjType<:QuantumObjectType,DimsType<:AbstractDimensions}
-    return CuSparseVector{_change_eltype(eltype(A), word_size)}(A)
+    return CuSparseVector{_convert_eltype_wordsize(eltype(A), word_size)}(A)
 end
 function cu(
     A::QuantumObject{ObjType,DimsType,<:SparseMatrixCSC},
     word_size::Union{Val{32},Val{64}},
 ) where {ObjType<:QuantumObjectType,DimsType<:AbstractDimensions}
-    return CuSparseMatrixCSC{_change_eltype(eltype(A), word_size)}(A)
+    return CuSparseMatrixCSC{_convert_eltype_wordsize(eltype(A), word_size)}(A)
 end
-
-_change_eltype(::Type{T}, ::Val{64}) where {T<:Int} = Int64
-_change_eltype(::Type{T}, ::Val{32}) where {T<:Int} = Int32
-_change_eltype(::Type{T}, ::Val{64}) where {T<:AbstractFloat} = Float64
-_change_eltype(::Type{T}, ::Val{32}) where {T<:AbstractFloat} = Float32
-_change_eltype(::Type{Complex{T}}, ::Val{64}) where {T<:Union{Int,AbstractFloat}} = ComplexF64
-_change_eltype(::Type{Complex{T}}, ::Val{32}) where {T<:Union{Int,AbstractFloat}} = ComplexF32
 
 QuantumToolbox.to_dense(A::MT) where {MT<:AbstractCuSparseArray} = CuArray(A)
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -190,3 +190,10 @@ _CType(::Type{Complex{Int32}}) = ComplexF32
 _CType(::Type{Complex{Int64}}) = ComplexF64
 _CType(::Type{Complex{Float32}}) = ComplexF32
 _CType(::Type{Complex{Float64}}) = ComplexF64
+
+_convert_eltype_wordsize(::Type{T}, ::Val{64}) where {T<:Int} = Int64
+_convert_eltype_wordsize(::Type{T}, ::Val{32}) where {T<:Int} = Int32
+_convert_eltype_wordsize(::Type{T}, ::Val{64}) where {T<:AbstractFloat} = Float64
+_convert_eltype_wordsize(::Type{T}, ::Val{32}) where {T<:AbstractFloat} = Float32
+_convert_eltype_wordsize(::Type{Complex{T}}, ::Val{64}) where {T<:Union{Int,AbstractFloat}} = ComplexF64
+_convert_eltype_wordsize(::Type{Complex{T}}, ::Val{32}) where {T<:Union{Int,AbstractFloat}} = ComplexF32


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Move `_change_eltype`  in CUDA extension to `utilities.jl` and rename it as `_convert_eltype_wordsize`