### PR TITLE
Fix definition of noise derivative in stochastic solvers

### DIFF
--- a/src/time_evolution/callback_helpers/smesolve_callback_helpers.jl
+++ b/src/time_evolution/callback_helpers/smesolve_callback_helpers.jl
@@ -11,6 +11,7 @@ struct SaveFuncSMESolve{
     TEXPV<:Union{Nothing,AbstractMatrix},
     TMEXPV<:Union{Nothing,AbstractMatrix},
     TLT<:AbstractVector,
+    CT<:AbstractVector,
 } <: AbstractSaveFunc
     store_measurement::Val{SM}
     e_ops::TE
@@ -20,10 +21,11 @@ struct SaveFuncSMESolve{
     expvals::TEXPV
     m_expvals::TMEXPV
     tlist::TLT
+    dWdt_cache::CT
 end
 
 (f::SaveFuncSMESolve)(u, t, integrator) =
-    _save_func_smesolve(u, integrator, f.e_ops, f.m_ops, f.progr, f.iter, f.expvals, f.m_expvals, f.tlist)
+    _save_func_smesolve(u, integrator, f.e_ops, f.m_ops, f.progr, f.iter, f.expvals, f.m_expvals, f.tlist, f.dWdt_cache)
 (f::SaveFuncSMESolve{false,Nothing})(u, t, integrator) = _save_func(integrator, f.progr) # Common for both all solvers
 
 _get_e_ops_data(e_ops, ::Type{SaveFuncSMESolve}) = _get_e_ops_data(e_ops, SaveFuncMESolve)
@@ -33,7 +35,7 @@ _get_m_ops_data(sc_ops, ::Type{SaveFuncSMESolve}) =
 ##
 
 # When e_ops is a list of operators
-function _save_func_smesolve(u, integrator, e_ops, m_ops, progr, iter, expvals, m_expvals, tlist)
+function _save_func_smesolve(u, integrator, e_ops, m_ops, progr, iter, expvals, m_expvals, tlist, dWdt_cache)
     # This is equivalent to tr(op * ρ), when both are matrices.
     # The advantage of using this convention is that We don't need
     # to reshape u to make it a matrix, but we reshape the e_ops once.
@@ -47,8 +49,8 @@ function _save_func_smesolve(u, integrator, e_ops, m_ops, progr, iter, expvals, 
     end
 
     if !isnothing(m_expvals) && iter[] > 1
-        _dWdt = _homodyne_dWdt(integrator, tlist, iter)
-        @. m_expvals[:, iter[]-1] = real(_expect(m_ops)) + _dWdt
+        _homodyne_dWdt!(dWdt_cache, integrator, tlist, iter)
+        @. m_expvals[:, iter[]-1] = real(_expect(m_ops)) + dWdt_cache
     end
 
     iter[] += 1

--- a/src/time_evolution/callback_helpers/ssesolve_callback_helpers.jl
+++ b/src/time_evolution/callback_helpers/ssesolve_callback_helpers.jl
@@ -11,6 +11,7 @@ struct SaveFuncSSESolve{
     TEXPV<:Union{Nothing,AbstractMatrix},
     TMEXPV<:Union{Nothing,AbstractMatrix},
     TLT<:AbstractVector,
+    CT<:AbstractVector,
 } <: AbstractSaveFunc
     store_measurement::Val{SM}
     e_ops::TE
@@ -20,10 +21,11 @@ struct SaveFuncSSESolve{
     expvals::TEXPV
     m_expvals::TMEXPV
     tlist::TLT
+    dWdt_cache::CT
 end
 
 (f::SaveFuncSSESolve)(u, t, integrator) =
-    _save_func_ssesolve(u, integrator, f.e_ops, f.m_ops, f.progr, f.iter, f.expvals, f.m_expvals, f.tlist)
+    _save_func_ssesolve(u, integrator, f.e_ops, f.m_ops, f.progr, f.iter, f.expvals, f.m_expvals, f.tlist, f.dWdt_cache)
 (f::SaveFuncSSESolve{false,Nothing})(u, t, integrator) = _save_func(integrator, f.progr) # Common for both all solvers
 
 _get_e_ops_data(e_ops, ::Type{SaveFuncSSESolve}) = get_data.(e_ops)
@@ -34,7 +36,7 @@ _get_save_callback_idx(cb, ::Type{SaveFuncSSESolve}) = 2 # The first one is the 
 ##
 
 # When e_ops is a list of operators
-function _save_func_ssesolve(u, integrator, e_ops, m_ops, progr, iter, expvals, m_expvals, tlist)
+function _save_func_ssesolve(u, integrator, e_ops, m_ops, progr, iter, expvals, m_expvals, tlist, dWdt_cache)
     ψ = u
 
     _expect = op -> dot(ψ, op, ψ)
@@ -44,8 +46,8 @@ function _save_func_ssesolve(u, integrator, e_ops, m_ops, progr, iter, expvals, 
     end
 
     if !isnothing(m_expvals) && iter[] > 1
-        _dWdt = _homodyne_dWdt(integrator, tlist, iter)
-        @. m_expvals[:, iter[]-1] = real(_expect(m_ops)) + _dWdt
+        _homodyne_dWdt!(dWdt_cache, integrator, tlist, iter)
+        @. m_expvals[:, iter[]-1] = real(_expect(m_ops)) + dWdt_cache
     end
 
     iter[] += 1


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [ ] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
The noise process is currently computed at the time points the SDE integrator stops. The previous implementation of the derivative $d W / d t$ was using the finite difference between the last and the second to last noise points, which don't necessary coincide with the points expressed in `tlist`.

As long as there is no possibility to set the time list at which save the noise process (see [this issue here](https://github.com/SciML/DiffEqNoiseProcess.jl/issues/214)) we should ensure that the derivative is computed between points in `tlist`.

## Related issues or PRs
This PR tries to fix #452