### PR TITLE
GPU support for steadystate_fourier

### DIFF
--- a/ext/QuantumToolboxCUDAExt.jl
+++ b/ext/QuantumToolboxCUDAExt.jl
@@ -3,9 +3,9 @@ module QuantumToolboxCUDAExt
 using QuantumToolbox
 using QuantumToolbox: makeVal, getVal
 import QuantumToolbox: _sparse_similar, _convert_eltype_wordsize
-import CUDA: cu, CuArray, allowscalar
+import CUDA: cu, CuArray, allowscalar, @allowscalar, has_cuda
 import CUDA.CUSPARSE: CuSparseVector, CuSparseMatrixCSC, CuSparseMatrixCSR, AbstractCuSparseArray
-import SparseArrays: SparseVector, SparseMatrixCSC, sparse
+import SparseArrays: SparseVector, SparseMatrixCSC, sparse, spzeros
 import CUDA.Adapt: adapt
 
 allowscalar(false)
@@ -104,5 +104,10 @@ QuantumToolbox.to_dense(::Type{T}, A::AbstractCuSparseArray) where {T<:Number} =
 
 QuantumToolbox._sparse_similar(A::CuSparseMatrixCSC, args...) = sparse(args..., fmt = :csc)
 QuantumToolbox._sparse_similar(A::CuSparseMatrixCSR, args...) = sparse(args..., fmt = :csr)
-
+_sparse_similar(A::CuSparseMatrixCSC, I::AbstractVector, J::AbstractVector, V::AbstractVector, m::Int, n::Int) =
+    CuSparseMatrixCSC(sparse(I, J, V, m, n))
+_sparse_similar(A::CuSparseMatrixCSC, m::Int, n::Int) = CuSparseMatrixCSC(spzeros(eltype(A), m, n))
+_sparse_similar(A::CuSparseMatrixCSR, I::AbstractVector, J::AbstractVector, V::AbstractVector, m::Int, n::Int) =
+    CuSparseMatrixCSR(sparse(I, J, V, m, n))
+_sparse_similar(A::CuSparseMatrixCSR, m::Int, n::Int) = CuSparseMatrixCSR(spzeros(eltype(A), m, n))
 end

--- a/ext/QuantumToolboxCUDAExt.jl
+++ b/ext/QuantumToolboxCUDAExt.jl
@@ -2,8 +2,8 @@ module QuantumToolboxCUDAExt
 
 using QuantumToolbox
 using QuantumToolbox: makeVal, getVal
-import QuantumToolbox: _sparse_similar, _convert_eltype_wordsize, allowed_setindex!
-import CUDA: cu, CuArray, allowscalar, @allowscalar, has_cuda
+import QuantumToolbox: _sparse_similar, _convert_eltype_wordsize
+import CUDA: cu, CuArray, allowscalar
 import CUDA.CUSPARSE: CuSparseVector, CuSparseMatrixCSC, CuSparseMatrixCSR, AbstractCuSparseArray
 import SparseArrays: SparseVector, SparseMatrixCSC, sparse, spzeros
 import CUDA.Adapt: adapt
@@ -104,11 +104,22 @@ QuantumToolbox.to_dense(::Type{T}, A::AbstractCuSparseArray) where {T<:Number} =
 
 QuantumToolbox._sparse_similar(A::CuSparseMatrixCSC, args...) = sparse(args..., fmt = :csc)
 QuantumToolbox._sparse_similar(A::CuSparseMatrixCSR, args...) = sparse(args..., fmt = :csr)
-QuantumToolbox._sparse_similar(A::CuSparseMatrixCSC, I::AbstractVector, J::AbstractVector, V::AbstractVector, m::Int, n::Int) =
-    CuSparseMatrixCSC(sparse(I, J, V, m, n))
+QuantumToolbox._sparse_similar(
+    A::CuSparseMatrixCSC,
+    I::AbstractVector,
+    J::AbstractVector,
+    V::AbstractVector,
+    m::Int,
+    n::Int,
+) = CuSparseMatrixCSC(sparse(I, J, V, m, n))
 QuantumToolbox._sparse_similar(A::CuSparseMatrixCSC, m::Int, n::Int) = CuSparseMatrixCSC(spzeros(eltype(A), m, n))
-QuantumToolbox._sparse_similar(A::CuSparseMatrixCSR, I::AbstractVector, J::AbstractVector, V::AbstractVector, m::Int, n::Int) =
-    CuSparseMatrixCSR(sparse(I, J, V, m, n))
+QuantumToolbox._sparse_similar(
+    A::CuSparseMatrixCSR,
+    I::AbstractVector,
+    J::AbstractVector,
+    V::AbstractVector,
+    m::Int,
+    n::Int,
+) = CuSparseMatrixCSR(sparse(I, J, V, m, n))
 QuantumToolbox._sparse_similar(A::CuSparseMatrixCSR, m::Int, n::Int) = CuSparseMatrixCSR(spzeros(eltype(A), m, n))
