### PR TITLE
Make CUDA conversion more general

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
+- Make CUDA conversion more general using Adapt.jl. ([#437])
+
 ## [v0.29.1]
 Release date: 2025-03-07
 
@@ -187,3 +189,4 @@ Release date: 2024-11-13
 [#423]: https://github.com/qutip/QuantumToolbox.jl/issues/423
 [#428]: https://github.com/qutip/QuantumToolbox.jl/issues/428
 [#430]: https://github.com/qutip/QuantumToolbox.jl/issues/430
+[#437]: https://github.com/qutip/QuantumToolbox.jl/issues/437

--- a/ext/QuantumToolboxCUDAExt.jl
+++ b/ext/QuantumToolboxCUDAExt.jl
@@ -82,7 +82,8 @@ function cu(A::QuantumObject; word_size::Union{Val,Int} = Val(64))
 
     return cu(A, makeVal(word_size))
 end
-cu(A::QuantumObject, word_size::Union{Val{32},Val{64}}) = QuantumObject(adapt(CuArray{_convert_eltype_wordsize(eltype(A), word_size)}, A.data), A.type, A.dimensions)
+cu(A::QuantumObject, word_size::Union{Val{32},Val{64}}) =
+    QuantumObject(adapt(CuArray{_convert_eltype_wordsize(eltype(A), word_size)}, A.data), A.type, A.dimensions)
 function cu(
     A::QuantumObject{ObjType,DimsType,<:SparseVector},
     word_size::Union{Val{32},Val{64}},

--- a/ext/QuantumToolboxCUDAExt.jl
+++ b/ext/QuantumToolboxCUDAExt.jl
@@ -6,6 +6,7 @@ import QuantumToolbox: _sparse_similar, _convert_eltype_wordsize
 import CUDA: cu, CuArray, allowscalar
 import CUDA.CUSPARSE: CuSparseVector, CuSparseMatrixCSC, CuSparseMatrixCSR, AbstractCuSparseArray
 import SparseArrays: SparseVector, SparseMatrixCSC
+import CUDA.Adapt: adapt
 
 allowscalar(false)
 
@@ -81,7 +82,7 @@ function cu(A::QuantumObject; word_size::Union{Val,Int} = Val(64))
 
     return cu(A, makeVal(word_size))
 end
-cu(A::QuantumObject, word_size::Union{Val{32},Val{64}}) = CuArray{_convert_eltype_wordsize(eltype(A), word_size)}(A)
+cu(A::QuantumObject, word_size::Union{Val{32},Val{64}}) = QuantumObject(adapt(CuArray{_convert_eltype_wordsize(eltype(A), word_size)}, A.data), A.type, A.dimensions)
 function cu(
     A::QuantumObject{ObjType,DimsType,<:SparseVector},
     word_size::Union{Val{32},Val{64}},

--- a/test/ext-test/gpu/cuda_ext.jl
+++ b/test/ext-test/gpu/cuda_ext.jl
@@ -66,6 +66,10 @@
     @test typeof(CuSparseMatrixCSR(Xsc).data) == CuSparseMatrixCSR{ComplexF64,Int32}
     @test typeof(CuSparseMatrixCSR{ComplexF32}(Xsc).data) == CuSparseMatrixCSR{ComplexF32,Int32}
 
+    # type conversion of CUDA Diagonal arrays
+    @test cu(qeye(10), word_size=Val(32)).data isa Diagonal{ComplexF32, <:CuVector{ComplexF32}}
+    @test cu(qeye(10), word_size=Val(64)).data isa Diagonal{ComplexF64, <:CuVector{ComplexF64}}
+
     # Sparse To Dense
     # @test to_dense(cu(ψsi; word_size = 64)).data isa CuVector{Int64} # TODO: Fix this in CUDA.jl
     @test to_dense(cu(ψsf; word_size = 64)).data isa CuVector{Float64}

--- a/test/ext-test/gpu/cuda_ext.jl
+++ b/test/ext-test/gpu/cuda_ext.jl
@@ -67,8 +67,8 @@
     @test typeof(CuSparseMatrixCSR{ComplexF32}(Xsc).data) == CuSparseMatrixCSR{ComplexF32,Int32}
 
     # type conversion of CUDA Diagonal arrays
-    @test cu(qeye(10), word_size=Val(32)).data isa Diagonal{ComplexF32, <:CuVector{ComplexF32}}
-    @test cu(qeye(10), word_size=Val(64)).data isa Diagonal{ComplexF64, <:CuVector{ComplexF64}}
+    @test cu(qeye(10), word_size = Val(32)).data isa Diagonal{ComplexF32,<:CuVector{ComplexF32}}
+    @test cu(qeye(10), word_size = Val(64)).data isa Diagonal{ComplexF64,<:CuVector{ComplexF64}}
 
     # Sparse To Dense
     # @test to_dense(cu(ψsi; word_size = 64)).data isa CuVector{Int64} # TODO: Fix this in CUDA.jl


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
The PR [here](https://github.com/JuliaGPU/CUDA.jl/pull/2729) is not going to be merged. In the meantime I made a few changes to make the CUDA conversion more general using `Adapt`.

## Related issues or PRs
Fixes #436 
