### PR TITLE
Use LScene instead of Axis3 for Bloch Sphere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce `Lanczos` solver for `spectrum`. ([#476])
 - Add Bloch-Redfield master equation solver. ([#473])
 - Implement Bloch Sphere rendering and align style with qutip. ([#472], [#480])
+- Use `LScene` instead of `Axis3` for `Bloch` sphere rendering. ([#485])
 
 ## [v0.31.1]
 Release date: 2025-05-16
@@ -236,3 +237,4 @@ Release date: 2024-11-13
 [#473]: https://github.com/qutip/QuantumToolbox.jl/issues/473
 [#476]: https://github.com/qutip/QuantumToolbox.jl/issues/476
 [#480]: https://github.com/qutip/QuantumToolbox.jl/issues/480
+[#485]: https://github.com/qutip/QuantumToolbox.jl/issues/485

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Introduce `Lanczos` solver for `spectrum`. ([#476])
 - Add Bloch-Redfield master equation solver. ([#473])
-- Implement Bloch Sphere rendering and align style with qutip. ([#472], [#480])
-- Use `LScene` instead of `Axis3` for `Bloch` sphere rendering. ([#485])
+- Implement Bloch Sphere rendering and align style with qutip. ([#472], [#480], [#485])
 
 ## [v0.31.1]
 Release date: 2025-05-16

--- a/docs/src/users_guide/plotting_the_bloch_sphere.md
+++ b/docs/src/users_guide/plotting_the_bloch_sphere.md
@@ -121,7 +121,7 @@ yp = sin.(th)
 zp = zeros(20)
 pnts = [xp, yp, zp]
 add_points!(b, pnts)
-fig, ax = render(b)
+fig, lscene = render(b)
 fig
 ```
 
@@ -132,7 +132,7 @@ xz = zeros(20)
 yz = sin.(th)
 zz = cos.(th)
 add_points!(b, [xz, yz, zz])
-fig, ax = render(b)
+fig, lscene = render(b)
 fig
 ```
 
@@ -148,7 +148,7 @@ yp = sin.(th)
 zp = zeros(20)
 pnts = [xp, yp, zp]
 add_points!(b, pnts, meth=:m) # add `meth=:m` to signify 'multi' colored points
-fig, ax = render(b)
+fig, lscene = render(b)
 fig
 ```
 
@@ -157,7 +157,7 @@ Now, the data points cycle through a variety of predefined colors. Now lets add 
 ```@example Bloch_sphere_rendering
 pnts = [xz, yz, zz]
 add_points!(b, pnts) # no `meth=:m`
-fig, ax = render(b)
+fig, lscene = render(b)
 fig
 ```
 

--- a/ext/QuantumToolboxMakieExt.jl
+++ b/ext/QuantumToolboxMakieExt.jl
@@ -382,8 +382,9 @@ function _setup_bloch_plot!(b::Bloch, location)
     length(b.view) == 2 || throw(ArgumentError("The length of `Bloch.view` must be 2."))
     cam3d!(lscene.scene, center = false)
     cam = cameracontrols(lscene)
-    cam.fov[] = 12
-    update_cam!(lscene.scene, cam, deg2rad(b.view[1]), deg2rad(b.view[2]), 12)
+    cam.fov[] = 12 # Set field of view to 12 degrees
+    dist = 12 # Set distance from the camera to the Bloch sphere
+    update_cam!(lscene.scene, cam, deg2rad(b.view[1]), deg2rad(b.view[2]), dist)
     return fig, lscene
 end
 

--- a/ext/QuantumToolboxMakieExt.jl
+++ b/ext/QuantumToolboxMakieExt.jl
@@ -6,7 +6,7 @@ import QuantumToolbox: _state_to_bloch
 import LinearAlgebra: cross, deg2rad, normalize, size
 import Makie:
     Axis,
-    Axis3,
+    LScene,
     Colorbar,
     Figure,
     GridLayout,
@@ -28,7 +28,10 @@ import Makie:
     RGBf,
     Vec3f,
     Point3f,
-    NoShading
+    NoShading,
+    cameracontrols,
+    update_cam!,
+    cam3d!
 
 @doc raw"""
     plot_wigner(
@@ -148,7 +151,7 @@ function _plot_wigner(
 
     lyt = GridLayout(location)
 
-    ax = Axis3(lyt[1, 1], azimuth = 1.775pi, elevation = pi / 16, protrusions = (30, 90, 30, 30), viewmode = :stretch)
+    ax = LScene(lyt[1, 1], azimuth = 1.775pi, elevation = pi / 16, protrusions = (30, 90, 30, 30), viewmode = :stretch)
 
     wig = wigner(state, xvec, yvec; g = g, method = method)
     wlim = maximum(abs, wig)
@@ -340,23 +343,23 @@ Render the Bloch sphere visualization from the given [`Bloch`](@ref) object `b`.
 
 # Returns
 
-- A tuple `(fig, axis)` where `fig` is the figure object and `axis` is the axis object used for plotting. These can be further manipulated or saved by the user.
+- A tuple `(fig, lscene)` where `fig` is the figure object and `lscene` is the LScene object used for plotting. These can be further manipulated or saved by the user.
 """
 function QuantumToolbox.render(b::Bloch; location = nothing)
-    fig, ax = _setup_bloch_plot!(b, location)
-    _draw_bloch_sphere!(b, ax)
-    _draw_reference_circles!(ax)
-    _draw_axes!(ax)
-    _plot_points!(b, ax)
-    _plot_lines!(b, ax)
-    _plot_arcs!(b, ax)
-    _plot_vectors!(b, ax)
-    _add_labels!(b, ax)
-    return fig, ax
+    fig, lscene = _setup_bloch_plot!(b, location)
+    _draw_bloch_sphere!(b, lscene)
+    _draw_reference_circles!(lscene)
+    _draw_axes!(lscene)
+    _plot_points!(b, lscene)
+    _plot_lines!(b, lscene)
+    _plot_arcs!(b, lscene)
+    _plot_vectors!(b, lscene)
+    _add_labels!(b, lscene)
+    return fig, lscene
 end
 
 raw"""
-    _setup_bloch_plot!(b::Bloch, location) -> (fig, ax)
+    _setup_bloch_plot!(b::Bloch, location) -> (fig, lscene)
 
 Initialize the figure and `3D` axis for Bloch sphere visualization.
 
@@ -366,7 +369,7 @@ Initialize the figure and `3D` axis for Bloch sphere visualization.
 
 # Returns
 - `fig`: Created Makie figure
-- `ax`: Configured Axis3 object
+- `lscene`: Configured LScene object
 
 Sets up the `3D` coordinate system with appropriate limits and view angles.
 """
@@ -374,52 +377,35 @@ function _setup_bloch_plot!(b::Bloch, location)
     fig, location = _getFigAndLocation(location)
     bg_color = parse(RGBf, b.frame_color)
     frame_color = RGBAf(bg_color, b.frame_alpha)
-    ax = Axis3(
-        location;
-        aspect = :data,
-        limits = (-b.frame_limit, b.frame_limit, -b.frame_limit, b.frame_limit, -b.frame_limit, b.frame_limit),
-        xgridvisible = false,
-        ygridvisible = false,
-        zgridvisible = false,
-        xticklabelsvisible = false,
-        yticklabelsvisible = false,
-        zticklabelsvisible = false,
-        xticksvisible = false,
-        yticksvisible = false,
-        zticksvisible = false,
-        xlabel = "",
-        ylabel = "",
-        zlabel = "",
-        backgroundcolor = frame_color,
-        xypanelvisible = false,
-        xzpanelvisible = false,
-        yzpanelvisible = false,
-        xspinesvisible = false,
-        yspinesvisible = false,
-        zspinesvisible = false,
-        protrusions = (0, 0, 0, 0),
-        perspectiveness = 0.2,
-        viewmode = :fit,
+    lscene = LScene(
+        location,
+        show_axis = false,
+        scenekw = (
+            backgroundcolor = frame_color,
+        )
     )
     length(b.view) == 2 || throw(ArgumentError("The length of `Bloch.view` must be 2."))
-    ax.azimuth[] = deg2rad(b.view[1])
-    ax.elevation[] = deg2rad(b.view[2])
-    return fig, ax
+    cam3d!(lscene.scene, center = false)
+    update_cam!(lscene.scene, (1, 0, 0), (0, 0, 0))
+    cam = cameracontrols(lscene)
+    cam.fov[] = 5
+    update_cam!(lscene.scene, cam, deg2rad(b.view[1]), deg2rad(b.view[2]), 26)
+    return fig, lscene
 end
 
 raw"""
-    _draw_bloch_sphere!(b, ax)
+    _draw_bloch_sphere!(b, lscene)
 
 Draw the translucent sphere representing the Bloch sphere surface.
 """
-function _draw_bloch_sphere!(b::Bloch, ax)
+function _draw_bloch_sphere!(b::Bloch, lscene)
     n_lon = 4
     n_lat = 4
     radius = 1.0f0
     base_color = parse(RGBf, b.sphere_color)
     sphere_color = RGBAf(base_color, b.sphere_alpha)
     sphere_mesh = Sphere(Point3f(0), radius)
-    mesh!(ax, sphere_mesh; color = sphere_color, shading = NoShading, transparency = true, rasterize = 3)
+    mesh!(lscene, sphere_mesh; color = sphere_color, shading = NoShading, transparency = true, rasterize = 3)
     θ_vals = range(0.0f0, 2π, length = n_lon + 1)[1:(end-1)]
     φ_curve = range(0.0f0, π, length = 600)
     line_alpha = max(0.05, b.sphere_alpha * 0.5)
@@ -427,7 +413,7 @@ function _draw_bloch_sphere!(b::Bloch, ax)
         x_line = [radius * sin(ϕ) * cos(θi) for ϕ in φ_curve]
         y_line = [radius * sin(ϕ) * sin(θi) for ϕ in φ_curve]
         z_line = [radius * cos(ϕ) for ϕ in φ_curve]
-        lines!(ax, x_line, y_line, z_line; color = RGBAf(0.5, 0.5, 0.5, line_alpha), linewidth = 1, transparency = true)
+        lines!(lscene, x_line, y_line, z_line; color = RGBAf(0.5, 0.5, 0.5, line_alpha), linewidth = 1, transparency = true)
     end
     φ_vals = range(0.0f0, π, length = n_lat + 2)
     θ_curve = range(0.0f0, 2π, length = 600)
@@ -435,21 +421,21 @@ function _draw_bloch_sphere!(b::Bloch, ax)
         x_ring = [radius * sin(ϕ) * cos(θi) for θi in θ_curve]
         y_ring = [radius * sin(ϕ) * sin(θi) for θi in θ_curve]
         z_ring = fill(radius * cos(ϕ), length(θ_curve))
-        lines!(ax, x_ring, y_ring, z_ring; color = RGBAf(0.5, 0.5, 0.5, line_alpha), linewidth = 1, transparency = true)
+        lines!(lscene, x_ring, y_ring, z_ring; color = RGBAf(0.5, 0.5, 0.5, line_alpha), linewidth = 1, transparency = true)
     end
 end
 
 raw"""
-    _draw_reference_circles!(ax)
+    _draw_reference_circles!(lscene)
 
 Draw the three great circles `(XY, YZ, XZ planes)` on the Bloch sphere.
 
 # Arguments
-- `ax`: Makie Axis3 object for drawing
+- `lscene`: Makie LScene object for drawing
 
 Adds faint circular guidelines representing the three principal planes.
 """
-function _draw_reference_circles!(ax)
+function _draw_reference_circles!(lscene)
     wire_color = RGBAf(0.5, 0.5, 0.5, 0.4)
     φ = range(0, 2π, length = 100)
     # XY, YZ, XZ circles
@@ -459,21 +445,21 @@ function _draw_reference_circles!(ax)
         [Point3f(cos(φi), 0, sin(φi)) for φi in φ],  # XZ
     ]
     for circle in circles
-        lines!(ax, circle; color = wire_color, linewidth = 1.0)
+        lines!(lscene, circle; color = wire_color, linewidth = 1.0)
     end
 end
 
 raw"""
-    _draw_axes!(ax)
+    _draw_axes!(lscene)
 
 Draw the three principal axes `(x, y, z)` of the Bloch sphere.
 
 # Arguments
-- `ax`: Makie Axis3 object for drawing
+- `lscene`: Makie LScene object for drawing
 
 Creates visible axis lines extending slightly beyond the unit sphere.
 """
-function _draw_axes!(ax)
+function _draw_axes!(lscene)
     axis_color = RGBAf(0.3, 0.3, 0.3, 0.8)
     axis_width = 0.8
     axes = [
@@ -482,22 +468,22 @@ function _draw_axes!(ax)
         ([Point3f(0, 0, 1.0), Point3f(0, 0, -1.0)], "z"),  # Z-axis
     ]
     for (points, _) in axes
-        lines!(ax, points; color = axis_color, linewidth = axis_width)
+        lines!(lscene, points; color = axis_color, linewidth = axis_width)
     end
 end
 
 raw"""
-    _plot_points!(b::Bloch, ax)
+    _plot_points!(b::Bloch, lscene)
 
 Plot all quantum state points on the Bloch sphere.
 
 # Arguments
 - `b::Bloch`: Contains point data and styling information
-- `ax`: Axis3 object for plotting
+- `lscene`: LScene object for plotting
 
 Handles both scatter points and line traces based on style specifications.
 """
-function _plot_points!(b::Bloch, ax)
+function _plot_points!(b::Bloch, lscene)
     for k in 1:length(b.points)
         pts = b.points[k]
         style = b.point_style[k]
@@ -536,7 +522,7 @@ function _plot_points!(b::Bloch, ax)
             ys = raw_y[indperm]
             zs = raw_z[indperm]
             scatter!(
-                ax,
+                lscene,
                 xs,
                 ys,
                 zs;
@@ -553,23 +539,23 @@ function _plot_points!(b::Bloch, ax)
             ys = raw_y
             zs = raw_z
             c = isa(colors, Vector) ? colors[1] : colors
-            lines!(ax, xs, ys, zs; color = c, linewidth = 2.0, transparency = alpha < 1.0, alpha = alpha)
+            lines!(lscene, xs, ys, zs; color = c, linewidth = 2.0, transparency = alpha < 1.0, alpha = alpha)
         end
     end
 end
 
 raw"""
-    _plot_lines!(b::Bloch, ax)
+    _plot_lines!(b::Bloch, lscene)
 
 Draw all connecting lines between points on the Bloch sphere.
 
 # Arguments
 - `b::Bloch`: Contains line data and formatting
-- `ax`: Axis3 object for drawing
+- `lscene`: LScene object for drawing
 
 Processes line style specifications and color mappings.
 """
-function _plot_lines!(b::Bloch, ax)
+function _plot_lines!(b::Bloch, lscene)
     color_map =
         Dict("k" => :black, "r" => :red, "g" => :green, "b" => :blue, "c" => :cyan, "m" => :magenta, "y" => :yellow)
     for (line, fmt) in b.lines
@@ -585,22 +571,22 @@ function _plot_lines!(b::Bloch, ax)
         else
             :solid
         end
-        lines!(ax, x, y, z; color = color, linewidth = 1.0, linestyle = linestyle)
+        lines!(lscene, x, y, z; color = color, linewidth = 1.0, linestyle = linestyle)
     end
 end
 
 raw"""
-    _plot_arcs!(b::Bloch, ax)
+    _plot_arcs!(b::Bloch, lscene)
 
 Draw circular arcs connecting points on the Bloch sphere surface.
 
 # Arguments
 - `b::Bloch`: Contains arc data points
-- `ax`: Axis3 object for drawing
+- `lscene`: LScene object for drawing
 
 Calculates great circle arcs between specified points.
 """
-function _plot_arcs!(b::Bloch, ax)
+function _plot_arcs!(b::Bloch, lscene)
     for arc_pts in b.arcs
         length(arc_pts) >= 2 || continue
         v1 = normalize(arc_pts[1])
@@ -613,22 +599,22 @@ function _plot_arcs!(b::Bloch, ax)
         end
         t_range = range(0, θ, length = 100)
         arc_points = [Point3f((v1 * cos(t) + cross(n, v1) * sin(t))) for t in t_range]
-        lines!(ax, arc_points; color = RGBAf(0.8, 0.4, 0.1, 0.9), linewidth = 2.0, linestyle = :solid)
+        lines!(lscene, arc_points; color = RGBAf(0.8, 0.4, 0.1, 0.9), linewidth = 2.0, linestyle = :solid)
     end
 end
 
 raw"""
-    _plot_vectors!(b::Bloch, ax)
+    _plot_vectors!(b::Bloch, lscene)
 
 Draw vectors from origin representing quantum states.
 
 # Arguments
 - `b::Bloch`: Contains vector data
-- `ax`: Axis3 object for drawing
+- `lscene`: LScene object for drawing
 
 Scales vectors appropriately and adds `3D` arrow markers.
 """
-function _plot_vectors!(b::Bloch, ax)
+function _plot_vectors!(b::Bloch, lscene)
     isempty(b.vectors) && return
     arrowsize_vec = Vec3f(b.vector_arrowsize...)
     r = 1.0
@@ -639,7 +625,7 @@ function _plot_vectors!(b::Bloch, ax)
         max_length = r * 0.90
         vec = length > max_length ? (vec/length) * max_length : vec
         arrows!(
-            ax,
+            lscene,
             [Point3f(0, 0, 0)],
             [vec],
             color = color,
@@ -652,16 +638,16 @@ function _plot_vectors!(b::Bloch, ax)
 end
 
 raw"""
-    _add_labels!(ax)
+    _add_labels!(lscene)
 
 Add axis labels and state labels to the Bloch sphere.
 
 # Arguments
-- `ax`: Axis3 object for text placement
+- `lscene`: LScene object for text placement
 
 Positions standard labels `(x, y, |0⟩, |1⟩)` at appropriate locations.
 """
-function _add_labels!(b::Bloch, ax)
+function _add_labels!(b::Bloch, lscene)
     length(b.xlabel) == 2 || throw(ArgumentError("The length of `Bloch.xlabel` must be 2."))
     length(b.ylabel) == 2 || throw(ArgumentError("The length of `Bloch.ylabel` must be 2."))
     length(b.zlabel) == 2 || throw(ArgumentError("The length of `Bloch.zlabel` must be 2."))
@@ -674,7 +660,7 @@ function _add_labels!(b::Bloch, ax)
     offset_scale = b.frame_limit
 
     (b.xlabel[1] == "") || text!(
-        ax,
+        lscene,
         b.xlabel[1],
         position = Point3f(offset_scale * b.xlpos[1], 0, 0),
         color = label_color,
@@ -682,7 +668,7 @@ function _add_labels!(b::Bloch, ax)
         align = (:center, :center),
     )
     (b.xlabel[2] == "") || text!(
-        ax,
+        lscene,
         b.xlabel[2],
         position = Point3f(offset_scale * b.xlpos[2], 0, 0),
         color = label_color,
@@ -690,7 +676,7 @@ function _add_labels!(b::Bloch, ax)
         align = (:center, :center),
     )
     (b.ylabel[1] == "") || text!(
-        ax,
+        lscene,
         b.ylabel[1],
         position = Point3f(0, offset_scale * b.ylpos[1], 0),
         color = label_color,
@@ -698,7 +684,7 @@ function _add_labels!(b::Bloch, ax)
         align = (:center, :center),
     )
     (b.ylabel[2] == "") || text!(
-        ax,
+        lscene,
         b.ylabel[2],
         position = Point3f(0, offset_scale * b.ylpos[2], 0),
         color = label_color,
@@ -706,7 +692,7 @@ function _add_labels!(b::Bloch, ax)
         align = (:center, :center),
     )
     (b.zlabel[1] == "") || text!(
-        ax,
+        lscene,
         b.zlabel[1],
         position = Point3f(0, 0, offset_scale * b.zlpos[1]),
         color = label_color,
@@ -714,7 +700,7 @@ function _add_labels!(b::Bloch, ax)
         align = (:center, :center),
     )
     (b.zlabel[2] == "") || text!(
-        ax,
+        lscene,
         b.zlabel[2],
         position = Point3f(0, 0, offset_scale * b.zlpos[2]),
         color = label_color,

--- a/ext/QuantumToolboxMakieExt.jl
+++ b/ext/QuantumToolboxMakieExt.jl
@@ -6,6 +6,7 @@ import QuantumToolbox: _state_to_bloch
 import LinearAlgebra: cross, deg2rad, normalize, size
 import Makie:
     Axis,
+    Axis3,
     LScene,
     Colorbar,
     Figure,
@@ -151,7 +152,7 @@ function _plot_wigner(
 
     lyt = GridLayout(location)
 
-    ax = LScene(lyt[1, 1], azimuth = 1.775pi, elevation = pi / 16, protrusions = (30, 90, 30, 30), viewmode = :stretch)
+    ax = Axis3(lyt[1, 1], azimuth = 1.775pi, elevation = pi / 16, protrusions = (30, 90, 30, 30), viewmode = :stretch)
 
     wig = wigner(state, xvec, yvec; g = g, method = method)
     wlim = maximum(abs, wig)

--- a/ext/QuantumToolboxMakieExt.jl
+++ b/ext/QuantumToolboxMakieExt.jl
@@ -34,6 +34,8 @@ import Makie:
     update_cam!,
     cam3d!
 
+import Makie.GeometryBasics: Tessellation
+
 @doc raw"""
     plot_wigner(
         library::Val{:Makie},
@@ -349,8 +351,8 @@ Render the Bloch sphere visualization from the given [`Bloch`](@ref) object `b`.
 function QuantumToolbox.render(b::Bloch; location = nothing)
     fig, lscene = _setup_bloch_plot!(b, location)
     _draw_bloch_sphere!(b, lscene)
-    _draw_reference_circles!(lscene)
-    _draw_axes!(lscene)
+    _draw_reference_circles!(b, lscene)
+    _draw_axes!(b, lscene)
     _plot_points!(b, lscene)
     _plot_lines!(b, lscene)
     _plot_arcs!(b, lscene)
@@ -376,9 +378,7 @@ Sets up the `3D` coordinate system with appropriate limits and view angles.
 """
 function _setup_bloch_plot!(b::Bloch, location)
     fig, location = _getFigAndLocation(location)
-    bg_color = parse(RGBf, b.frame_color)
-    frame_color = RGBAf(bg_color, b.frame_alpha)
-    lscene = LScene(location, show_axis = false, scenekw = (backgroundcolor = frame_color,))
+    lscene = LScene(location, show_axis = false, scenekw = (clear = true,))
     length(b.view) == 2 || throw(ArgumentError("The length of `Bloch.view` must be 2."))
     cam3d!(lscene.scene, center = false)
     cam = cameracontrols(lscene)
@@ -393,65 +393,52 @@ raw"""
 Draw the translucent sphere representing the Bloch sphere surface.
 """
 function _draw_bloch_sphere!(b::Bloch, lscene)
-    n_lon = 4
-    n_lat = 4
     radius = 1.0f0
-    base_color = parse(RGBf, b.sphere_color)
-    sphere_color = RGBAf(base_color, b.sphere_alpha)
     sphere_mesh = Sphere(Point3f(0), radius)
-    mesh!(lscene, sphere_mesh; color = sphere_color, shading = NoShading, transparency = true, rasterize = 3)
-    θ_vals = range(0.0f0, 2π, length = n_lon + 1)[1:(end-1)]
-    φ_curve = range(0.0f0, π, length = 600)
-    line_alpha = max(0.05, b.sphere_alpha * 0.5)
+    mesh!(
+        lscene,
+        sphere_mesh;
+        color = b.sphere_color,
+        alpha = b.sphere_alpha,
+        shading = NoShading,
+        transparency = true,
+        rasterize = 3,
+    )
+    θ_vals = range(0, π, 5)[1:(end-1)]
+    φ_curve = range(0, 2π, 600)
     for θi in θ_vals
-        x_line = [radius * sin(ϕ) * cos(θi) for ϕ in φ_curve]
-        y_line = [radius * sin(ϕ) * sin(θi) for ϕ in φ_curve]
-        z_line = [radius * cos(ϕ) for ϕ in φ_curve]
-        lines!(
-            lscene,
-            x_line,
-            y_line,
-            z_line;
-            color = RGBAf(0.5, 0.5, 0.5, line_alpha),
-            linewidth = 1,
-            transparency = true,
-        )
+        x_line = radius * sin.(φ_curve) .* cos(θi)
+        y_line = radius * sin.(φ_curve) .* sin(θi)
+        z_line = radius * cos.(φ_curve)
+        lines!(lscene, x_line, y_line, z_line; color = b.frame_color, alpha = b.frame_alpha)
     end
-    φ_vals = range(0.0f0, π, length = n_lat + 2)
-    θ_curve = range(0.0f0, 2π, length = 600)
+    φ_vals = range(0, π, 6)
+    θ_curve = range(0, 2π, 600)
     for ϕ in φ_vals
-        x_ring = [radius * sin(ϕ) * cos(θi) for θi in θ_curve]
-        y_ring = [radius * sin(ϕ) * sin(θi) for θi in θ_curve]
+        x_ring = radius * sin(ϕ) .* cos.(θ_curve)
+        y_ring = radius * sin(ϕ) .* sin.(θ_curve)
         z_ring = fill(radius * cos(ϕ), length(θ_curve))
-        lines!(
-            lscene,
-            x_ring,
-            y_ring,
-            z_ring;
-            color = RGBAf(0.5, 0.5, 0.5, line_alpha),
-            linewidth = 1,
-            transparency = true,
-        )
+        lines!(lscene, x_ring, y_ring, z_ring; color = b.frame_color, alpha = b.frame_alpha)
     end
 end
 
 raw"""
-    _draw_reference_circles!(lscene)
+    _draw_reference_circles!(b::Bloch, lscene)
 
-Draw the three great circles `(XY, YZ, XZ planes)` on the Bloch sphere.
+Draw the three great circles `(XY, XZ planes)` on the Bloch sphere.
 
 # Arguments
+- `b::Bloch`: Bloch sphere object containing frame color
 - `lscene`: Makie LScene object for drawing
 
 Adds faint circular guidelines representing the three principal planes.
 """
-function _draw_reference_circles!(lscene)
-    wire_color = RGBAf(0.5, 0.5, 0.5, 0.4)
+function _draw_reference_circles!(b::Bloch, lscene)
+    wire_color = b.frame_color
     φ = range(0, 2π, length = 100)
-    # XY, YZ, XZ circles
+    # XY, XZ circles
     circles = [
         [Point3f(cos(φi), sin(φi), 0) for φi in φ],  # XY
-        [Point3f(0, cos(φi), sin(φi)) for φi in φ],  # YZ
         [Point3f(cos(φi), 0, sin(φi)) for φi in φ],  # XZ
     ]
     for circle in circles
@@ -460,25 +447,25 @@ function _draw_reference_circles!(lscene)
 end
 
 raw"""
-    _draw_axes!(lscene)
+    _draw_axes!(b::Bloch, lscene)
 
 Draw the three principal axes `(x, y, z)` of the Bloch sphere.
 
 # Arguments
+- `b::Bloch`: Bloch sphere object containing axis color
 - `lscene`: Makie LScene object for drawing
 
 Creates visible axis lines extending slightly beyond the unit sphere.
 """
-function _draw_axes!(lscene)
-    axis_color = RGBAf(0.3, 0.3, 0.3, 0.8)
-    axis_width = 0.8
+function _draw_axes!(b::Bloch, lscene)
+    axis_color = b.frame_color
     axes = [
-        ([Point3f(1.0, 0, 0), Point3f(-1.0, 0, 0)], "x"),  # X-axis
-        ([Point3f(0, 1.0, 0), Point3f(0, -1.0, 0)], "y"),  # Y-axis
-        ([Point3f(0, 0, 1.0), Point3f(0, 0, -1.0)], "z"),  # Z-axis
+        [Point3f(1.0, 0, 0), Point3f(-1.0, 0, 0)],  # X-axis
+        [Point3f(0, 1.0, 0), Point3f(0, -1.0, 0)],  # Y-axis
+        [Point3f(0, 0, 1.0), Point3f(0, 0, -1.0)],  # Z-axis
     ]
-    for (points, _) in axes
-        lines!(lscene, points; color = axis_color, linewidth = axis_width)
+    for points in axes
+        lines!(lscene, points; color = axis_color)
     end
 end
 
@@ -667,12 +654,11 @@ function _add_labels!(b::Bloch, lscene)
 
     label_color = parse(RGBf, b.font_color)
     label_size = b.font_size
-    offset_scale = b.frame_limit
 
     (b.xlabel[1] == "") || text!(
         lscene,
         b.xlabel[1],
-        position = Point3f(offset_scale * b.xlpos[1], 0, 0),
+        position = Point3f(b.xlpos[1], 0, 0),
         color = label_color,
         fontsize = label_size,
         align = (:center, :center),
@@ -680,7 +666,7 @@ function _add_labels!(b::Bloch, lscene)
     (b.xlabel[2] == "") || text!(
         lscene,
         b.xlabel[2],
-        position = Point3f(offset_scale * b.xlpos[2], 0, 0),
+        position = Point3f(b.xlpos[2], 0, 0),
         color = label_color,
         fontsize = label_size,
         align = (:center, :center),
@@ -688,7 +674,7 @@ function _add_labels!(b::Bloch, lscene)
     (b.ylabel[1] == "") || text!(
         lscene,
         b.ylabel[1],
-        position = Point3f(0, offset_scale * b.ylpos[1], 0),
+        position = Point3f(0, b.ylpos[1], 0),
         color = label_color,
         fontsize = label_size,
         align = (:center, :center),
@@ -696,7 +682,7 @@ function _add_labels!(b::Bloch, lscene)
     (b.ylabel[2] == "") || text!(
         lscene,
         b.ylabel[2],
-        position = Point3f(0, offset_scale * b.ylpos[2], 0),
+        position = Point3f(0, b.ylpos[2], 0),
         color = label_color,
         fontsize = label_size,
         align = (:center, :center),
@@ -704,7 +690,7 @@ function _add_labels!(b::Bloch, lscene)
     (b.zlabel[1] == "") || text!(
         lscene,
         b.zlabel[1],
-        position = Point3f(0, 0, offset_scale * b.zlpos[1]),
+        position = Point3f(0, 0, b.zlpos[1]),
         color = label_color,
         fontsize = label_size,
         align = (:center, :center),
@@ -712,7 +698,7 @@ function _add_labels!(b::Bloch, lscene)
     (b.zlabel[2] == "") || text!(
         lscene,
         b.zlabel[2],
-        position = Point3f(0, 0, offset_scale * b.zlpos[2]),
+        position = Point3f(0, 0, b.zlpos[2]),
         color = label_color,
         fontsize = label_size,
         align = (:center, :center),

--- a/ext/QuantumToolboxMakieExt.jl
+++ b/ext/QuantumToolboxMakieExt.jl
@@ -377,13 +377,7 @@ function _setup_bloch_plot!(b::Bloch, location)
     fig, location = _getFigAndLocation(location)
     bg_color = parse(RGBf, b.frame_color)
     frame_color = RGBAf(bg_color, b.frame_alpha)
-    lscene = LScene(
-        location,
-        show_axis = false,
-        scenekw = (
-            backgroundcolor = frame_color,
-        )
-    )
+    lscene = LScene(location, show_axis = false, scenekw = (backgroundcolor = frame_color,))
     length(b.view) == 2 || throw(ArgumentError("The length of `Bloch.view` must be 2."))
     cam3d!(lscene.scene, center = false)
     update_cam!(lscene.scene, (1, 0, 0), (0, 0, 0))
@@ -413,7 +407,15 @@ function _draw_bloch_sphere!(b::Bloch, lscene)
         x_line = [radius * sin(ϕ) * cos(θi) for ϕ in φ_curve]
         y_line = [radius * sin(ϕ) * sin(θi) for ϕ in φ_curve]
         z_line = [radius * cos(ϕ) for ϕ in φ_curve]
-        lines!(lscene, x_line, y_line, z_line; color = RGBAf(0.5, 0.5, 0.5, line_alpha), linewidth = 1, transparency = true)
+        lines!(
+            lscene,
+            x_line,
+            y_line,
+            z_line;
+            color = RGBAf(0.5, 0.5, 0.5, line_alpha),
+            linewidth = 1,
+            transparency = true,
+        )
     end
     φ_vals = range(0.0f0, π, length = n_lat + 2)
     θ_curve = range(0.0f0, 2π, length = 600)
@@ -421,7 +423,15 @@ function _draw_bloch_sphere!(b::Bloch, lscene)
         x_ring = [radius * sin(ϕ) * cos(θi) for θi in θ_curve]
         y_ring = [radius * sin(ϕ) * sin(θi) for θi in θ_curve]
         z_ring = fill(radius * cos(ϕ), length(θ_curve))
-        lines!(lscene, x_ring, y_ring, z_ring; color = RGBAf(0.5, 0.5, 0.5, line_alpha), linewidth = 1, transparency = true)
+        lines!(
+            lscene,
+            x_ring,
+            y_ring,
+            z_ring;
+            color = RGBAf(0.5, 0.5, 0.5, line_alpha),
+            linewidth = 1,
+            transparency = true,
+        )
     end
 end
 

--- a/ext/QuantumToolboxMakieExt.jl
+++ b/ext/QuantumToolboxMakieExt.jl
@@ -381,10 +381,9 @@ function _setup_bloch_plot!(b::Bloch, location)
     lscene = LScene(location, show_axis = false, scenekw = (backgroundcolor = frame_color,))
     length(b.view) == 2 || throw(ArgumentError("The length of `Bloch.view` must be 2."))
     cam3d!(lscene.scene, center = false)
-    update_cam!(lscene.scene, (1, 0, 0), (0, 0, 0))
     cam = cameracontrols(lscene)
-    cam.fov[] = 5
-    update_cam!(lscene.scene, cam, deg2rad(b.view[1]), deg2rad(b.view[2]), 26)
+    cam.fov[] = 12
+    update_cam!(lscene.scene, cam, deg2rad(b.view[1]), deg2rad(b.view[2]), 12)
     return fig, lscene
 end
 

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -81,9 +81,8 @@ A structure representing a Bloch sphere visualization for quantum states.
 
 - `font_color::String`: Color of axis labels and text
 - `font_size::Int`: Font size for labels. Default: `15`
-- `frame_alpha::Float64`: Transparency of the frame background
-- `frame_color::String`: Background color of the frame
-- `frame_limit::Float64`: Axis limits for the 3D frame (symmetric around origin)
+- `frame_alpha::Float64`: Transparency of the wireframe
+- `frame_color::String`: Color of the wireframe
 
 ## Point properties
 
@@ -111,11 +110,11 @@ A structure representing a Bloch sphere visualization for quantum states.
 
 ## Label properties
 - `xlabel::Vector{AbstractString}`: Labels for x-axis. Default: `[L"x", ""]`
-- `xlpos::Vector{Float64}`: Positions of x-axis labels. Default: `[1.0, -1.0]`
+- `xlpos::Vector{Float64}`: Positions of x-axis labels. Default: `[1.2, -1.2]`
 - `ylabel::Vector{AbstractString}`: Labels for y-axis. Default: `[L"y", ""]`
-- `ylpos::Vector{Float64}`: Positions of y-axis labels. Default: `[1.0, -1.0]`
+- `ylpos::Vector{Float64}`: Positions of y-axis labels. Default: `[1.2, -1.2]`
 - `zlabel::Vector{AbstractString}`: Labels for z-axis. Default: `[L"|0\rangle", L"|1\rangle"]`
-- `zlpos::Vector{Float64}`: Positions of z-axis labels. Default: `[1.0, -1.0]`
+- `zlpos::Vector{Float64}`: Positions of z-axis labels. Default: `[1.2, -1.2]`
 """
 @kwdef mutable struct Bloch
     points::Vector{Matrix{Float64}} = Vector{Matrix{Float64}}()
@@ -126,7 +125,6 @@ A structure representing a Bloch sphere visualization for quantum states.
     font_size::Int = 15
     frame_alpha::Float64 = 0.1
     frame_color::String = "gray"
-    frame_limit::Float64 = 1.2
     point_default_color::Vector{String} = ["blue", "red", "green", "#CC6600"]
     point_color::Vector{Union{Nothing,String}} = Union{Nothing,String}[]
     point_marker::Vector{Symbol} = [:circle, :rect, :diamond, :utriangle]
@@ -140,11 +138,11 @@ A structure representing a Bloch sphere visualization for quantum states.
     vector_arrowsize::Vector{Float64} = [0.07, 0.08, 0.08]
     view::Vector{Int} = [30, 30]
     xlabel::Vector{AbstractString} = [L"x", ""]
-    xlpos::Vector{Float64} = [1.0, -1.0]
+    xlpos::Vector{Float64} = [1.2, -1.2]
     ylabel::Vector{AbstractString} = [L"y", ""]
-    ylpos::Vector{Float64} = [1.0, -1.0]
+    ylpos::Vector{Float64} = [1.2, -1.2]
     zlabel::Vector{AbstractString} = [L"|0\rangle", L"|1\rangle"]
-    zlpos::Vector{Float64} = [1.0, -1.0]
+    zlpos::Vector{Float64} = [1.2, -1.2]
 end
 
 const BLOCH_DATA_FIELDS = (:points, :vectors, :lines, :arcs)

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -524,7 +524,7 @@ Render the Bloch sphere visualization from the given [`Bloch`](@ref) object `b`.
 
 # Returns
 
-- A tuple `(fig, axis)` where `fig` is the figure object and `axis` is the axis object used for plotting. These can be further manipulated or saved by the user.
+- A tuple `(fig, lscene)` where `fig` is the figure object and `lscene` is the `LScene` object used for plotting. These can be further manipulated or saved by the user.
 """
 function render end
 

--- a/test/ext-test/cpu/makie/makie_ext.jl
+++ b/test/ext-test/cpu/makie/makie_ext.jl
@@ -65,23 +65,24 @@ end
 
 @testset "Makie Bloch sphere" begin
     ρ = 0.7 * ket2dm(basis(2, 0)) + 0.3 * ket2dm(basis(2, 1))
-    fig, ax = plot_bloch(ρ)
+    fig, lscene = plot_bloch(ρ)
     @test fig isa Figure
-    @test ax isa Axis3
+    @test lscene isa LScene
 
     ψ = (basis(2, 0) + basis(2, 1)) / √2
-    fig, ax = plot_bloch(ψ)
+    fig, lscene = plot_bloch(ψ)
     @test fig isa Figure
-    @test ax isa Axis3
+    @test lscene isa LScene
 
     ϕ = dag(ψ)
-    fig, ax = plot_bloch(ϕ)
+    fig, lscene = plot_bloch(ϕ)
     @test fig isa Figure
-    @test ax isa Axis3
+    @test lscene isa LScene
 
     fig = Figure()
-    pos = fig[1, 1]
-    fig1, ax = plot_bloch(ψ; location = pos)
+    ax = Axis(fig[1, 1])
+    pos = fig[1, 2]
+    fig1, lscene = plot_bloch(ψ; location = pos)
     @test fig1 === fig
 
     b = Bloch()
@@ -141,9 +142,9 @@ end
     add_line!(b, [0, 0, 0], [1, 1, 1])
     add_arc!(b, [1, 0, 0], [0, 1, 0], [0, 0, 1])
     try
-        fig, ax = QuantumToolbox.render(b)
+        fig, lscene = render(b)
         @test !isnothing(fig)
-        @test !isnothing(ax)
+        @test !isnothing(lscene)
     catch e
         @test false
         @info "Render threw unexpected error" exception=e
@@ -153,9 +154,9 @@ end
     ψ₂ = normalize(basis(2, 0) - im * basis(2, 1))
     add_line!(b, ψ₁, ψ₂; fmt = "r--")
     try
-        fig, ax = QuantumToolbox.render(b)
+        fig, lscene = render(b)
         @test !isnothing(fig)
-        @test !isnothing(ax)
+        @test !isnothing(lscene)
     catch e
         @test false
         @info "Render threw unexpected error" exception=e
@@ -187,9 +188,9 @@ end
     add_line!(b, [1, 0, 0], [0, 1, 0])
     add_arc!(b, [1, 0, 0], [0, 1, 0], [0, 0, 1])
     try
-        fig, ax = render(b)
+        fig, lscene = render(b)
         @test !isnothing(fig)
-        @test !isnothing(ax)
+        @test !isnothing(lscene)
     catch e
         @test false
         @info "Render threw unexpected error" exception=e
@@ -202,9 +203,9 @@ end
     add_arc!(b, ψ₁, ψ₂)
     add_arc!(b, ψ₂, ψ₃, ψ₁)
     try
-        fig, ax = render(b)
+        fig, lscene = render(b)
         @test !isnothing(fig)
-        @test !isnothing(ax)
+        @test !isnothing(lscene)
     catch e
         @test false
         @info "Render threw unexpected error" exception=e


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
use `LScene` instead of `Axis3` for Bloch Sphere rendering, in order to have more freedom.