### PR TITLE
Add citation bibtex for arXiv preprint

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,11 @@
+@article{QuantumToolbox-jl2025,
+    title={{QuantumToolbox.jl}: An efficient {Julia} framework for simulating open quantum systems},
+    author={Mercurio, Alberto and Huang, Yi-Te and Cai, Li-Xun and Chen, Yueh-Nan and Savona, Vincenzo and Nori, Franco},
+    journal={arXiv preprint arXiv:2504.21440},
+    year={2025},
+    publisher = {arXiv},
+    eprint={2504.21440},
+    archivePrefix={arXiv},
+    primaryClass={quant-ph},
+    doi = {10.48550/arXiv.2504.21440}
+}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 and [Y.-T. Huang](https://github.com/ytdHuang).
 
 <!-- Table of Badges -->
-| **Release**       | [![Release][release-img]][release-url] [![License][license-img]][license-url] [![DOI][doi-img]][doi-url] [![Downloads][download-img]][download-url] |
+| **Release**       | [![Release][release-img]][release-url] [![License][license-img]][license-url] [![Cite][cite-img]][cite-url] [![Downloads][download-img]][download-url] |
 |:-----------------:|:-------------|
 | **Runtests**      | [![Runtests][runtests-img]][runtests-url] [![Coverage][codecov-img]][codecov-url] |
 | **Code Quality**  | [![Code Quality][code-quality-img]][code-quality-url] [![Aqua QA][aqua-img]][aqua-url] [![JET][jet-img]][jet-url] |
@@ -24,8 +24,8 @@ and [Y.-T. Huang](https://github.com/ytdHuang).
 [license-img]: https://img.shields.io/badge/license-New%20BSD-blue.svg
 [license-url]: https://opensource.org/licenses/BSD-3-Clause
 
-[doi-img]: https://zenodo.org/badge/DOI/10.5281/zenodo.10822816.svg
-[doi-url]: https://doi.org/10.5281/zenodo.10822816
+[cite-img]: https://img.shields.io/badge/cite-arXiv%3A2504.21440_(2023)-blue
+[cite-url]: https://doi.org/10.48550/arXiv.2504.21440
 
 [download-img]: https://img.shields.io/badge/dynamic/json?url=http%3A%2F%2Fjuliapkgstats.com%2Fapi%2Fv1%2Ftotal_downloads%2FQuantumToolbox&query=total_requests&label=Downloads
 [download-url]: https://juliapkgstats.com/pkg/QuantumToolbox
@@ -176,6 +176,23 @@ Here we provide a brief performance comparison between `QuantumToolbox.jl` and o
 You are most welcome to contribute to `QuantumToolbox.jl` development by forking this repository and sending pull requests (PRs), or filing bug reports at the issues page. You can also help out with users' questions, or discuss proposed changes in the [QuTiP discussion group](https://groups.google.com/g/qutip).
 
 For more information about contribution, including technical advice, please see the [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
+
+## Cite `QuantumToolbox.jl`
+If you like `QuantumToolbox.jl`, we would appreciate it if you starred the repository in order to help us increase its visibility. Furthermore, if you find the framework useful in your research, we would be grateful if you could cite our arXiv preprint [ [arXiv:2504.21440 (2025)](https://doi.org/10.48550/arXiv.2504.21440)  ] using the following bibtex entry:
+
+```bib
+@article{QuantumToolbox-jl2025,
+    title={{QuantumToolbox.jl}: An efficient {Julia} framework for simulating open quantum systems},
+    author={Mercurio, Alberto and Huang, Yi-Te and Cai, Li-Xun and Chen, Yueh-Nan and Savona, Vincenzo and Nori, Franco},
+    journal={arXiv preprint arXiv:2504.21440},
+    year={2025},
+    publisher = {arXiv},
+    eprint={2504.21440},
+    archivePrefix={arXiv},
+    primaryClass={quant-ph},
+    doi = {10.48550/arXiv.2504.21440}
+}
+```
 
 ## Acknowledgements
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -42,7 +42,7 @@ const PAGES = [
         # "Key differences from QuTiP" => "getting_started/qutip_differences.md",
         "The Importance of Type-Stability" => "getting_started/type_stability.md",
         "Example: Create QuantumToolbox.jl Logo" => "getting_started/logo.md",
-        # "Cite QuantumToolbox.jl" => "getting_started/cite.md",
+        "Cite QuantumToolbox.jl" => "getting_started/cite.md",
     ],
     "Users Guide" => [
         "Basic Operations on Quantum Objects" => [

--- a/docs/src/getting_started/cite.md
+++ b/docs/src/getting_started/cite.md
@@ -1,0 +1,17 @@
+# [Cite QuantumToolbox.jl](@id doc:Cite)
+
+If you like `QuantumToolbox.jl`, we would appreciate it if you could cite our arXiv preprint [ [arXiv:2504.21440 (2025)](https://doi.org/10.48550/arXiv.2504.21440)  ] using the following bibtex entry:
+
+```bib
+@article{QuantumToolbox-jl2025,
+    title={{QuantumToolbox.jl}: An efficient {Julia} framework for simulating open quantum systems},
+    author={Mercurio, Alberto and Huang, Yi-Te and Cai, Li-Xun and Chen, Yueh-Nan and Savona, Vincenzo and Nori, Franco},
+    journal={arXiv preprint arXiv:2504.21440},
+    year={2025},
+    publisher = {arXiv},
+    eprint={2504.21440},
+    archivePrefix={arXiv},
+    primaryClass={quant-ph},
+    doi = {10.48550/arXiv.2504.21440}
+}
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,6 +23,9 @@ hero:
       text: API
       link: /resources/api
     - theme: alt
+      text: Cite us
+      link: /getting_started/cite
+    - theme: alt
       text: View on Github
       link: https://github.com/qutip/QuantumToolbox.jl
     - theme: alt


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
This PR adds the citation bibtex and related elements including:
- add `CITATION.bib` file
- replace Zenodo DOI badge in `README` as: [![Cite](https://img.shields.io/badge/cite-arXiv%3A2504.21440_(2023)-blue)](https://doi.org/10.48550/arXiv.2504.21440)
- add a `Cite` section in `README`
- add `Cite us` button in documentation main page
- add `Cite` page in documentation

Regarding the `QuantumToolbox.cite()` function (like the one in qutip), I suggest we implement it after the paper is actually published.