### PR TITLE
fix/bloch: use of fig location to display the bloch sphere in documentation

### DIFF
--- a/docs/src/users_guide/plotting_the_bloch_sphere.md
+++ b/docs/src/users_guide/plotting_the_bloch_sphere.md
@@ -24,7 +24,8 @@ b = Bloch();
 which will load an instance of [`Bloch`](@ref). Before getting into the details of these objects, we can simply plot the blank [`Bloch`](@ref) sphere associated with these instances via:
 
 ```@example Bloch_sphere_rendering
-fig, _ = render(b);
+fig = Figure(size = (700, 700), figure_padding = 0)
+fig, _ = render(b, location = fig[1,1])
 fig
 ```
 
@@ -35,7 +36,8 @@ As an example, we can add a single data point via [`add_points!`](@ref):
 ```@example Bloch_sphere_rendering
 pnt = [1 / sqrt(3), 1 / sqrt(3), 1 / sqrt(3)];
 add_points!(b, pnt);
-fig, _ = render(b);
+fig = Figure(size = (700, 700), figure_padding = 0)
+fig, _ = render(b, location = fig[1,1])
 fig
 ```
 
@@ -46,7 +48,7 @@ and then a single vector via  [`add_vectors!`](@ref):
 ```@example Bloch_sphere_rendering
 vec = [0, 1, 0];
 add_vectors!(b, vec)
-fig, _ = render(b)
+fig, _ = render(b, location = fig[1,1])
 fig
 ```
 
@@ -55,7 +57,7 @@ and then add another vector corresponding to the ``|0\rangle`` state:
 ```@example Bloch_sphere_rendering
 x = basis(2, 0)
 add_states!(b, [x])
-fig, _ = render(b)
+fig, _ = render(b, location = fig[1,1])
 fig
 ```
 
@@ -65,7 +67,7 @@ We can also plot multiple points, vectors, and states at the same time by passin
 
 ```@example Bloch_sphere_rendering
 clear!(b)
-fig, _ = render(b)
+fig, _ = render(b, location = fig[1,1])
 fig
 ```
 
@@ -76,8 +78,8 @@ x = basis(2, 0) + basis(2, 1)
 y = basis(2, 0) - im * basis(2, 1)
 z = basis(2, 0)
 b = Bloch()
-add_states!(b, [x, y, z])
-fig, _ = render(b)
+add_states!(b, [x, y, z]);
+fig, _ = render(b, location = fig[1,1])
 fig
 ```
 
@@ -87,7 +89,7 @@ A similar method works for adding vectors:
 clear!(b)
 vecs = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
 add_vectors!(b, vecs)
-fig, _ = render(b)
+fig, _ = render(b,location = fig[1,1])
 fig
 ```
 
@@ -101,7 +103,7 @@ vec = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
 add_vectors!(b, vec);
 add_line!(b, [1,0,0], [0,1,0])
 add_arc!(b, [1, 0, 0], [0, 1, 0], [0, 0, 1])
-fig, _ = render(b)
+fig, _ = render(b, location = fig[1,1])
 fig
 ```
 
@@ -117,7 +119,7 @@ yp = sin.(th);
 zp = zeros(20);
 pnts = [xp, yp, zp];
 add_points!(b, pnts);
-fig, ax = render(b);
+fig, _ = render(b, location = fig[1,1])
 fig
 ```
 
@@ -131,7 +133,7 @@ yz = sin.(th);
 zz = cos.(th);
 pnts = [xz, yz, zz];
 add_points!(b, pnts);
-fig, ax = render(b);
+fig, _ = render(b, location = fig[1,1])
 fig
 ```
 
@@ -146,7 +148,7 @@ yp = sin.(th);
 zp = zeros(20);
 pnts = [xp, yp, zp];
 add_points!(b, pnts, meth=:m);
-fig, ax = render(b);
+fig, _ = render(b, location = fig[1,1])
 fig
 ```
 
@@ -155,6 +157,6 @@ Now, the data points cycle through a variety of predefined colors. Now lets add 
 ```@example Bloch_sphere_rendering
 pnts = [xz, yz, zz] ;
 add_points!(b, pnts);
-fig, ax = render(b);
+fig, _ = render(b, location = fig[1,1])
 fig
 ```

