### PR TITLE
Make `fock` non-mutating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
 - Make CUDA conversion more general using Adapt.jl. ([#437])
+- Make the generation of `fock` states non-mutating to support Zygote.jl. ([#438])
 
 ## [v0.29.1]
 Release date: 2025-03-07
@@ -190,3 +191,4 @@ Release date: 2024-11-13
 [#428]: https://github.com/qutip/QuantumToolbox.jl/issues/428
 [#430]: https://github.com/qutip/QuantumToolbox.jl/issues/430
 [#437]: https://github.com/qutip/QuantumToolbox.jl/issues/437
+[#438]: https://github.com/qutip/QuantumToolbox.jl/issues/438

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
-- Make CUDA conversion more general using Adapt.jl. ([#437])
+- Make CUDA conversion more general using Adapt.jl. ([#436], [#437])
 - Make the generation of `fock` states non-mutating to support Zygote.jl. ([#438])
 
 ## [v0.29.1]
@@ -190,5 +190,6 @@ Release date: 2024-11-13
 [#423]: https://github.com/qutip/QuantumToolbox.jl/issues/423
 [#428]: https://github.com/qutip/QuantumToolbox.jl/issues/428
 [#430]: https://github.com/qutip/QuantumToolbox.jl/issues/430
+[#436]: https://github.com/qutip/QuantumToolbox.jl/issues/436
 [#437]: https://github.com/qutip/QuantumToolbox.jl/issues/437
 [#438]: https://github.com/qutip/QuantumToolbox.jl/issues/438

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -37,8 +37,7 @@ function fock(N::Int, j::Int = 0; dims::Union{Int,AbstractVector{Int},Tuple} = N
     if getVal(sparse)
         array = sparsevec([j + 1], [1.0 + 0im], N)
     else
-        array = zeros(ComplexF64, N)
-        array[j+1] = 1
+        array = [j == i ? 1.0 + 0im : 0.0 + 0im for j in 1:N]
     end
     return QuantumObject(array; type = Ket, dims = dims)
 end

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -37,7 +37,7 @@ function fock(N::Int, j::Int = 0; dims::Union{Int,AbstractVector{Int},Tuple} = N
     if getVal(sparse)
         array = sparsevec([j + 1], [1.0 + 0im], N)
     else
-        array = [j == i ? 1.0 + 0im : 0.0 + 0im for j in 1:N]
+        array = [i == j ? 1.0 + 0im : 0.0 + 0im for i in 1:N]
     end
     return QuantumObject(array; type = Ket, dims = dims)
 end

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -37,7 +37,7 @@ function fock(N::Int, j::Int = 0; dims::Union{Int,AbstractVector{Int},Tuple} = N
     if getVal(sparse)
         array = sparsevec([j + 1], [1.0 + 0im], N)
     else
-        array = [i == j ? 1.0 + 0im : 0.0 + 0im for i in 1:N]
+        array = [i == (j+1) ? 1.0 + 0im : 0.0 + 0im for i in 1:N]
     end
     return QuantumObject(array; type = Ket, dims = dims)
 end

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -37,7 +37,7 @@ function fock(N::Int, j::Int = 0; dims::Union{Int,AbstractVector{Int},Tuple} = N
     if getVal(sparse)
         array = sparsevec([j + 1], [1.0 + 0im], N)
     else
-        array = [i == (j+1) ? 1.0 + 0im : 0.0 + 0im for i in 1:N]
+        array = [i == (j + 1) ? 1.0 + 0im : 0.0 + 0im for i in 1:N]
     end
     return QuantumObject(array; type = Ket, dims = dims)
 end


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Here I do a small change in the generation of a `fock` state, using comprehension instead of creating a zero vector and then mutating one element. This would support Zygote.jl differentiation, as it doesn't support mutating arrays.