### PR TITLE
Lanczos-based `spectrum` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
+- Introduce `Lanczos` solver for `spectrum`. ([#476])
+
 ## [v0.31.1]
 Release date: 2025-05-16
 
@@ -228,3 +230,4 @@ Release date: 2024-11-13
 [#455]: https://github.com/qutip/QuantumToolbox.jl/issues/455
 [#456]: https://github.com/qutip/QuantumToolbox.jl/issues/456
 [#460]: https://github.com/qutip/QuantumToolbox.jl/issues/460
+[#476]: https://github.com/qutip/QuantumToolbox.jl/issues/476

--- a/benchmarks/correlations_and_spectrum.jl
+++ b/benchmarks/correlations_and_spectrum.jl
@@ -19,6 +19,8 @@ function benchmark_correlations_and_spectrum!(SUITE)
 
     PI_solver = PseudoInverse()
 
+    L_solver = Lanczos()
+
     SUITE["Correlations and Spectrum"]["FFT Correlation"] =
         @benchmarkable _calculate_fft_spectrum($H, $t_l, $c_ops, $(a'), $a)
 
@@ -27,6 +29,9 @@ function benchmark_correlations_and_spectrum!(SUITE)
 
     SUITE["Correlations and Spectrum"]["Spectrum"]["Pseudo Inverse"] =
         @benchmarkable spectrum($H, $ω_l, $c_ops, $(a'), $a, solver = $PI_solver)
+
+    SUITE["Correlations and Spectrum"]["Spectrum"]["Lanczos"] =
+        @benchmarkable spectrum($H, $ω_l, $c_ops, $(a'), $a, solver = $L_solver)
 
     return nothing
 end

--- a/docs/src/resources/api.md
+++ b/docs/src/resources/api.md
@@ -248,6 +248,7 @@ spectrum_correlation_fft
 spectrum
 ExponentialSeries
 PseudoInverse
+Lanczos
 ```
 
 ## [Entropy and Metrics](@id doc-API:Entropy-and-Metrics)

--- a/src/QuantumToolbox.jl
+++ b/src/QuantumToolbox.jl
@@ -115,7 +115,6 @@ include("time_evolution/time_evolution_dynamical.jl")
 
 # Others
 include("correlations.jl")
-include("spectrum.jl")
 include("wigner.jl")
 include("spin_lattice.jl")
 include("arnoldi.jl")
@@ -123,6 +122,7 @@ include("entropy.jl")
 include("metrics.jl")
 include("negativity.jl")
 include("steadystate.jl")
+include("spectrum.jl")
 include("visualization.jl")
 
 # deprecated functions

--- a/src/spectrum.jl
+++ b/src/spectrum.jl
@@ -33,10 +33,10 @@ A solver which solves [`spectrum`](@ref) by using a non-symmetric Lanczos varian
 The nonsymmetric Lanczos algorithm is adapted from Algorithm 6.6 in [Saad2011](https://www-users.cse.umn.edu/~saad/eig_book_2ndEd.pdf).
 The running estimate is updated via a [Wallis-Euler recursion](https://en.wikipedia.org/wiki/Continued_fraction).
 """
-Base.@kwdef struct Lanczos{T<:Real,IT<:Int,SS<:Union{Nothing,<:SteadyStateSolver}} <: SpectrumSolver
+Base.@kwdef struct Lanczos{T<:Real,SS<:Union{Nothing,<:SteadyStateSolver}} <: SpectrumSolver
     tol::T = 1e-8
-    maxiter::IT = 5000
-    verbose::IT = 0
+    maxiter::Int = 5000
+    verbose::Int = 0
     steadystate_solver::SS = nothing
 end
 
@@ -223,7 +223,7 @@ function _spectrum(
     w₊₁ = vT(zeros(cT, D^2))
 
     # Frequency of renormalization
-    renormFrequency::typeof(solver.maxiter) = 1
+    renormFrequency = 1
 
     # Loop over the Krylov subspace(s)
     for k in 1:solver.maxiter

--- a/src/spectrum.jl
+++ b/src/spectrum.jl
@@ -33,10 +33,11 @@ A solver which solves [`spectrum`](@ref) by using a non-symmetric Lanczos varian
 The nonsymmetric Lanczos algorithm is adapted from Algorithm 6.6 in [Saad2011](https://www-users.cse.umn.edu/~saad/eig_book_2ndEd.pdf).
 The running estimate is updated via a [Wallis-Euler recursion](https://en.wikipedia.org/wiki/Continued_fraction).
 """
-Base.@kwdef struct Lanczos{T<:Real,IT<:Int} <: SpectrumSolver
+Base.@kwdef mutable struct Lanczos{T<:Real,IT<:Int} <: SpectrumSolver
     tol::T = 1e-8
     maxiter::IT = 5000
     verbose::IT = 0
+    steadystate_solver::Union{Nothing,SteadyStateSolver} = nothing
 end
 
 @doc raw"""
@@ -172,7 +173,9 @@ function _spectrum(
     cT = _CType(L)
 
     # Calculate |v₁> = B|ρss>
-    ρss = mat2vec(steadystate(L))
+    ρss =
+        solver.steadystate_solver === nothing ? mat2vec(steadystate(L)) :
+        mat2vec(steadystate(L; solver = solver.steadystate_solver))
     vₖ = (spre(B) * ρss).data
 
     # Define (possibly GPU) vector type

--- a/src/spectrum.jl
+++ b/src/spectrum.jl
@@ -193,24 +193,24 @@ function _spectrum(
     Length = length(ωList)
 
     # Current and previous estimates of the spectrum
-    lanczosFactor   = vT(zeros(cT, Length))
+    lanczosFactor = vT(zeros(cT, Length))
     lanczosFactor₋₁ = vT(zeros(cT, Length))
 
     # Tridiagonal matrix elements
-    αₖ = cT( 0)
+    αₖ = cT(0)
     βₖ = cT(-1)
     δₖ = cT(+1)
 
     # Current and up to second-to-last A and B Euler sequences
-    A₋₂ = vT( ones(cT, Length))
+    A₋₂ = vT(ones(cT, Length))
     A₋₁ = vT(zeros(cT, Length))
-    Aₖ  = vT(zeros(cT, Length))
+    Aₖ = vT(zeros(cT, Length))
     B₋₂ = vT(zeros(cT, Length))
-    B₋₁ = vT( ones(cT, Length))
-    Bₖ  = vT(zeros(cT, Length))
+    B₋₁ = vT(ones(cT, Length))
+    Bₖ = vT(zeros(cT, Length))
 
     # Maximum norm and residue
-    maxNorm    = vT(zeros(cT, length(ωList)))
+    maxNorm = vT(zeros(cT, length(ωList)))
     maxResidue = fT(0.0)
 
     # Previous and next left/right Krylov vectors
@@ -227,7 +227,7 @@ function _spectrum(
         # k-th diagonal element
         w₊₁ = wₖ * L.data
         αₖ = w₊₁ * vₖ
-        
+
         # Update A(k), B(k) and continuous fraction; normalization avoids overflow
         Aₖ .= (-1im .* ωList .+ αₖ) .* A₋₁ .- (βₖ * δₖ) .* A₋₂
         Bₖ .= (-1im .* ωList .+ αₖ) .* B₋₁ .- (βₖ * δₖ) .* B₋₂
@@ -236,7 +236,7 @@ function _spectrum(
 
         # Renormalize Euler sequences to avoid overflow
         if k % renormFrequency == 0
-            maxNorm .= max.(abs.(Aₖ), abs.(Bₖ))  # Note: the MATLAB and C++ codes return the actual complex number
+            maxNorm .= max.(abs.(Aₖ), abs.(Bₖ))
             Aₖ ./= maxNorm
             Bₖ ./= maxNorm
             A₋₁ ./= maxNorm
@@ -244,8 +244,9 @@ function _spectrum(
         end
 
         # Check for convergence
-        maxResidue = maximum(abs.(lanczosFactor .- lanczosFactor₋₁)) / 
-                     max(maximum(abs.(lanczosFactor)), maximum(abs.(lanczosFactor₋₁)))
+        maxResidue =
+            maximum(abs.(lanczosFactor .- lanczosFactor₋₁)) /
+            max(maximum(abs.(lanczosFactor)), maximum(abs.(lanczosFactor₋₁)))
         if maxResidue <= solver.tol
             if solver.verbose > 1
                 println("spectrum(): solver::Lanczos converged after $(k) iterations")
@@ -260,13 +261,13 @@ function _spectrum(
         w₊₁ .= w₊₁ .- αₖ .* wₖ .- δₖ .* w₋₁
         v₋₁ .= vₖ
         w₋₁ .= wₖ
-        vₖ  .= v₊₁
-        wₖ  .= w₊₁
+        vₖ .= v₊₁
+        wₖ .= w₊₁
 
         # k-th off-diagonal elements
         buf = wₖ * vₖ
-        δₖ  = sqrt(abs(buf))
-        βₖ  = buf / δₖ
+        δₖ = sqrt(abs(buf))
+        βₖ = buf / δₖ
 
         # Normalize (k+1)-th left/right vectors
         vₖ ./= δₖ
@@ -288,7 +289,7 @@ function _spectrum(
     # Restore the norm
     lanczosFactor .= gfNorm .* lanczosFactor
 
-    return -2 .* real( lanczosFactor )
+    return -2 .* real(lanczosFactor)
 end
 
 @doc raw"""

--- a/src/spectrum.jl
+++ b/src/spectrum.jl
@@ -33,11 +33,11 @@ A solver which solves [`spectrum`](@ref) by using a non-symmetric Lanczos varian
 The nonsymmetric Lanczos algorithm is adapted from Algorithm 6.6 in [Saad2011](https://www-users.cse.umn.edu/~saad/eig_book_2ndEd.pdf).
 The running estimate is updated via a [Wallis-Euler recursion](https://en.wikipedia.org/wiki/Continued_fraction).
 """
-Base.@kwdef mutable struct Lanczos{T<:Real,IT<:Int} <: SpectrumSolver
+Base.@kwdef struct Lanczos{T<:Real,IT<:Int,SS<:Union{Nothing,<:SteadyStateSolver}} <: SpectrumSolver
     tol::T = 1e-8
     maxiter::IT = 5000
     verbose::IT = 0
-    steadystate_solver::Union{Nothing,SteadyStateSolver} = nothing
+    steadystate_solver::SS = nothing
 end
 
 @doc raw"""
@@ -164,7 +164,7 @@ function _spectrum(
     ωlist::AbstractVector,
     A::QuantumObject{Operator},
     B::QuantumObject{Operator},
-    solver::Lanczos;
+    solver::Lanczos,
 )
     check_dimensions(L, A, B)
 
@@ -202,7 +202,7 @@ function _spectrum(
     # Tridiagonal matrix elements
     αₖ = cT(0)
     βₖ = cT(-1)
-    δₖ = cT(+1)
+    δₖ = fT(+1)
 
     # Current and up to second-to-last A and B Euler sequences
     A₋₂ = vT(ones(cT, Length))

--- a/src/spectrum.jl
+++ b/src/spectrum.jl
@@ -59,6 +59,7 @@ S(\omega) = \int_{-\infty}^\infty \lim_{t \rightarrow \infty} \left\langle \hat{
 See also the following list for `SpectrumSolver` docstrings:
 - [`ExponentialSeries`](@ref)
 - [`PseudoInverse`](@ref)
+- [`Lanczos`](@ref)
 """
 function spectrum(
     H::QuantumObject{HOpType},
@@ -228,7 +229,8 @@ function _spectrum(
     # Loop over the Krylov subspace(s)
     for k in 1:solver.maxiter
         # k-th diagonal element
-        αₖ = (wₖ * L.data) * vₖ
+        w₊₁ = wₖ * L.data
+        αₖ = w₊₁ * vₖ
         
         # Update A(k), B(k) and continuous fraction; normalization avoids overflow
         Aₖ .= (-1im .* ωList .+ αₖ) .* A₋₁ .- (βₖ * δₖ) .* A₋₂
@@ -257,8 +259,9 @@ function _spectrum(
 
         # (k+1)-th left/right vectors, orthogonal to previous ones
         # Consider using explicit BLAS calls
-        v₊₁ .= L.data * vₖ .- αₖ .* vₖ .- βₖ .* v₋₁
-        w₊₁ .= wₖ * L.data .- αₖ .* wₖ .- δₖ .* w₋₁
+        v₊₁ = L.data * vₖ
+        v₊₁ .= v₊₁ .- αₖ .* vₖ .- βₖ .* v₋₁
+        w₊₁ .= w₊₁ .- αₖ .* wₖ .- δₖ .* w₋₁
         v₋₁ .= vₖ
         w₋₁ .= wₖ
         vₖ  .= v₊₁

--- a/src/spectrum.jl
+++ b/src/spectrum.jl
@@ -247,9 +247,10 @@ function _spectrum(
         end
 
         # Check for convergence
-        maxResidue =
-            mapreduce((x, y) -> abs(x - y), max, lanczosFactor, lanczosFactor₋₁) /
-            max(maximum(abs, lanczosFactor), maximum(abs, lanczosFactor₋₁))
+
+        residueNorm = max(maximum(abs, lanczosFactor), maximum(abs, lanczosFactor₋₁))
+        lanczosFactor₋₁ .-= lanczosFactor
+        maxResidue = maximum(abs, lanczosFactor₋₁) / residueNorm
         if maxResidue <= solver.tol
             if solver.verbose > 1
                 println("spectrum(): solver::Lanczos converged after $(k) iterations")

--- a/src/spectrum.jl
+++ b/src/spectrum.jl
@@ -33,13 +33,11 @@ A solver which solves [`spectrum`](@ref) by using a non-symmetric Lanczos varian
 The nonsymmetric Lanczos algorithm is adapted from Algorithm 6.6 in [Saad2011](https://www-users.cse.umn.edu/~saad/eig_book_2ndEd.pdf).
 The running estimate is updated via a [Wallis-Euler recursion](https://en.wikipedia.org/wiki/Continued_fraction).
 """
-struct Lanczos{T<:Real,IT<:Int} <: SpectrumSolver
-    tol::T
-    maxiter::IT
-    verbose::IT
+Base.@kwdef struct Lanczos{T<:Real,IT<:Int} <: SpectrumSolver
+    tol::T = 1e-8
+    maxiter::IT = 5000
+    verbose::IT = 0
 end
-
-Lanczos(; tol = 1e-8, maxiter = 5000, verbose = 0) = Lanczos(tol, maxiter, verbose)
 
 @doc raw"""
     spectrum(H::QuantumObject,
@@ -166,7 +164,6 @@ function _spectrum(
     A::QuantumObject{Operator},
     B::QuantumObject{Operator},
     solver::Lanczos;
-    kwargs...,
 )
     check_dimensions(L, A, B)
 
@@ -283,12 +280,10 @@ function _spectrum(
         B₋₁ .= Bₖ
     end
 
-    if solver.verbose > 0
-        if maxResidue > solver.tol
-            println("spectrum(): maxiter = $(solver.maxiter) reached before convergence!")
-            println("spectrum(): Max residue = $maxResidue")
-            println("spectrum(): Consider increasing maxiter and/or tol")
-        end
+    if solver.verbose > 0 && maxResidue > solver.tol
+        println("spectrum(): maxiter = $(solver.maxiter) reached before convergence!")
+        println("spectrum(): Max residue = $maxResidue")
+        println("spectrum(): Consider increasing maxiter and/or tol")
     end
 
     # Restore the norm

--- a/test/core-test/correlations_and_spectrum.jl
+++ b/test/core-test/correlations_and_spectrum.jl
@@ -13,10 +13,12 @@
     ω_l2 = range(0, 3, length = 1000)
     spec2 = spectrum(H, ω_l2, c_ops, a', a)
     spec3 = spectrum(H, ω_l2, c_ops, a', a; solver = PseudoInverse())
+    spec4 = spectrum(H, ω_l2, c_ops, a', a; solver = Lanczos())
 
     spec1 = spec1 ./ maximum(spec1)
     spec2 = spec2 ./ maximum(spec2)
     spec3 = spec3 ./ maximum(spec3)
+    spec4 = spec4 ./ maximum(spec4)
 
     test_func1 = maximum(real.(spec1)) * (0.1 / 2)^2 ./ ((ω_l1 .- 1) .^ 2 .+ (0.1 / 2)^2)
     test_func2 = maximum(real.(spec2)) * (0.1 / 2)^2 ./ ((ω_l2 .- 1) .^ 2 .+ (0.1 / 2)^2)
@@ -26,12 +28,14 @@
     @test sum(abs2.(spec2[idxs2] .- test_func2[idxs2])) / sum(abs2.(test_func2[idxs2])) < 0.01
     @test all(corr1 .≈ corr2)
     @test all(spec2 .≈ spec3)
+    @test all(spec2 .≈ spec4)
 
     @testset "Type Inference spectrum" begin
         @inferred correlation_2op_1t(H, nothing, t_l, c_ops, a', a; progress_bar = Val(false))
         @inferred spectrum_correlation_fft(t_l, corr1)
         @inferred spectrum(H, ω_l2, c_ops, a', a)
         @inferred spectrum(H, ω_l2, c_ops, a', a; solver = PseudoInverse())
+        @inferred spectrum(H, ω_l2, c_ops, a', a; solver = Lanczos())
     end
 
     # tlist and τlist checks

--- a/test/core-test/correlations_and_spectrum.jl
+++ b/test/core-test/correlations_and_spectrum.jl
@@ -38,6 +38,18 @@
         @inferred spectrum(H, ω_l2, c_ops, a', a; solver = Lanczos())
     end
 
+    @testset "Verbose mode Lanczos" begin
+        cout = stdout
+        r, w = redirect_stdout()
+        nout = @async read(r, String)
+        spectrum(H, ω_l2, c_ops, a', a; solver = Lanczos(verbose = 2, maxiter = 2, tol = 1e-16));
+        redirect_stdout(cout)
+        close(w)
+        out = fetch(nout)
+        outlines = split(out, '\n', keepempty = false)
+        @test last(outlines) == "spectrum(): Consider increasing maxiter and/or tol"
+    end
+
     # tlist and τlist checks
     t_fft_wrong = [0, 1, 10]
     t_wrong1 = [1, 2, 3]


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Lanczos-based `spectrum` method.

## Related issues or PRs
Resolves #463.

## Additional context
This PR implements the non-symmetric variant of the Hermitian Lanczos method described in [Koch2011](https://www.cond-mat.de/events/correl11/manuscripts/koch.pdf).

The pseudo-code for the non-symmetric Lanczos algorithm can be found in Algorithm 6.6 of [Saad2011](https://www-users.cse.umn.edu/~saad/eig_book_2ndEd.pdf).

At each step, the running estimate for the result is updated via a [Wallis-Euler recursion](https://en.wikipedia.org/wiki/Continued_fraction) to avoid recomputing the whole continued fraction each time, and the convergence is evaluated accordingly.