--- a/docs/src/users_guide/plotting_the_bloch_sphere.md
+++ b/docs/src/users_guide/plotting_the_bloch_sphere.md
@@ -7,67 +7,74 @@ using CairoMakie
 CairoMakie.enable_only_mime!(MIME"image/svg+xml"())
 ```
 
-## [Introduction](@id doc:Bloch_sphere_rendering)
+## Introduction
 
 When studying the dynamics of a two-level system, it's often convenient to visualize the state of the system by plotting the state vector or density matrix on the Bloch sphere.
 
-In [QuantumToolbox.jl](https://qutip.org/QuantumToolbox.jl/), this can be done using the [`Bloch`](@ref) or [`plot_bloch`](@ref) methods that provide same syntax as [QuTiP](https://qutip.readthedocs.io/en/stable/guide/guide-bloch.html).
+In [`QuantumToolbox`](https://qutip.org/QuantumToolbox.jl/), this can be done using the [`Bloch`](@ref) or [`plot_bloch`](@ref) methods that provide same syntax as [QuTiP](https://qutip.readthedocs.io/en/stable/guide/guide-bloch.html).
 
 ## Create a Bloch Sphere
 
-In [QuantumToolbox.jl](https://qutip.org/QuantumToolbox.jl/), creating a [`Bloch`](@ref) sphere is accomplished by calling either:
+In [`QuantumToolbox`](https://qutip.org/QuantumToolbox.jl/), creating a [`Bloch`](@ref) sphere is accomplished by calling either:
 
 ```@example Bloch_sphere_rendering
-b = Bloch();
+b = Bloch()
 ```
 
 which will load an instance of [`Bloch`](@ref). Before getting into the details of these objects, we can simply plot the blank [`Bloch`](@ref) sphere associated with these instances via:
 
 ```@example Bloch_sphere_rendering
 fig = Figure(size = (700, 700), figure_padding = 0)
-fig, _ = render(b, location = fig[1,1])
+fig, ax = render(b,location = fig[1,1])
 fig
 ```
 
-## Add a Single Data Point
+See the [API documentation for Bloch sphere](@ref doc-API:Bloch-Sphere) for a full list of other available functions.
+
+## Add a single data point
 
 As an example, we can add a single data point via [`add_points!`](@ref):
 
 ```@example Bloch_sphere_rendering
-pnt = [1 / sqrt(3), 1 / sqrt(3), 1 / sqrt(3)];
-add_points!(b, pnt);
+pnt = [1 / sqrt(3), 1 / sqrt(3), 1 / sqrt(3)]
+add_points!(b, pnt)
 fig = Figure(size = (700, 700), figure_padding = 0)
-fig, _ = render(b, location = fig[1,1])
+fig, ax = render(b,location = fig[1,1])
 fig
 ```
 
-## Add a Single Vector
+## Add a single vector
 
-and then a single vector via  [`add_vectors!`](@ref):
+Add a single vector via  [`add_vectors!`](@ref):
 
 ```@example Bloch_sphere_rendering
-vec = [0, 1, 0];
+vec = [0, 1, 0]
 add_vectors!(b, vec)
-fig, _ = render(b, location = fig[1,1])
+fig = Figure(size = (700, 700), figure_padding = 0)
+fig, ax = render(b,location = fig[1,1])
 fig
 ```
 
-and then add another vector corresponding to the ``|0\rangle`` state:
+## Add a single quantum state
+
+Add another vector corresponding to the ``|0\rangle`` state:
 
 ```@example Bloch_sphere_rendering