-QuantumToolbox.allowed_setindex!(A::AbstractCuSparseArray, v, I...) = @allowscalar A[I...] = v
 end

--- a/ext/QuantumToolboxCUDAExt.jl
+++ b/ext/QuantumToolboxCUDAExt.jl
@@ -2,8 +2,8 @@ module QuantumToolboxCUDAExt
 
 using QuantumToolbox
 using QuantumToolbox: makeVal, getVal
-import QuantumToolbox: _sparse_similar, _convert_eltype_wordsize, _spre, _spost
-import CUDA: cu, CuArray, allowscalar, adapt, kron
+import QuantumToolbox: _sparse_similar, _convert_eltype_wordsize
+import CUDA: cu, CuArray, allowscalar
 import CUDA.CUSPARSE: CuSparseVector, CuSparseMatrixCSC, CuSparseMatrixCSR, AbstractCuSparseArray
 import SparseArrays: SparseVector, SparseMatrixCSC, sparse, spzeros
 import CUDA.Adapt: adapt
@@ -122,14 +122,4 @@ QuantumToolbox._sparse_similar(
     n::Int,
 ) = CuSparseMatrixCSR(sparse(I, J, V, m, n))
 QuantumToolbox._sparse_similar(A::CuSparseMatrixCSR, m::Int, n::Int) = CuSparseMatrixCSR(spzeros(eltype(A), m, n))
-function QuantumToolbox._spre(A::AbstractCuSparseArray, Id::AbstractMatrix)
-    Id_gpu = Id isa AbstractCuSparseArray ? Id : CuSparseMatrixCSC(sparse(Id))
-    return kron(Id_gpu, A)
-end
-QuantumToolbox._spre(A::AbstractCuSparseArray, Id::AbstractCuSparseArray) = kron(Id, A)
-function _spost(B::AbstractCuSparseArray, Id::AbstractMatrix)
-    Id_gpu = Id isa AbstractCuSparseArray ? Id : CuSparseMatrixCSC(sparse(Id))
-    return kron(B, Id_gpu)
-end
-QuantumToolbox._spost(B::AbstractCuSparseArray, Id::AbstractCuSparseArray) = kron(B, Id)
 end

--- a/ext/QuantumToolboxCUDAExt.jl
+++ b/ext/QuantumToolboxCUDAExt.jl
@@ -102,8 +102,8 @@ QuantumToolbox.to_dense(A::MT) where {MT<:AbstractCuSparseArray} = CuArray(A)
 QuantumToolbox.to_dense(::Type{T1}, A::CuArray{T2}) where {T1<:Number,T2<:Number} = CuArray{T1}(A)
 QuantumToolbox.to_dense(::Type{T}, A::AbstractCuSparseArray) where {T<:Number} = CuArray{T}(A)
 
