### PR TITLE
Make Makie extension more general

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,7 +67,7 @@ jobs:
             node:
               os: 'ubuntu-latest'
               arch: 'x64'
-            group: 'CairoMakie_Ext'
+            group: 'Makie_Ext'
           - version: '1'
             node:
               os: 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
 - Support different length for `to` and `from` on GeneralDimensions. ([#448])
+- Extend the `Makie.jl` extension to all the other available backends. ([#450])
 
 ## [v0.30.0]
 Release date: 2025-04-12
@@ -204,3 +205,4 @@ Release date: 2024-11-13
 [#440]: https://github.com/qutip/QuantumToolbox.jl/issues/440
 [#443]: https://github.com/qutip/QuantumToolbox.jl/issues/443
 [#448]: https://github.com/qutip/QuantumToolbox.jl/issues/448
+[#450]: https://github.com/qutip/QuantumToolbox.jl/issues/450

--- a/Project.toml
+++ b/Project.toml
@@ -27,13 +27,13 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [extensions]
-QuantumToolboxCairoMakieExt = "CairoMakie"
+QuantumToolboxMakieExt = "Makie"
 QuantumToolboxChainRulesCoreExt = "ChainRulesCore"
 QuantumToolboxCUDAExt = "CUDA"
 QuantumToolboxGPUArraysExt = ["GPUArrays", "KernelAbstractions"]
@@ -41,7 +41,6 @@ QuantumToolboxGPUArraysExt = ["GPUArrays", "KernelAbstractions"]
 [compat]
 ArrayInterface = "6, 7"
 CUDA = "5"
-CairoMakie = "0.12, 0.13"
 ChainRulesCore = "1"
 DiffEqBase = "6"
 DiffEqCallbacks = "4.2.1 - 4"
@@ -54,6 +53,7 @@ IncompleteLU = "0.2"
 KernelAbstractions = "0.9.2"
 LinearAlgebra = "1"
 LinearSolve = "2, 3"
+Makie = "0.20, 0.21, 0.22"
 OrdinaryDiffEqCore = "1"
 OrdinaryDiffEqTsit5 = "1"
 Pkg = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -81,7 +81,7 @@ const PAGES = [
 makedocs(;
     modules = [
         QuantumToolbox, 
-        Base.get_extension(QuantumToolbox, :QuantumToolboxCairoMakieExt),
+        Base.get_extension(QuantumToolbox, :QuantumToolboxMakieExt),
     ],
     authors = "Alberto Mercurio and Yi-Te Huang",
     repo = Remotes.GitHub("qutip", "QuantumToolbox.jl"),

--- a/docs/src/getting_started/logo.md
+++ b/docs/src/getting_started/logo.md
@@ -76,7 +76,7 @@ xvec = range(-ρ, ρ, 500) .* 1.5
 yvec = xvec .+ (abs(imag(α1)) - abs(imag(α2))) / 2
 
 fig = Figure(size = (250, 250), figure_padding = 0)
-fig, ax, hm = plot_wigner(ψ, xvec = xvec, yvec = yvec, g = 2, library = Val(:CairoMakie), location = fig[1,1])
+fig, ax, hm = plot_wigner(ψ, xvec = xvec, yvec = yvec, g = 2, library = Val(:Makie), location = fig[1,1])
 hidespines!(ax)
 hidexdecorations!(ax)
 hideydecorations!(ax)
@@ -110,7 +110,7 @@ And the Wigner function becomes more uniform:
 
 ```@example logo
 fig = Figure(size = (250, 250), figure_padding = 0)
-fig, ax, hm = plot_wigner(sol.states[end], xvec = xvec, yvec = yvec, g = 2, library = Val(:CairoMakie), location = fig[1,1])
+fig, ax, hm = plot_wigner(sol.states[end], xvec = xvec, yvec = yvec, g = 2, library = Val(:Makie), location = fig[1,1])
 hidespines!(ax)
 hidexdecorations!(ax)
 hideydecorations!(ax)

--- a/docs/src/users_guide/extensions/cairomakie.md
+++ b/docs/src/users_guide/extensions/cairomakie.md
@@ -1,18 +1,18 @@
-# [Extension for CairoMakie.jl](@id doc:CairoMakie)
+# [Extension for the Makie.jl ecosystem](@id doc:Makie)
 
-This is an extension to support visualization (plotting functions) using [`CairoMakie.jl`](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie) library.
+This is an extension to support visualization (plotting functions) using [`Makie.jl`](https://github.com/MakieOrg/Makie.jl) library.
 
-This extension will be automatically loaded if user imports both `QuantumToolbox.jl` and [`CairoMakie.jl`](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie):
+This extension will be automatically loaded if user imports both `QuantumToolbox.jl` and [`Makie.jl`](https://github.com/MakieOrg/Makie.jl). It is worth noting that the `Makie.jl` package provides only the engine for plotting, and the user has to import the specific backend. Here we demonstrate the usage of [`CairoMakie.jl`](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie), which will automatically import `Makie.jl`.
 
 ```julia
 using QuantumToolbox
 using CairoMakie
 ```
 
-To plot with [`CairoMakie.jl`](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie) library, specify the keyword argument `library = Val(:CairoMakie)` for the plotting functions.
+To plot with [`CairoMakie.jl`](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie) library, specify the keyword argument `library = Val(:Makie)` for the plotting functions.
 
 !!! warning "Beware of type-stability!"
-    If you want to keep type stability, it is recommended to use `Val(:CairoMakie)` instead of `:CairoMakie`. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
+    If you want to keep type stability, it is recommended to use `Val(:Makie)` instead of `:Makie`. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
 
 The supported plotting functions are listed as follows:
 

--- a/ext/QuantumToolboxMakieExt.jl
+++ b/ext/QuantumToolboxMakieExt.jl
@@ -1,12 +1,12 @@
-module QuantumToolboxCairoMakieExt
+module QuantumToolboxMakieExt
 
 using QuantumToolbox
-using CairoMakie:
+using Makie:
     Axis, Axis3, Colorbar, Figure, GridLayout, heatmap!, surface!, barplot!, GridPosition, @L_str, Reverse, ylims!
 
 @doc raw"""
     plot_wigner(
-        library::Val{:CairoMakie},
+        library::Val{:Makie},
         state::QuantumObject{OpType};
         xvec::Union{Nothing,AbstractVector} = nothing,
         yvec::Union{Nothing,AbstractVector} = nothing,
@@ -18,10 +18,10 @@ using CairoMakie:
         kwargs...
     ) where {OpType}
 
-Plot the [Wigner quasipropability distribution](https://en.wikipedia.org/wiki/Wigner_quasiprobability_distribution) of `state` using the [`CairoMakie`](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie) plotting library.
+Plot the [Wigner quasipropability distribution](https://en.wikipedia.org/wiki/Wigner_quasiprobability_distribution) of `state` using the [`Makie`](https://github.com/MakieOrg/Makie.jl) plotting library.
 
 # Arguments
-- `library::Val{:CairoMakie}`: The plotting library to use.
+- `library::Val{:Makie}`: The plotting library to use.
 - `state::QuantumObject`: The quantum state for which the Wigner function is calculated. It can be either a [`Ket`](@ref), [`Bra`](@ref), or [`Operator`](@ref).
 - `xvec::AbstractVector`: The x-coordinates of the phase space grid. Defaults to a linear range from -7.5 to 7.5 with 200 points.
 - `yvec::AbstractVector`: The y-coordinates of the phase space grid. Defaults to a linear range from -7.5 to 7.5 with 200 points.
@@ -38,13 +38,13 @@ Plot the [Wigner quasipropability distribution](https://en.wikipedia.org/wiki/Wi
 - `hm`: Either the heatmap or surface object, depending on the projection.
 
 !!! note "Import library first"
-    [`CairoMakie`](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie) must first be imported before using this function.
+    [`Makie.jl`](https://github.com/MakieOrg/Makie.jl) must first be imported before using this function. This can be done by importing one of the available backends, such as [`CairoMakie.jl`](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie), [`GLMakie.jl`](https://github.com/MakieOrg/Makie.jl/tree/master/GLMakie), or [`WGLMakie.jl`](https://github.com/MakieOrg/Makie.jl/tree/master/WGLMakie).
 
 !!! warning "Beware of type-stability!"
-    If you want to keep type stability, it is recommended to use `Val(:two_dim)` and `Val(:three_dim)` instead of `:two_dim` and `:three_dim`, respectively. Also, specify the library as `Val(:CairoMakie)` See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
+    If you want to keep type stability, it is recommended to use `Val(:two_dim)` and `Val(:three_dim)` instead of `:two_dim` and `:three_dim`, respectively. Also, specify the library as `Val(:Makie)` See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
 """
 function QuantumToolbox.plot_wigner(
-    library::Val{:CairoMakie},
+    library::Val{:Makie},
     state::QuantumObject{OpType};
     xvec::Union{Nothing,AbstractVector} = LinRange(-7.5, 7.5, 200),
     yvec::Union{Nothing,AbstractVector} = LinRange(-7.5, 7.5, 200),
@@ -74,7 +74,7 @@ function QuantumToolbox.plot_wigner(
 end
 
 function _plot_wigner(
-    ::Val{:CairoMakie},
+    ::Val{:Makie},
     state::QuantumObject{OpType},
     xvec::AbstractVector,
     yvec::AbstractVector,
@@ -107,7 +107,7 @@ function _plot_wigner(
 end
 
 function _plot_wigner(
-    ::Val{:CairoMakie},
+    ::Val{:Makie},
     state::QuantumObject{OpType},
     xvec::AbstractVector,
     yvec::AbstractVector,
@@ -142,7 +142,7 @@ end
 
 @doc raw"""
     plot_fock_distribution(
-        library::Val{:CairoMakie},
+        library::Val{:Makie},
         ρ::QuantumObject{SType};
         fock_numbers::Union{Nothing, AbstractVector} = nothing,
         unit_y_range::Bool = true,
@@ -153,7 +153,7 @@ end
 Plot the [Fock state](https://en.wikipedia.org/wiki/Fock_state) distribution of `ρ`. 
 
 # Arguments
-- `library::Val{:CairoMakie}`: The plotting library to use.
+- `library::Val{:Makie}`: The plotting library to use.
 - `ρ::QuantumObject`: The quantum state for which the Fock state distribution is to be plotted. It can be either a [`Ket`](@ref), [`Bra`](@ref), or [`Operator`](@ref).
 - `location::Union{GridPosition,Nothing}`: The location of the plot in the layout. If `nothing`, the plot is created in a new figure. Default is `nothing`.
 - `fock_numbers::Union{Nothing, AbstractVector}`: list of x ticklabels to represent fock numbers, default is `nothing`.
@@ -166,13 +166,13 @@ Plot the [Fock state](https://en.wikipedia.org/wiki/Fock_state) distribution of 
 - `bp`: The barplot object.
 
 !!! note "Import library first"
-    [`CairoMakie`](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie) must first be imported before using this function.
+    [`Makie.jl`](https://github.com/MakieOrg/Makie.jl) must first be imported before using this function. This can be done by importing one of the available backends, such as [`CairoMakie.jl`](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie), [`GLMakie.jl`](https://github.com/MakieOrg/Makie.jl/tree/master/GLMakie), or [`WGLMakie.jl`](https://github.com/MakieOrg/Makie.jl/tree/master/WGLMakie).
 
 !!! warning "Beware of type-stability!"
-    If you want to keep type stability, it is recommended to use `Val(:two_dim)` and `Val(:three_dim)` instead of `:two_dim` and `:three_dim`, respectively. Also, specify the library as `Val(:CairoMakie)` See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
+    If you want to keep type stability, it is recommended to use `Val(:two_dim)` and `Val(:three_dim)` instead of `:two_dim` and `:three_dim`, respectively. Also, specify the library as `Val(:Makie)` See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
 """
 function QuantumToolbox.plot_fock_distribution(
-    library::Val{:CairoMakie},
+    library::Val{:Makie},
     ρ::QuantumObject{SType};
     fock_numbers::Union{Nothing,AbstractVector} = nothing,
     unit_y_range::Bool = true,
@@ -190,7 +190,7 @@ function QuantumToolbox.plot_fock_distribution(
 end
 
 function _plot_fock_distribution(
-    ::Val{:CairoMakie},
+    ::Val{:Makie},
     ρ::QuantumObject{SType};
     fock_numbers::Union{Nothing,AbstractVector} = nothing,
     unit_y_range::Bool = true,

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -3,28 +3,28 @@ export plot_wigner, plot_fock_distribution
 @doc raw"""
     plot_wigner(
         state::QuantumObject{OpType}; 
-        library::Union{Val,Symbol}=Val(:CairoMakie), 
+        library::Union{Val,Symbol}=Val(:Makie), 
         kwargs...
     ) where {OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}
 
 Plot the [Wigner quasipropability distribution](https://en.wikipedia.org/wiki/Wigner_quasiprobability_distribution) of `state` using the [`wigner`](@ref) function. 
     
-The `library` keyword argument specifies the plotting library to use, defaulting to [`CairoMakie`](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie). 
+The `library` keyword argument specifies the plotting library to use, defaulting to [`Makie.jl`](https://github.com/MakieOrg/Makie.jl). 
 
 # Arguments
 - `state::QuantumObject`: The quantum state for which to plot the Wigner distribution.
-- `library::Union{Val,Symbol}`: The plotting library to use. Default is `Val(:CairoMakie)`.
+- `library::Union{Val,Symbol}`: The plotting library to use. Default is `Val(:Makie)`.
 - `kwargs...`: Additional keyword arguments to pass to the plotting function. See the documentation for the specific plotting library for more information.
 
 !!! note "Import library first"
     The plotting libraries must first be imported before using them with this function.
 
 !!! warning "Beware of type-stability!"
-    If you want to keep type stability, it is recommended to use `Val(:CairoMakie)` instead of `:CairoMakie` as the plotting library. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
+    If you want to keep type stability, it is recommended to use `Val(:Makie)` instead of `:Makie` as the plotting library. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
 """
 plot_wigner(
     state::QuantumObject{OpType};
-    library::Union{Val,Symbol} = Val(:CairoMakie),
+    library::Union{Val,Symbol} = Val(:Makie),
     kwargs...,
 ) where {OpType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}} =
     plot_wigner(makeVal(library), state; kwargs...)
@@ -39,28 +39,28 @@ plot_wigner(
 @doc raw"""
     plot_fock_distribution(
         ρ::QuantumObject{SType};
-        library::Union{Val, Symbol} = Val(:CairoMakie),
+        library::Union{Val, Symbol} = Val(:Makie),
         kwargs...
     ) where {SType<:Union{KetQuantumObject,OperatorQuantumObject}}
 
 Plot the [Fock state](https://en.wikipedia.org/wiki/Fock_state) distribution of `ρ`. 
     
-The `library` keyword argument specifies the plotting library to use, defaulting to [`CairoMakie`](https://github.com/MakieOrg/Makie.jl/tree/master/CairoMakie). 
+The `library` keyword argument specifies the plotting library to use, defaulting to [`Makie`](https://github.com/MakieOrg/Makie.jl). 
 
 # Arguments
 - `ρ::QuantumObject`: The quantum state for which to plot the Fock state distribution.
-- `library::Union{Val,Symbol}`: The plotting library to use. Default is `Val(:CairoMakie)`.
+- `library::Union{Val,Symbol}`: The plotting library to use. Default is `Val(:Makie)`.
 - `kwargs...`: Additional keyword arguments to pass to the plotting function. See the documentation for the specific plotting library for more information.
 
 !!! note "Import library first"
     The plotting libraries must first be imported before using them with this function.
 
 !!! warning "Beware of type-stability!"
-    If you want to keep type stability, it is recommended to use `Val(:CairoMakie)` instead of `:CairoMakie` as the plotting library. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
+    If you want to keep type stability, it is recommended to use `Val(:Makie)` instead of `:Makie` as the plotting library. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
 """
 plot_fock_distribution(
     ρ::QuantumObject{SType};
-    library::Union{Val,Symbol} = Val(:CairoMakie),
+    library::Union{Val,Symbol} = Val(:Makie),
     kwargs...,
 ) where {SType<:Union{BraQuantumObject,KetQuantumObject,OperatorQuantumObject}} =
     plot_fock_distribution(makeVal(library), ρ; kwargs...)

--- a/test/ext-test/cpu/cairomakie/Project.toml
+++ b/test/ext-test/cpu/cairomakie/Project.toml
@@ -1,6 +1,0 @@
-[deps]
-CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-QuantumToolbox = "6c2fb7c5-b903-41d2-bc5e-5a7c320b9fab"
-
-[compat]
-CairoMakie = "0.12"

--- a/test/ext-test/cpu/makie/Project.toml
+++ b/test/ext-test/cpu/makie/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+QuantumToolbox = "6c2fb7c5-b903-41d2-bc5e-5a7c320b9fab"

--- a/test/ext-test/cpu/makie/makie_ext.jl
+++ b/test/ext-test/cpu/makie/makie_ext.jl
@@ -9,27 +9,15 @@
 
     using Makie
 
-    fig, ax, hm = plot_wigner(
-        ψ;
-        library = Val(:Makie),
-        xvec = xvec,
-        yvec = yvec,
-        projection = Val(:two_dim),
-        colorbar = true,
-    )
+    fig, ax, hm =
+        plot_wigner(ψ; library = Val(:Makie), xvec = xvec, yvec = yvec, projection = Val(:two_dim), colorbar = true)
     @test fig isa Figure
     @test ax isa Axis
     @test hm isa Heatmap
     @test all(isapprox.(hm[3].val, wig, atol = 1e-6))
 
-    fig, ax, surf = plot_wigner(
-        ψ;
-        library = Val(:Makie),
-        xvec = xvec,
-        yvec = yvec,
-        projection = Val(:three_dim),
-        colorbar = true,
-    )
+    fig, ax, surf =
+        plot_wigner(ψ; library = Val(:Makie), xvec = xvec, yvec = yvec, projection = Val(:three_dim), colorbar = true)
     @test fig isa Figure
     @test ax isa Axis3
     @test surf isa Surface

--- a/test/ext-test/cpu/makie/makie_ext.jl
+++ b/test/ext-test/cpu/makie/makie_ext.jl
@@ -1,17 +1,17 @@
-@testset "CairoMakie Extension" verbose = true begin
+@testset "Makie Extension" verbose = true begin
     ψ = normalize(coherent(50, 5.0) + coherent(50, -5.0))
     xvec = yvec = -15.0:0.1:15.0
     wig = transpose(wigner(ψ, xvec, yvec))
 
-    @test_throws ArgumentError plot_wigner(ψ; library = :CairoMakie, xvec = xvec, yvec = yvec)
+    @test_throws ArgumentError plot_wigner(ψ; library = :Makie, xvec = xvec, yvec = yvec)
 
-    @test_throws ArgumentError plot_fock_distribution(ψ; library = :CairoMakie)
+    @test_throws ArgumentError plot_fock_distribution(ψ; library = :Makie)
 
-    using CairoMakie
+    using Makie
 
     fig, ax, hm = plot_wigner(
         ψ;
-        library = Val(:CairoMakie),
+        library = Val(:Makie),
         xvec = xvec,
         yvec = yvec,
         projection = Val(:two_dim),
@@ -24,7 +24,7 @@
 
     fig, ax, surf = plot_wigner(
         ψ;
-        library = Val(:CairoMakie),
+        library = Val(:Makie),
         xvec = xvec,
         yvec = yvec,
         projection = Val(:three_dim),
@@ -39,7 +39,7 @@
     pos = fig[2, 3]
     fig1, ax, hm = plot_wigner(
         ψ;
-        library = Val(:CairoMakie),
+        library = Val(:Makie),
         xvec = xvec,
         yvec = yvec,
         projection = Val(:two_dim),
@@ -53,7 +53,7 @@
     pos = fig[2, 3]
     fig1, ax, surf = plot_wigner(
         ψ;
-        library = Val(:CairoMakie),
+        library = Val(:Makie),
         xvec = xvec,
         yvec = yvec,
         projection = Val(:three_dim),
@@ -65,11 +65,11 @@
 
     fig = Figure()
     pos = fig[2, 3]
-    fig1, ax = plot_fock_distribution(ψ; library = Val(:CairoMakie), location = pos)
+    fig1, ax = plot_fock_distribution(ψ; library = Val(:Makie), location = pos)
     @test fig1 === fig
     @test fig[2, 3].layout.content[1].content[1, 1].layout.content[1].content === ax
 
     fig = Figure()
     pos = fig[2, 3]
-    fig1, ax = @test_logs (:warn,) plot_fock_distribution(ψ * 2; library = Val(:CairoMakie), location = pos)
+    fig1, ax = @test_logs (:warn,) plot_fock_distribution(ψ * 2; library = Val(:Makie), location = pos)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,8 +68,8 @@ if (GROUP == "AutoDiff_Ext")
     include(joinpath(testdir, "ext-test", "cpu", "autodiff", "zygote.jl"))
 end
 
-if (GROUP == "CairoMakie_Ext")
-    Pkg.activate("ext-test/cpu/cairomakie")
+if (GROUP == "Makie_Ext")
+    Pkg.activate("ext-test/cpu/makie")
     Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
     Pkg.instantiate()
 
@@ -77,7 +77,7 @@ if (GROUP == "CairoMakie_Ext")
     QuantumToolbox.about()
 
     # CarioMakie is imported in the following script
-    include(joinpath(testdir, "ext-test", "cpu", "cairomakie", "cairomakie_ext.jl"))
+    include(joinpath(testdir, "ext-test", "cpu", "makie", "makie_ext.jl"))
 end
 
 if (GROUP == "CUDA_Ext")


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
The previous extension was only limited to CairoMakie.jl, which is only one of many backends available in the Makie.jl ecosystem.

Here, I make the extension more general, by defining it only for the Makie.jl, which is common to alls the backends.

In this way, the user can also use GLMakie.jl or WGLMakie.jl, for example. Allowing for interactive data plot.