-x = basis(2, 0)
-add_states!(b, [x])
-fig, _ = render(b, location = fig[1,1])
+z0 = basis(2, 0)
+add_states!(b, z0)
+fig = Figure(size = (700, 700), figure_padding = 0)
+fig, ax = render(b,location = fig[1,1])
 fig
 ```
 
-## Add Multiple Vectors
+## Add multiple data
 
-We can also plot multiple points, vectors, and states at the same time by passing arrays instead of individual elements via  [`add_vectors!](@ref). Before giving an example, we can use [`clear!`](@ref) to remove the current data from our [`Bloch`](@ref) sphere instead of creating a new instance:
+We can also plot multiple points, vectors, and states at the same time by passing arrays instead of individual elements via [`add_points!](@ref), [`add_vectors!](@ref), and [`add_states!](@ref), respectively. Before giving an example, we can use [`clear!`](@ref) to remove the current data from our [`Bloch`](@ref) sphere instead of creating a new instance:
 
 ```@example Bloch_sphere_rendering
 clear!(b)
-fig, _ = render(b, location = fig[1,1])
+fig = Figure(size = (700, 700), figure_padding = 0)
+fig, ax = render(b,location = fig[1,1])
 fig
 ```
 
@@ -77,11 +84,14 @@ Now on the same [`Bloch`](@ref) sphere, we can plot the three states via [`add_s
 x = basis(2, 0) + basis(2, 1)
 y = basis(2, 0) - im * basis(2, 1)
 z = basis(2, 0)
-b = Bloch()
-add_states!(b, [x, y, z]);
-fig, _ = render(b, location = fig[1,1])
+add_states!(b, [x, y, z])
+fig = Figure(size = (700, 700), figure_padding = 0)
+fig, ax = render(b,location = fig[1,1])
 fig
 ```
+
+!!! note "State normalization"
+    The function [`add_states!`](@ref) will automatically normalize the given quantum state(s), while [`add_vectors!`](@ref) does not normalize the given vectors.
 
 A similar method works for adding vectors:
 
@@ -89,74 +99,117 @@ A similar method works for adding vectors:
 clear!(b)
 vecs = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
 add_vectors!(b, vecs)
-fig, _ = render(b,location = fig[1,1])
+fig = Figure(size = (700, 700), figure_padding = 0)
+fig, ax = render(b,location = fig[1,1])
 fig
 ```
 
-# Add Arc, Line, and Vector
+# Add lines and arcs
 
 You can also add lines and arcs via [`add_line!`](@ref) and [`add_arc!`](@ref) respectively:
 
 ```@example Bloch_sphere_rendering
-clear!(b)
-vec = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
-add_vectors!(b, vec);
-add_line!(b, [1,0,0], [0,1,0])
-add_arc!(b, [1, 0, 0], [0, 1, 0], [0, 0, 1])
-fig, _ = render(b, location = fig[1,1])
+add_line!(b, x, y)
+add_arc!(b, y, z)
+fig = Figure(size = (700, 700), figure_padding = 0)
+fig, ax = render(b,location = fig[1,1])
 fig
 ```
 
-## Add Multiple Points
+## Add multiple points
 
 Adding multiple points to the [`Bloch`](@ref) sphere works slightly differently than adding multiple states or vectors. For example, lets add a set of `20` points around the equator (after calling [`clear!`](@ref)):
 
 ```@example Bloch_sphere_rendering
-th = range(0, 2π; length=20);
 clear!(b)
-xp = cos.(th);
-yp = sin.(th);
-zp = zeros(20);
-pnts = [xp, yp, zp];
-add_points!(b, pnts);
-fig, _ = render(b, location = fig[1,1])
+
+th = LinRange(0, 2π, 20)
+xp = cos.(th)
+yp = sin.(th)
+zp = zeros(20)
+pnts = [xp, yp, zp]
+add_points!(b, pnts)
+fig = Figure(size = (700, 700), figure_padding = 0)
+fig, ax = render(b,location = fig[1,1])
 fig
 ```
 
-Notice that, in contrast to states or vectors, each point remains the same color as the initial point. This is because adding multiple data points using [`add_points!`](@ref) is interpreted, by default, to correspond to a single data point (single qubit state) plotted at different times. This is very useful when visualizing the dynamics of a qubit. If we want to plot additional qubit states we can call additional [`add_points!`](@ref):
-
-## Add Another Set of Points
+Notice that, in contrast to states or vectors, each point remains the same color as the initial point. This is because adding multiple data points using [`add_points!`](@ref) is interpreted, by default, to correspond to a single data point (single qubit state) plotted at different times. This is very useful when visualizing the dynamics of a qubit. If we want to plot additional qubit states we can call additional [`add_points!`](@ref) function:
 
 ```@example Bloch_sphere_rendering
-xz = zeros(20);
-yz = sin.(th);
-zz = cos.(th);
-pnts = [xz, yz, zz];
-add_points!(b, pnts);
-fig, _ = render(b, location = fig[1,1])
+xz = zeros(20)
+yz = sin.(th)
+zz = cos.(th)
+add_points!(b, [xz, yz, zz])
+fig = Figure(size = (700, 700), figure_padding = 0)
+fig, ax = render(b,location = fig[1,1])
 fig
 ```
 
-The color and shape of the data points is varied automatically by [`Bloch`](@ref). Notice how the color and point markers change for each set of data.
+The color and shape of the data points is varied automatically by [`Bloch`](@ref). Notice how the color and point markers change for each set of data. Again, we have had to call [`add_points!`](@ref) twice because adding more than one set of multiple data points is not supported by the [`add_points!`](@ref) function.
 
-What if we want to vary the color of our points. We can tell [`Bloch`](@ref) to vary the color of each point according to the colors listed in the `point_color` attribute.
+What if we want to vary the color of our points. We can tell [`Bloch`](@ref) to vary the color of each point according to the colors listed in the `point_color` field (see [Configuring the Bloch sphere](@ref doc:Configuring-the-Bloch-sphere) below). Again, after [`clear!`](@ref):
 
 ```@example Bloch_sphere_rendering
 clear!(b)
-xp = cos.(th);
-yp = sin.(th);
-zp = zeros(20);
-pnts = [xp, yp, zp];
-add_points!(b, pnts, meth=:m);
-fig, _ = render(b, location = fig[1,1])
+
+xp = cos.(th)
+yp = sin.(th)
+zp = zeros(20)
+pnts = [xp, yp, zp]
+add_points!(b, pnts, meth=:m) # add `meth=:m` to signify 'multi' colored points
+fig = Figure(size = (700, 700), figure_padding = 0)
+fig, ax = render(b,location = fig[1,1])
 fig
 ```
 
 Now, the data points cycle through a variety of predefined colors. Now lets add another set of points, but this time we want the set to be a single color, representing say a qubit going from the ``|0\rangle`` state to the ``|1\rangle`` state in the `y-z` plane:
 
 ```@example Bloch_sphere_rendering
-pnts = [xz, yz, zz] ;
-add_points!(b, pnts);
-fig, _ = render(b, location = fig[1,1])
+pnts = [xz, yz, zz]
+add_points!(b, pnts) # no `meth=:m`
+fig = Figure(size = (700, 700), figure_padding = 0)
+fig, ax = render(b,location = fig[1,1])
 fig
+```
+
+## [Configuring the Bloch sphere](@id doc:Configuring-the-Bloch-sphere)
+
+At the end of the last section we saw that the colors and marker shapes of the data plotted on the Bloch sphere are automatically varied according to the number of points and vectors added. But what if you want a different choice of color, or you want your sphere to be purple with different axes labels? Well then you are in luck as the Bloch class has many attributes which one can control. Assuming `b = Bloch()`:
+
+| **Field** | **Description** | **Default setting** |
+|:----------|:----------------|:--------------------|
+| `b.points` | Points to plot on the Bloch sphere (3D coordinates) | `Vector{Matrix{Float64}}()` (empty) |
+| `b.vectors` | Vectors to plot on the Bloch sphere | `Vector{Vector{Float64}}()` (empty) |
+| `b.lines` | Lines to draw on the sphere (points, style, properties) | `Vector{Tuple{Vector{Vector{Float64}},String}}()` (empty) |
+| `b.arcs` | Arcs to draw on the sphere | `Vector{Vector{Vector{Float64}}}()` (empty) |
+| `b.font_color` | Color of axis labels and text | `"black"` |
+| `b.font_size` | Font size for labels | `15` |
+| `b.frame_alpha` | Transparency of the frame background | `0.1` |
+| `b.frame_color` | Background color of the frame | `"gray"` |
+| `b.frame_limit` | Axis limits for the 3D frame (symmetric around origin) | `1.14` |
+| `b.point_default_color` | Default color cycle for points | `["blue", "red", "green", "#CC6600"]` |
+| `b.point_color` | List of colors for Bloch point markers to cycle through | `Union{Nothing,String}[]` |
+| `b.point_marker` | List of point marker shapes to cycle through | `[:circle, :rect, :diamond, :utriangle]` |
+| `b.point_size` | List of point marker sizes (not all markers look the same size when plotted) | `[5.5, 6.2, 6.5, 7.5]` |
+| `b.point_style` | List of marker styles | `Symbol[]` |
+| `b.point_alpha` | List of marker transparencies | `Float64[]` |
+| `b.sphere_color` | Color of Bloch sphere surface | `0.2` |
+| `b.sphere_alpha` | Transparency of sphere surface | `"#FFDDDD"` |
+| `b.vector_color` | Colors for vectors | `["green", "#CC6600", "blue", "red"]` |
+| `b.vector_width` | Width of vectors | `0.025` |
+| `b.vector_arrowsize` | Arrow size parameters as (head length, head width, stem width) | `(0.07, 0.08, 0.08)` |
+| `b.view` | Azimuthal and elevation viewing angles in degrees | `(-60, 30)` |
+| `b.xlabel` | Labels for x-axis | `[L"x", ""]` |
+| `b.xlpos` | Positions of x-axis labels | `[1.0, -1.0]` |
+| `b.ylabel` | Labels for y-axis | `[L"y", ""]` |
+| `b.ylpos` | Positions of y-axis labels | `[1.0, -1.0]` |
+| `b.zlabel` | Labels for z-axis | `[1.0, -1.0]` |
+| `b.zlpos` | Positions of z-axis labels | `[L"|0\rangle", L"|1\rangle"]` |
+
+These properties can also be accessed via the `print` command:
+
+```@example Bloch_sphere_rendering
+b = Bloch()
+print(b)
 ```

--- a/ext/QuantumToolboxMakieExt.jl
+++ b/ext/QuantumToolboxMakieExt.jl
@@ -736,7 +736,11 @@ Plot a pure quantum state on the Bloch sphere using the `Makie` backend.
 !!! note "Internal function"
     This is the `Makie`-specific implementation called by the main `plot_bloch` function.
 """
-function QuantumToolbox.plot_bloch(::Val{:Makie}, state::QuantumObject{OpType}; kwargs...) where {OpType<:Union{Ket,Bra,Operator}}
+function QuantumToolbox.plot_bloch(
+    ::Val{:Makie},
+    state::QuantumObject{OpType};
+    kwargs...,
+) where {OpType<:Union{Ket,Bra,Operator}}
     bloch_vec = _state_to_bloch(state)
     return _render_bloch_makie(bloch_vec; kwargs...)
 end

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,14 +1,6 @@
 export plot_wigner
 export plot_fock_distribution
-export plot_bloch,
-    Bloch,
-    render,
-    add_points!,
-    add_vectors!,
-    add_line!,
-    add_arc!,
-    clear!,
-    add_states!
+export plot_bloch, Bloch, render, add_points!, add_vectors!, add_line!, add_arc!, clear!, add_states!
 
 @doc raw"""
     plot_wigner(
@@ -519,7 +511,11 @@ The `library` keyword argument specifies the plotting backend to use. The defaul
 !!! warning "Beware of type-stability!"
     For improved performance and type-stability, prefer passing `Val(:Makie)` instead of `:Makie`. See [Performance Tips](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) for details.
 """
-plot_bloch(state::QuantumObject{OpType}; library::Union{Symbol,Val} = Val(:Makie), kwargs...) where {OpType<:Union{Ket,Bra,Operator}} = plot_bloch(makeVal(lib_val), state; kwargs...)
+plot_bloch(
+    state::QuantumObject{OpType};
+    library::Union{Symbol,Val} = Val(:Makie),
+    kwargs...,
+) where {OpType<:Union{Ket,Bra,Operator}} = plot_bloch(makeVal(lib_val), state; kwargs...)
 
 @doc raw"""
     plot_bloch(::Val{T}, state::QuantumObject; kwargs...) where {T}


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [ ] Appropriate tests were added and tested locally by running: `make test`.
- [ ] Any code changes should be `julia` formatted by running: `make format`.
- [ ] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [ ] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description

Improve the display of the Bloch sphere as location was not provided earlier

## Related issues or PRs

This PR aims to be a commit to #480 to correct the display build of bloch sphere via proper use of location parameter.

## Additional context