-QuantumToolbox.QuantumToolbox._sparse_similar(A::CuSparseMatrixCSC, args...) = CuSparseMatrixCSC(sparse(args...))
-QuantumToolbox.QuantumToolbox._sparse_similar(A::CuSparseMatrixCSR, args...) = CuSparseMatrixCSC(sparse(args...))
+QuantumToolbox._sparse_similar(A::CuSparseMatrixCSC, args...) = CuSparseMatrixCSC(sparse(args...))
+QuantumToolbox._sparse_similar(A::CuSparseMatrixCSR, args...) = CuSparseMatrixCSC(sparse(args...))
 QuantumToolbox._sparse_similar(
     A::CuSparseMatrixCSC,
     I::AbstractVector,

--- a/ext/QuantumToolboxCUDAExt.jl
+++ b/ext/QuantumToolboxCUDAExt.jl
@@ -2,7 +2,7 @@ module QuantumToolboxCUDAExt
 
 using QuantumToolbox
 using QuantumToolbox: makeVal, getVal
-import QuantumToolbox: _sparse_similar, _convert_eltype_wordsize
+import QuantumToolbox: _sparse_similar, _convert_eltype_wordsize, allowed_setindex!
 import CUDA: cu, CuArray, allowscalar, @allowscalar, has_cuda
 import CUDA.CUSPARSE: CuSparseVector, CuSparseMatrixCSC, CuSparseMatrixCSR, AbstractCuSparseArray
 import SparseArrays: SparseVector, SparseMatrixCSC, sparse, spzeros
@@ -104,10 +104,11 @@ QuantumToolbox.to_dense(::Type{T}, A::AbstractCuSparseArray) where {T<:Number} =
 
 QuantumToolbox._sparse_similar(A::CuSparseMatrixCSC, args...) = sparse(args..., fmt = :csc)
 QuantumToolbox._sparse_similar(A::CuSparseMatrixCSR, args...) = sparse(args..., fmt = :csr)
-_sparse_similar(A::CuSparseMatrixCSC, I::AbstractVector, J::AbstractVector, V::AbstractVector, m::Int, n::Int) =
+QuantumToolbox._sparse_similar(A::CuSparseMatrixCSC, I::AbstractVector, J::AbstractVector, V::AbstractVector, m::Int, n::Int) =
     CuSparseMatrixCSC(sparse(I, J, V, m, n))
-_sparse_similar(A::CuSparseMatrixCSC, m::Int, n::Int) = CuSparseMatrixCSC(spzeros(eltype(A), m, n))
-_sparse_similar(A::CuSparseMatrixCSR, I::AbstractVector, J::AbstractVector, V::AbstractVector, m::Int, n::Int) =
+QuantumToolbox._sparse_similar(A::CuSparseMatrixCSC, m::Int, n::Int) = CuSparseMatrixCSC(spzeros(eltype(A), m, n))
+QuantumToolbox._sparse_similar(A::CuSparseMatrixCSR, I::AbstractVector, J::AbstractVector, V::AbstractVector, m::Int, n::Int) =
     CuSparseMatrixCSR(sparse(I, J, V, m, n))
-_sparse_similar(A::CuSparseMatrixCSR, m::Int, n::Int) = CuSparseMatrixCSR(spzeros(eltype(A), m, n))
+QuantumToolbox._sparse_similar(A::CuSparseMatrixCSR, m::Int, n::Int) = CuSparseMatrixCSR(spzeros(eltype(A), m, n))
+QuantumToolbox.allowed_setindex!(A::AbstractCuSparseArray, v, I...) = @allowscalar A[I...] = v
 end

--- a/ext/QuantumToolboxCUDAExt.jl
+++ b/ext/QuantumToolboxCUDAExt.jl
@@ -102,8 +102,8 @@ QuantumToolbox.to_dense(A::MT) where {MT<:AbstractCuSparseArray} = CuArray(A)
 QuantumToolbox.to_dense(::Type{T1}, A::CuArray{T2}) where {T1<:Number,T2<:Number} = CuArray{T1}(A)
 QuantumToolbox.to_dense(::Type{T}, A::AbstractCuSparseArray) where {T<:Number} = CuArray{T}(A)
 
-QuantumToolbox._sparse_similar(A::CuSparseMatrixCSC, args...) = sparse(args..., fmt = :csc)
-QuantumToolbox._sparse_similar(A::CuSparseMatrixCSR, args...) = sparse(args..., fmt = :csr)
+QuantumToolbox.QuantumToolbox._sparse_similar(A::CuSparseMatrixCSC, args...) = CuSparseMatrixCSC(sparse(args...))
+QuantumToolbox.QuantumToolbox._sparse_similar(A::CuSparseMatrixCSR, args...) = CuSparseMatrixCSC(sparse(args...))
 QuantumToolbox._sparse_similar(
     A::CuSparseMatrixCSC,
     I::AbstractVector,

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -374,7 +374,7 @@ function _steadystate_fourier(
     I_N = sparse(I, N, N)
     I_F = spdiagm(0 => ones(T, n_fourier))
     D_F = spdiagm(0 => n_vals)
-    block_diag = kron(I_F, L) + kron(D_F, I_N)
+    block_diag = _spre(L, I_F) + _spost(D_F, I_N)
     M += block_diag
     v0 = zeros(T, n_fourier * N)
     allowed_setindex!(v0, weight, n_max * N + 1)

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -378,8 +378,7 @@ function _steadystate_fourier(
     M += block_diag
     v0 = zeros(T, n_fourier * N)
     allowed_setindex!(v0, weight, n_max * N + 1)
-    (haskey(kwargs, :Pl) || haskey(kwargs, :Pr)) &&
-        error("The use of preconditioners must be defined in the solver.")
+    (haskey(kwargs, :Pl) || haskey(kwargs, :Pr)) && error("The use of preconditioners must be defined in the solver.")
     if !isnothing(solver.Pl)
         kwargs = (; kwargs..., Pl = solver.Pl(M))
     elseif isa(M, SparseMatrixCSC)
@@ -393,15 +392,15 @@ function _steadystate_fourier(
     ρtot = solve(prob, solver.alg; kwargs...).u
     offset1 = n_max * N
     offset2 = (n_max + 1) * N
-    ρ0 = Matrix(reshape(view(ρtot, (offset1 + 1):offset2), Ns, Ns))
+    ρ0 = Matrix(reshape(view(ρtot, (offset1+1):offset2), Ns, Ns))
     ρ0 ./= tr(ρ0)
     ρ0 = QuantumObject((ρ0 + ρ0') / 2, type = Operator(), dims = L_0.dimensions)
-    idx_ranges = [(offset1 - (i + 1) * N + 1):(offset1 - i * N) for i in 0:(n_max - 1)]
-    ρ_components = map(idx_range ->
-        QuantumObject(Matrix(reshape(view(ρtot, idx_range), Ns, Ns)),
-                      type = Operator(),
-                      dims = L_0.dimensions),
-        idx_ranges)
+    idx_ranges = [(offset1-(i+1)*N+1):(offset1-i*N) for i in 0:(n_max-1)]
+    ρ_components = map(
+        idx_range ->
+            QuantumObject(Matrix(reshape(view(ρtot, idx_range), Ns, Ns)), type = Operator(), dims = L_0.dimensions),
+        idx_ranges,
+    )
     return vcat([ρ0], ρ_components)
 end
 

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -371,9 +371,9 @@ function _steadystate_fourier(
     Km = _sparse_similar(L0_mat, spdiagm(1 => ones(T, n_fourier - 1)))
     M = kron(Kp, Lm_mat) + kron(Km, Lp_mat)
     n_vals = -1im * ωd * T.(n_list)
-    I_N = sparse(I, N, N)
-    I_F = spdiagm(0 => ones(T, n_fourier))
-    D_F = spdiagm(0 => n_vals)
+    I_N = _sparse_similar(L0_mat, sparse(I, N, N))
+    I_F = _sparse_similar(L0_mat, spdiagm(0 => ones(T, n_fourier)))
+    D_F = _sparse_similar(L0_mat, spdiagm(0 => n_vals))
     block_diag = _spre(L, I_F) + _spost(D_F, I_N)
     M += block_diag
     v0 = zeros(T, n_fourier * N)

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -374,7 +374,7 @@ function _steadystate_fourier(
     I_N = _sparse_similar(L0_mat, sparse(I, N, N))
     I_F = _sparse_similar(L0_mat, spdiagm(0 => ones(T, n_fourier)))
     D_F = _sparse_similar(L0_mat, spdiagm(0 => n_vals))
-    block_diag = _spre(L, I_F) + _spost(D_F, I_N)
+    block_diag = kron(I_F, L) + kron(D_F, I_N)
     M += block_diag
     v0 = zeros(T, n_fourier * N)
     allowed_setindex!(v0, weight, n_max * N + 1)

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -355,41 +355,30 @@ function _steadystate_fourier(
     tol::R = 1e-8,
     kwargs...,
 ) where {R<:Real}
-    # Get matrix data and promote types
     L0_mat = get_data(L_0)
     Lp_mat = get_data(L_p)
     Lm_mat = get_data(L_m)
     T = promote_type(eltype(L0_mat), eltype(Lp_mat), eltype(Lm_mat))
-
     N = size(L0_mat, 1)
     Ns = isqrt(N)
     n_fourier = 2 * n_max + 1
     n_list = (-n_max):n_max
-
-    # Create stabilization matrix Mn without scalar indexing
     weight = one(T)
     diag_indices = Ns * (0:(Ns-1)) .+ (1:Ns)
     Mn = _sparse_similar(L0_mat, ones(Int, Ns), diag_indices, fill(weight, Ns), N, N)
-
-    # Base Liouvillian
     L = L0_mat + Mn
-
-    # Build off-diagonal blocks
     Kp = _sparse_similar(L0_mat, spdiagm(-1 => ones(T, n_fourier-1)))
     Km = _sparse_similar(L0_mat, spdiagm(1 => ones(T, n_fourier-1)))
     M = kron(Kp, Lm_mat) + kron(Km, Lp_mat)
-
-    # Build diagonal blocks without comprehensions or loops
     n_vals = -1im * ωd * T.(n_list)
-    diag_blocks = broadcast(n -> L + n * sparse(I, N, N), n_vals)
-    block_diag = blockdiag(diag_blocks...)
+    I_N  = sparse(I, N, N)
+    I_F = spdiagm(0 => ones(T, n_fourier))
+    block_diag = kron(I_F, L) .+ kron(spdiagm(0 => n_vals), I_N)
+    D_F  = spdiagm(0 => n_vals)
+    block_diag = kron(I_F, L) .+ kron(D_F, I_N)
     M += block_diag
-
-    # Initialize RHS vector without scalar indexing
     v0 = zeros(T, n_fourier * N)
     allowed_setindex!(v0, weight, n_max*N+1)
-
-    # Preconditioners setup
     (haskey(kwargs, :Pl) || haskey(kwargs, :Pr)) && error("The use of preconditioners must be defined in the solver.")
     if !isnothing(solver.Pl)
         kwargs = (; kwargs..., Pl = solver.Pl(M))
@@ -405,20 +394,14 @@ function _steadystate_fourier(
     if !haskey(kwargs, :reltol)
         kwargs = (; kwargs..., reltol = tol)
     end
-
-    # Solve linear system
     prob = LinearProblem(M, v0)
     ρtot = solve(prob, solver.alg; kwargs...).u
-
-    # Extract ρ0 and normalize without scalar indexing
     offset1 = n_max * N
     offset2 = (n_max + 1) * N
     ρ0 = Matrix(reshape(view(ρtot, (offset1+1):offset2), Ns, Ns))
     ρ0_tr = tr(ρ0)
     ρ0 ./= ρ0_tr
     ρ0 = QuantumObject((ρ0 + ρ0') / 2, type = Operator(), dims = L_0.dimensions)
-
-    # Collect higher-order Fourier components without loops
     idx_ranges = [(offset1-(i+1)*N+1):(offset1-i*N) for i in 0:(n_max-1)]
     ρ_components = map(idx_range -> 
         QuantumObject(Matrix(reshape(view(ρtot, idx_range), Ns, Ns)), 

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -378,7 +378,8 @@ function _steadystate_fourier(
     M += block_diag
     v0 = zeros(T, n_fourier * N)
     allowed_setindex!(v0, weight, n_max * N + 1)
-    (haskey(kwargs, :Pl) || haskey(kwargs, :Pr)) && error("The use of preconditioners must be defined in the solver.")
+    (haskey(kwargs, :Pl) || haskey(kwargs, :Pr)) &&
+        error("The use of preconditioners must be defined in the solver.")
     if !isnothing(solver.Pl)
         kwargs = (; kwargs..., Pl = solver.Pl(M))
     elseif isa(M, SparseMatrixCSC)
@@ -392,15 +393,15 @@ function _steadystate_fourier(
     ρtot = solve(prob, solver.alg; kwargs...).u
     offset1 = n_max * N
     offset2 = (n_max + 1) * N
-    ρ0 = Matrix(reshape(view(ρtot, (offset1+1):offset2), Ns, Ns))
+    ρ0 = Matrix(reshape(view(ρtot, (offset1 + 1):offset2), Ns, Ns))
     ρ0 ./= tr(ρ0)
     ρ0 = QuantumObject((ρ0 + ρ0') / 2, type = Operator(), dims = L_0.dimensions)
-    idx_ranges = [(offset1-(i+1)*N+1):(offset1-i*N) for i in 0:(n_max-1)]
-    ρ_components = map(
-        idx_range ->
-            QuantumObject(Matrix(reshape(view(ρtot, idx_range), Ns, Ns)), type = Operator(), dims = L_0.dimensions),
-        idx_ranges,
-    )
+    idx_ranges = [(offset1 - (i + 1) * N + 1):(offset1 - i * N) for i in 0:(n_max - 1)]
+    ρ_components = map(idx_range ->
+        QuantumObject(Matrix(reshape(view(ρtot, idx_range), Ns, Ns)),
+                      type = Operator(),
+                      dims = L_0.dimensions),
+        idx_ranges)
     return vcat([ρ0], ρ_components)
 end
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -134,6 +134,8 @@ _dense_similar(A::AbstractArray, args...) = similar(A, args...)
 _dense_similar(A::AbstractSparseMatrix, args...) = similar(nonzeros(A), args...)
 
 _sparse_similar(A::AbstractArray, args...) = sparse(args...)
+_sparse_similar(A::AbstractArray, m::Int, n::Int) = spzeros(eltype(A), m, n)
+_sparse_similar(A::AbstractArray, rows, cols, vals, m::Int, n::Int) = sparse(rows, cols, vals, m, n)
 
 _Ginibre_ensemble(n::Int, rank::Int = n) = randn(ComplexF64, n, rank) / sqrt(n)
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -200,3 +200,5 @@ _convert_eltype_wordsize(::Type{T}, ::Val{64}) where {T<:AbstractFloat} = Float6
 _convert_eltype_wordsize(::Type{T}, ::Val{32}) where {T<:AbstractFloat} = Float32
 _convert_eltype_wordsize(::Type{Complex{T}}, ::Val{64}) where {T<:Union{Int,AbstractFloat}} = ComplexF64
 _convert_eltype_wordsize(::Type{Complex{T}}, ::Val{32}) where {T<:Union{Int,AbstractFloat}} = ComplexF32
+
+function allowed_setindex! end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -135,7 +135,6 @@ _dense_similar(A::AbstractSparseMatrix, args...) = similar(nonzeros(A), args...)
 
 _sparse_similar(A::AbstractArray, args...) = sparse(args...)
 _sparse_similar(A::AbstractArray, m::Int, n::Int) = spzeros(eltype(A), m, n)
-_sparse_similar(A::AbstractArray, rows, cols, vals, m::Int, n::Int) = sparse(rows, cols, vals, m, n)
 
 _Ginibre_ensemble(n::Int, rank::Int = n) = randn(ComplexF64, n, rank) / sqrt(n)
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -200,5 +200,3 @@ _convert_eltype_wordsize(::Type{T}, ::Val{64}) where {T<:AbstractFloat} = Float6
 _convert_eltype_wordsize(::Type{T}, ::Val{32}) where {T<:AbstractFloat} = Float32
 _convert_eltype_wordsize(::Type{Complex{T}}, ::Val{64}) where {T<:Union{Int,AbstractFloat}} = ComplexF64
 _convert_eltype_wordsize(::Type{Complex{T}}, ::Val{32}) where {T<:Union{Int,AbstractFloat}} = ComplexF32
-
-function allowed_setindex! end

--- a/test/ext-test/gpu/cuda_ext.jl
+++ b/test/ext-test/gpu/cuda_ext.jl
@@ -154,6 +154,27 @@ end
     @test ρ_ss_cpu.data ≈ Array(ρ_ss_gpu_csr.data) atol = 1e-8 * length(ρ_ss_cpu)
 end
 
+@testset "CUDA steadystate_fourier" begin
+    N = 2
+    ωd = 1.0
+    n_max = 2
+    H0 = cu(sigmaz())
+    Hp = cu(sigmax())
+    Hm = cu(sigmax())
+    c_ops = [cu(sqrt(0.1) * sigmam())]
+    ρ_list1 = steadystate_fourier(H0, Hp, Hm, ωd, c_ops; solver = SteadyStateLinearSolver(), n_max = n_max)
+    ρ0 = steadystate_fourier(
+        H0,
+        Hp,
+        Hm,
+        ωd,
+        c_ops;
+        solver = SSFloquetEffectiveLiouvillian(SteadyStateDirectSolver()),
+        n_max = n_max,
+    )
+    @test isapprox(ρ0, ρ_list1[1]; atol = 1e-6)
+end
+
 @testset "CUDA ptrace" begin
     g = fock(2, 1)
     e = fock(2, 0)


### PR DESCRIPTION
This PR resolves #462. The `steadystate_fourier` tests in `steadtstate.jl `passes. 

## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [ ] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [ ] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Describe the proposed change here.

## Related issues or PRs
This PR fixes #462 

## Additional context

Tested via make test: The JET error is due to mesolve which is unrelated to this PR.

```

 QuantumToolbox.jl: Quantum Toolbox in Julia
≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
Copyright © QuTiP team 2022 and later.
Current admin team:
    Alberto Mercurio and Yi-Te Huang

Package information:
====================================
Julia              Ver. 1.11.3
QuantumToolbox     Ver. 0.31.1
SciMLOperators     Ver. 0.4.0
LinearSolve        Ver. 3.16.0
OrdinaryDiffEqCore Ver. 1.26.0

System information:
====================================
OS       : Linux (x86_64-linux-gnu)
CPU      : 4 × Intel(R) Core(TM) i5-7300HQ CPU @ 2.50GHz
Memory   : 7.658 GB
WORD_SIZE: 64
LIBM     : libopenlibm
LLVM     : libLLVM-16.0.6 (ORCJIT, skylake)
BLAS     : libopenblas64_.so (ilp64)
Threads  : 1 (on 4 virtual cores)

Test Summary:       | Pass  Total  Time
Block Diagonal Form |    4      4  6.4s
Test Summary:             | Pass  Total   Time
Correlations and Spectrum |   18     18  39.3s
Test Summary:            | Pass  Total     Time
Dynamical Fock Dimension |    5      5  1m39.5s
Test Summary:          | Pass  Total     Time
Dynamical Shifted Fock |    6      6  1m32.3s
Test Summary:             | Pass  Total   Time
Eigenvalues and Operators |   22     22  28.6s
Test Summary: | Pass  Total   Time
entropy       |   16     16  11.3s
Test Summary:                | Pass  Total  Time
entanglement and concurrence |   12     12  2.1s
Test Summary:                      | Pass  Total  Time
trace and Hilbert-Schmidt distance |    5      5  1.6s
Test Summary:                                  | Pass  Total   Time
fidelity, Bures metric, and Hellinger distance |   16     16  28.1s
Test Summary:               | Pass  Total  Time
Generalized Master Equation |    2      2  7.6s
Progress: [==============================] 100.0% --- Elapsed Time: 0h 00m 00s (ETA: 0h 00m 00s)
Test Summary:     | Pass  Total   Time
Low Rank Dynamics |    2      2  51.8s
Test Summary:                    | Pass  Total  Time
Negativity and Partial Transpose |   14     14  1.9s
  negativity                     |    4      4  0.0s
  partial_transpose              |   10     10  1.9s
Test Summary: | Pass  Total  Time
Progress Bar  |   60     60  9.1s
Test Summary:                    | Pass  Total   Time
Quantum Objects                  |  332    332  49.4s
  ArgumentError                  |    6      6   0.1s
  DomainError                    |   18     18   0.4s
  unsupported dims               |    5      5   0.7s
  Ket and Bra                    |   19     19   0.2s
  Operator and SuperOperator     |   36     36   1.9s
  OperatorKet and OperatorBra    |   27     27   1.2s
  Checks on non-QuantumObjects   |   12     12   0.0s
  arithmetic                     |   32     32   4.5s
  broadcasting                   |   12     12   2.6s
  REPL show                      |    7      7   1.6s
  matrix element                 |    6      6   1.3s
  element type conversion        |   16     16   1.4s
  Type Inference (QuantumObject) |           0   1.9s
  tensor                         |    4      4   0.1s
  projection                     |    7      7   0.1s
  dot product                    |    1      1   0.0s
  normalization                  |   10     10   0.8s
  expectation value              |   12     12   3.3s
  get coherence                  |    2      2   0.2s
  SVD and Schatten p-norm        |    4      4   0.2s
  purity                         |    4      4   0.1s
  sqrt, log, exp, sinm, cosm     |    4      4  18.8s
  tidyup                         |    8      8   0.9s
  ptrace                         |   59     59   5.1s
  permute                        |   21     21   2.0s
Test Summary:                                 | Pass  Total   Time
Quantum Objects Evolution                     |   78     78  17.5s
  Thrown Errors                               |    9      9   0.2s
  unsupported dims                            |    5      5   0.4s
  Operator and SuperOperator                  |   13     13   0.0s
  Promote Operators Type                      |    4      4   0.0s
  arithmetic                                  |   15     15   2.1s
  REPL show                                   |    2      2   0.6s
  Type Inference (QobjEvo)                    |    3      3   1.5s
  tensor                                      |    3      3   0.2s
  Time Dependent Operators and SuperOperators |   24     24  12.5s
Test Summary:                          | Pass  Total   Time
States and Operators                   |  222    222  12.6s
  zero state                           |    8      8   0.1s
  fock state                           |    2      2   0.3s
  coherent state                       |    4      4   0.0s
  thermal state                        |    6      6   1.2s
  maximally mixed state                |   10     10   0.4s
  random state                         |   17     17   0.5s
  entanglement states                  |   12     12   0.6s
  bosonic operators                    |    7      7   0.9s
  displacement and squeezing operators |    2      2   0.1s
  phase                                |    1      1   0.9s
  tunneling                            |    2      2   0.3s
  quantum Fourier transform            |   11     11   1.3s
  random unitary                       |    7      7   1.0s
  Spin-j operators                     |   31     31   1.2s
  spin state                           |   13     13   0.1s
  spin coherent state                  |   65     65   0.8s
  identity operator                    |   14     14   0.7s
  superoperators                       |   10     10   0.4s
  Type Inference (States)              |           0   1.3s
  Type Inference (Operators)           |           0   0.4s
┌ Warning: Interrupted. Larger maxiters is needed. If you are using an integrator for non-stiff ODEs or an automatic switching algorithm (the default), you may want to consider using a method for stiff equations. See the solver pages for more details (e.g. https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/#Stiff-Problems).
└ @ SciMLBase ~/.julia/packages/SciMLBase/Ha7rZ/src/integrator_interface.jl:589
Test Summary: | Pass  Total   Time
Steady State  |    7      7  52.6s
Progress: [==============================] 100.0% --- Elapsed Time: 0h 00m 00s (ETA: 0h 00m 00s)
Progress: [==============================] 100.0% --- Elapsed Time: 0h 00m 01s (ETA: 0h 00m 00s)
Progress: [==============================] 100.0% --- Elapsed Time: 0h 00m 03s (ETA: 0h 00m 00s)
Test Summary:                                      | Pass  Total      Time
Time Evolution and Partial Trace                   |  107    107  35m34.1s
  sesolve                                          |   19     19     11.3s
    Memory Allocations                             |    2      2      0.5s
    Type Inference sesolve                         |           0      3.1s
  mesolve, mcsolve, ssesolve and smesolve          |   80     80  35m07.9s
    Memory Allocations (mesolve)                   |    4      4      6.2s
    Memory Allocations (mcsolve)                   |    2      2      1.3s
    Memory Allocations (ssesolve)                  |    2      2   2m52.5s
    Memory Allocations (smesolve)                  |    4      4  10m20.9s
    Type Inference mesolve                         |           0     11.5s
    Type Inference mcsolve                         |           0      8.7s
    Type Inference ssesolve                        |           0     57.8s
    Type Inference smesolve                        |           0     58.8s
    mcsolve, ssesolve and smesolve reproducibility |   11     11   6m20.4s
  exceptions                                       |    6      6     10.8s
  example                                          |    2      2      3.8s
Test Summary:               | Pass  Total  Time
Utilities                   |  358    358  0.0s
  n_thermal                 |   10     10  0.0s
  CODATA Physical Constants |    3      3  0.0s
  convert unit              |  345    345  0.0s
  Type Inference            |           0  0.0s
Test Summary: | Pass  Total   Time
Wigner        |    4      4  15.8s
        Info Packages marked with ⌃ and ⌅ have new versions available. Those with ⌃ may be upgradable, but those with ⌅ are restricted by compatibility constraints from upgrading. To see why use `status --outdated -m`
JET.jl: JET-test failed at /home/Transcendence/.julia/packages/JET/yNWjn/src/JETBase.jl:1046
  Expression: (JET.report_package)(QuantumToolbox; toplevel_logger = nothing, target_defined_modules = true, ignore_missing_comparison = true)
  ═════ 2 possible errors found ═════
  ┌ ssesolveProblem(H::Union{…}, ψ0::QuantumToolbox.QuantumObject{…}, tlist::AbstractVector, sc_ops::Union{…}; e_ops::Union{…}, params::Any, rng::Random.AbstractRNG, progress_bar::Union{…}, store_measurement::Union{…}, kwargs...) @ QuantumToolbox /home/Transcendence/Desktop/mission/QToolBox.jl/clnoe/2/4/QuantumToolbox.jl/src/time_evolution/ssesolve.jl:101                                                                                                      
  │ no matching method found `check_dimensions(::Type{<:QuantumToolbox.AbstractQuantumObject{QuantumToolbox.Operator, N}} where N, ::QuantumToolbox.QuantumObject{QuantumToolbox.Ket})` (1/2 union split): QuantumToolbox.check_dimensions(H_eff_evo::Union{Type{…} where N, QuantumToolbox.AbstractQuantumObject}, ψ0::QuantumToolbox.QuantumObject{QuantumToolbox.Ket})
  └────────────────────
  ┌ ssesolveProblem(H::Union{…}, ψ0::QuantumToolbox.QuantumObject{…}, tlist::AbstractVector, sc_ops::Union{…}; e_ops::Union{…}, params::Any, rng::Random.AbstractRNG, progress_bar::Union{…}, store_measurement::Union{…}, kwargs...) @ QuantumToolbox /home/Transcendence/Desktop/mission/QToolBox.jl/clnoe/2/4/QuantumToolbox.jl/src/time_evolution/ssesolve.jl:116                                                                                                      
  │ no matching method found `QuantumToolbox.QuantumObjectEvolution(::Type{<:QuantumToolbox.AbstractQuantumObject{QuantumToolbox.Operator, N}} where N, ::Complex{Int64})` (1/2 union split): QobjEvo(H_eff_evo::Union{Type{…} where N, QuantumToolbox.AbstractQuantumObject}, (-1 QuantumToolbox.:* QuantumToolbox.im)::Complex{Int64})
  └────────────────────
  
Test Summary: | Pass  Fail  Total     Time
Code quality  |    9     1     10  1m39.3s
  Aqua.jl     |    9            9    28.2s
  JET.jl      |          1      1  1m11.1s
ERROR: LoadError: Some tests did not pass: 9 passed, 1 failed, 0 errored, 0 broken.
ERROR: Package QuantumToolbox errored during testing
Stacktrace:
 [1] pkgerror(msg::String)
   @ Pkg.Types ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/Pkg/src/Types.jl:68
 [2] test(ctx::Pkg.Types.Context, pkgs::Vector{Pkg.Types.PackageSpec}; coverage::Bool, julia_args::Cmd, test_args::Cmd, test_fn::Nothing, force_latest_compatible_version::Bool, allow_earlier_backwards_compatible_versions::Bool, allow_reresolve::Bool)                                                        
   @ Pkg.Operations ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/Pkg/src/Operations.jl:2118
 [3] test
   @ ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/Pkg/src/Operations.jl:2003 [inlined]
 [4] test(ctx::Pkg.Types.Context, pkgs::Vector{Pkg.Types.PackageSpec}; coverage::Bool, test_fn::Nothing, julia_args::Cmd, test_args::Cmd, force_latest_compatible_version::Bool, allow_earlier_backwards_compatible_versions::Bool, allow_reresolve::Bool, kwargs::@Kwargs{io::IOContext{IO}})                    
   @ Pkg.API ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/Pkg/src/API.jl:481
 [5] test(pkgs::Vector{Pkg.Types.PackageSpec}; io::IOContext{IO}, kwargs::@Kwargs{})
   @ Pkg.API ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/Pkg/src/API.jl:159
 [6] test(pkgs::Vector{Pkg.Types.PackageSpec})
   @ Pkg.API ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/Pkg/src/API.jl:148
 [7] test(; name::Nothing, uuid::Nothing, version::Nothing, url::Nothing, rev::Nothing, path::Nothing, mode::Pkg.Types.PackageMode, subdir::Nothing, kwargs::@Kwargs{})                                                                                                                                           
   @ Pkg.API ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/Pkg/src/API.jl:174
 [8] test()
   @ Pkg.API ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/Pkg/src/API.jl:165
 [9] top-level scope
   @ none:1
make: *** [Makefile:15: test] Error 1
```
