### PR TITLE
Fix `Bloch` docstrings and improve visualization of the sphere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Introduce `Lanczos` solver for `spectrum`. ([#476])
 - Add Bloch-Redfield master equation solver. ([#473])
-- Implement Bloch Sphere rendering and align style with qutip. ([#472], [#480], [#485])
+- Implement Bloch Sphere rendering and align style with qutip. ([#472], [#480], [#485], [#487])
 - Add `Base.copy` method for `AbstractQuantumObject`. ([#486])
 
 ## [v0.31.1]
@@ -239,3 +239,4 @@ Release date: 2024-11-13
 [#480]: https://github.com/qutip/QuantumToolbox.jl/issues/480
 [#485]: https://github.com/qutip/QuantumToolbox.jl/issues/485
 [#486]: https://github.com/qutip/QuantumToolbox.jl/issues/486
+[#487]: https://github.com/qutip/QuantumToolbox.jl/issues/487

--- a/docs/src/users_guide/plotting_the_bloch_sphere.md
+++ b/docs/src/users_guide/plotting_the_bloch_sphere.md
@@ -166,7 +166,9 @@ fig
 
 ## [Configuring the Bloch sphere](@id doc:Configuring-the-Bloch-sphere)
 
-At the end of the last section we saw that the colors and marker shapes of the data plotted on the Bloch sphere are automatically varied according to the number of points and vectors added. But what if you want a different choice of color, or you want your sphere to be purple with different axes labels? Well then you are in luck as the Bloch class has many attributes which one can control. Assuming `b = Bloch()`:
+At the end of the last section we saw that the colors and marker shapes of the data plotted on the Bloch sphere are automatically varied according to the number of points and vectors added. But what if you want a different choice of color, or you want your sphere to be purple with different axes labels? Well then you are in luck as the [`Bloch`](@ref) structure has many fields which one can control. Assuming `b = Bloch()`:
+
+### Data storage
 
 | **Field** | **Description** | **Default setting** |
 |:----------|:----------------|:--------------------|
@@ -174,11 +176,15 @@ At the end of the last section we saw that the colors and marker shapes of the d
 | `b.vectors` | Vectors to plot on the Bloch sphere | `Vector{Vector{Float64}}()` (empty) |
 | `b.lines` | Lines to draw on the sphere (points, style, properties) | `Vector{Tuple{Vector{Vector{Float64}},String}}()` (empty) |
 | `b.arcs` | Arcs to draw on the sphere | `Vector{Vector{Vector{Float64}}}()` (empty) |
+
+### Properties
+
+| **Field** | **Description** | **Default setting** |
+|:----------|:----------------|:--------------------|
 | `b.font_color` | Color of axis labels and text | `"black"` |
 | `b.font_size` | Font size for labels | `20` |
-| `b.frame_alpha` | Transparency of the frame background | `0.1` |
-| `b.frame_color` | Background color of the frame | `"gray"` |
-| `b.frame_limit` | Axis limits for the 3D frame (symmetric around origin) | `1.2` |
+| `b.frame_alpha` | Transparency of the wire frame | `0.1` |
+| `b.frame_color` | Color of the wire frame | `"gray"` |
 | `b.point_default_color` | Default color cycle for points | `["blue", "red", "green", "#CC6600"]` |
 | `b.point_color` | List of colors for Bloch point markers to cycle through | `Union{Nothing,String}[]` |
 | `b.point_marker` | List of point marker shapes to cycle through | `[:circle, :rect, :diamond, :utriangle]` |
@@ -192,11 +198,11 @@ At the end of the last section we saw that the colors and marker shapes of the d
 | `b.vector_arrowsize` | Arrow size parameters as (head length, head width, stem width) | `[0.07, 0.08, 0.08]` |
 | `b.view` | Azimuthal and elevation viewing angles in degrees | `[30, 30]` |
 | `b.xlabel` | Labels for x-axis | `[L"x", ""]` (``+x`` and ``-x``) |
-| `b.xlpos` | Positions of x-axis labels | `[1.0, -1.0]` |
+| `b.xlpos` | Positions of x-axis labels | `[1.2, -1.2]` |
 | `b.ylabel` | Labels for y-axis | `[L"y", ""]` (``+y`` and ``-y``) |
-| `b.ylpos` | Positions of y-axis labels | `[1.0, -1.0]` |
+| `b.ylpos` | Positions of y-axis labels | `[1.2, -1.2]` |
 | `b.zlabel` | Labels for z-axis | `[L"\|0\rangle", L"\|1\rangle]"` (``+z`` and ``-z``) |
-| `b.zlpos` | Positions of z-axis labels | `[1.0, -1.0]` |
+| `b.zlpos` | Positions of z-axis labels | `[1.2, -1.2]` |
 
 These properties can also be accessed via the `print` command:
 

--- a/docs/src/users_guide/plotting_the_bloch_sphere.md
+++ b/docs/src/users_guide/plotting_the_bloch_sphere.md
@@ -17,6 +17,9 @@ In [`QuantumToolbox`](https://qutip.org/QuantumToolbox.jl/), this can be done us
 
 In [`QuantumToolbox`](https://qutip.org/QuantumToolbox.jl/), creating a [`Bloch`](@ref) sphere is accomplished by calling either:
 
+!!! note "Import plotting libraries"
+    Remember to import plotting libraries first. Here, we demonstrate the functionalities with [`CairoMakie.jl`](https://docs.makie.org/stable/explanations/backends/cairomakie.html).
+
 ```@example Bloch_sphere_rendering
 b = Bloch()
 ```
@@ -172,7 +175,7 @@ At the end of the last section we saw that the colors and marker shapes of the d
 | `b.lines` | Lines to draw on the sphere (points, style, properties) | `Vector{Tuple{Vector{Vector{Float64}},String}}()` (empty) |
 | `b.arcs` | Arcs to draw on the sphere | `Vector{Vector{Vector{Float64}}}()` (empty) |
 | `b.font_color` | Color of axis labels and text | `"black"` |
-| `b.font_size` | Font size for labels | `15` |
+| `b.font_size` | Font size for labels | `20` |
 | `b.frame_alpha` | Transparency of the frame background | `0.1` |
 | `b.frame_color` | Background color of the frame | `"gray"` |
 | `b.frame_limit` | Axis limits for the 3D frame (symmetric around origin) | `1.2` |

--- a/docs/src/users_guide/plotting_the_bloch_sphere.md
+++ b/docs/src/users_guide/plotting_the_bloch_sphere.md
@@ -174,7 +174,7 @@ At the end of the last section we saw that the colors and marker shapes of the d
 |:----------|:----------------|:--------------------|
 | `b.points` | Points to plot on the Bloch sphere (3D coordinates) | `Vector{Matrix{Float64}}()` (empty) |
 | `b.vectors` | Vectors to plot on the Bloch sphere | `Vector{Vector{Float64}}()` (empty) |
-| `b.lines` | Lines to draw on the sphere (points, style, properties) | `Vector{Tuple{Vector{Vector{Float64}},String}}()` (empty) |
+| `b.lines` | Lines to draw on the sphere with each line given as `([start_pt, end_pt], line_format)` | `Vector{Tuple{Vector{Vector{Float64}},String}}()` (empty) |
 | `b.arcs` | Arcs to draw on the sphere | `Vector{Vector{Vector{Float64}}}()` (empty) |
 
 ### Properties
@@ -195,7 +195,7 @@ At the end of the last section we saw that the colors and marker shapes of the d
 | `b.sphere_alpha` | Transparency of sphere surface | `"#FFDDDD"` |
 | `b.vector_color` | Colors for vectors | `["green", "#CC6600", "blue", "red"]` |
 | `b.vector_width` | Width of vectors | `0.025` |
-| `b.vector_arrowsize` | Arrow size parameters as (head length, head width, stem width) | `[0.07, 0.08, 0.08]` |
+| `b.vector_arrowsize` | Arrow size parameters as `[head_length, head_width, stem_width]` | `[0.07, 0.08, 0.08]` |
 | `b.view` | Azimuthal and elevation viewing angles in degrees | `[30, 30]` |
 | `b.xlabel` | Labels for x-axis | `[L"x", ""]` (``+x`` and ``-x``) |
 | `b.xlpos` | Positions of x-axis labels | `[1.2, -1.2]` |

--- a/docs/src/users_guide/plotting_the_bloch_sphere.md
+++ b/docs/src/users_guide/plotting_the_bloch_sphere.md
@@ -195,7 +195,7 @@ At the end of the last section we saw that the colors and marker shapes of the d
 | `b.sphere_alpha` | Transparency of sphere surface | `"#FFDDDD"` |
 | `b.vector_color` | Colors for vectors | `["green", "#CC6600", "blue", "red"]` |
 | `b.vector_width` | Width of vectors | `0.025` |
-| `b.vector_arrowsize` | Arrow size parameters as `[head_length, head_width, stem_width]` | `[0.07, 0.08, 0.08]` |
+| `b.vector_arrowsize` | Scales the size of the arrow head. The first two elements scale the radius (in `x/y` direction) and the last one is the length of the cone. | `[0.07, 0.08, 0.08]` |
 | `b.view` | Azimuthal and elevation viewing angles in degrees | `[30, 30]` |
 | `b.xlabel` | Labels for x-axis | `[L"x", ""]` (``+x`` and ``-x``) |
 | `b.xlpos` | Positions of x-axis labels | `[1.2, -1.2]` |

--- a/ext/QuantumToolboxMakieExt.jl
+++ b/ext/QuantumToolboxMakieExt.jl
@@ -349,10 +349,10 @@ function QuantumToolbox.render(b::Bloch; location = nothing)
     _add_labels!(b, lscene)
 
     # plot data fields in Bloch
-    _plot_points!(b, lscene)
+    _plot_vectors!(b, lscene)
     _plot_lines!(b, lscene)
     _plot_arcs!(b, lscene)
-    _plot_vectors!(b, lscene)
+    _plot_points!(b, lscene) # plot points at the end so that they will be on the very top (front) figure layer.
 
     return fig, lscene
 end
@@ -523,6 +523,7 @@ Plot all quantum state points on the Bloch sphere.
 Handles both scatter points and line traces based on style specifications.
 """
 function _plot_points!(b::Bloch, lscene)
+    isempty(b.points) && return nothing
     for k in 1:length(b.points)
         pts = b.points[k]
         style = b.point_style[k]
@@ -596,6 +597,7 @@ Draw all connecting lines between points on the Bloch sphere.
 Processes line style specifications and color mappings.
 """
 function _plot_lines!(b::Bloch, lscene)
+    isempty(b.lines) && return nothing
     color_map =
         Dict("k" => :black, "r" => :red, "g" => :green, "b" => :blue, "c" => :cyan, "m" => :magenta, "y" => :yellow)
     for (line, fmt) in b.lines
@@ -628,6 +630,7 @@ Draw circular arcs connecting points on the Bloch sphere surface.
 Calculates great circle arcs between specified points.
 """
 function _plot_arcs!(b::Bloch, lscene)
+    isempty(b.arcs) && return nothing
     for arc_pts in b.arcs
         length(arc_pts) >= 2 || continue
         v1 = normalize(arc_pts[1])
@@ -657,22 +660,17 @@ Draw vectors from origin representing quantum states.
 Scales vectors appropriately and adds `3D` arrow markers.
 """
 function _plot_vectors!(b::Bloch, lscene)
-    isempty(b.vectors) && return
-    arrowsize_vec = Vec3f(b.vector_arrowsize...)
-    r = 1.0
+    isempty(b.vectors) && return nothing
     for (i, v) in enumerate(b.vectors)
         color = get(b.vector_color, i, RGBAf(0.2, 0.5, 0.8, 0.9))
-        vec = Vec3f(v...)
-        length = norm(vec)
-        max_length = r * 0.90
-        vec = length > max_length ? (vec/length) * max_length : vec
+        vec = 0.92 * Vec3f(v...) # multiply by 0.92 so that the point edge of the arrow represents the actual position
         arrows!(
             lscene,
             [Point3f(0, 0, 0)],
             [vec],
             color = color,
             linewidth = b.vector_width,
-            arrowsize = arrowsize_vec,
+            arrowsize = Vec3f(b.vector_arrowsize...),
             arrowcolor = color,
             rasterize = 3,
         )

--- a/ext/QuantumToolboxMakieExt.jl
+++ b/ext/QuantumToolboxMakieExt.jl
@@ -666,7 +666,11 @@ function _plot_vectors!(b::Bloch, lscene)
     for (i, v) in enumerate(b.vectors)
         color = get(b.vector_color, i, RGBAf(0.2, 0.5, 0.8, 0.9))
         nv = norm(v)
-        (arrow_head_length < nv) || throw(ArgumentError("The length of vector arrow head (Bloch.vector_arrowsize[3]=$arrow_head_length) should be shorter than vector norm: $nv"))
+        (arrow_head_length < nv) || throw(
+            ArgumentError(
+                "The length of vector arrow head (Bloch.vector_arrowsize[3]=$arrow_head_length) should be shorter than vector norm: $nv",
+            ),
+        )
 
         # multiply by the following factor makes the end point of arrow head represent the actual vector position.
         vec = (1 - arrow_head_length / nv) * Vec3f(v...)

--- a/ext/QuantumToolboxMakieExt.jl
+++ b/ext/QuantumToolboxMakieExt.jl
@@ -661,9 +661,15 @@ Scales vectors appropriately and adds `3D` arrow markers.
 """
 function _plot_vectors!(b::Bloch, lscene)
     isempty(b.vectors) && return nothing
+
+    arrow_head_length = b.vector_arrowsize[3]
     for (i, v) in enumerate(b.vectors)
         color = get(b.vector_color, i, RGBAf(0.2, 0.5, 0.8, 0.9))
-        vec = 0.92 * Vec3f(v...) # multiply by 0.92 so that the point edge of the arrow represents the actual position
+        nv = norm(v)
+        (arrow_head_length < nv) || throw(ArgumentError("The length of vector arrow head (Bloch.vector_arrowsize[3]=$arrow_head_length) should be shorter than vector norm: $nv"))
+
+        # multiply by the following factor makes the end point of arrow head represent the actual vector position.
+        vec = (1 - arrow_head_length / nv) * Vec3f(v...)
         arrows!(
             lscene,
             [Point3f(0, 0, 0)],

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -74,7 +74,7 @@ A structure representing a Bloch sphere visualization for quantum states. Availa
 ## Data storage
 - `points::Vector{Matrix{Float64}}`: Points to plot on the Bloch sphere (3D coordinates)
 - `vectors::Vector{Vector{Float64}}}`: Vectors to plot on the Bloch sphere
-- `lines::Vector{Tuple{Vector{Vector{Float64}},String,Dict{Any,Any}}}`: Lines to draw on the sphere (points, style, properties)
+- `lines::Vector{Tuple{Vector{Vector{Float64}},String}}`: Lines to draw on the sphere with each line given as `([start_pt, end_pt], line_format)`
 - `arcs::Vector{Vector{Vector{Float64}}}}`: Arcs to draw on the sphere
 
 ## Style properties
@@ -100,9 +100,9 @@ A structure representing a Bloch sphere visualization for quantum states. Availa
 
 ## Vector properties
 
-- `vector_color`::Vector{String}: Colors for vectors
-- `vector_width`::Float64: Width of vectors
-- `vector_arrowsize`::Vector{Float64}: Arrow size parameters as [head length, head width, stem width]
+- `vector_color::Vector{String}`: Colors for vectors
+- `vector_width::Float64`: Width of vectors
+- `vector_arrowsize::Vector{Float64}`: Arrow size parameters as `[head_length, head_width, stem_width]`
 
 ## Layout properties
 
@@ -203,29 +203,29 @@ Add a single point to the Bloch sphere visualization.
 
 # Arguments
 - `b::Bloch`: The Bloch sphere object to modify
-- `pnt::Vector{Float64}`: A 3D point to add
+- `pnt::Vector{<:Real}`: A 3D point to add
 - `meth::Symbol=:s`: Display method (`:s` for single point, `:m` for multiple, `:l` for line)
 - `color`: Color of the point (defaults to first default color if nothing)
 - `alpha=1.0`: Transparency (`1.0` means opaque and `0.0` means transparent)
 """
-function add_points!(b::Bloch, pnt::Vector{Float64}; meth::Symbol = :s, color = nothing, alpha = 1.0)
+function add_points!(b::Bloch, pnt::Vector{<:Real}; meth::Symbol = :s, color = nothing, alpha = 1.0)
     return add_points!(b, reshape(pnt, 3, 1); meth, color, alpha)
 end
-function add_points!(b::Bloch, pnts::Vector{Vector{Float64}}; meth::Symbol = :s, color = nothing, alpha = 1.0)
+function add_points!(b::Bloch, pnts::Vector{Vector{<:Real}}; meth::Symbol = :s, color = nothing, alpha = 1.0)
     return add_points!(b, Matrix(hcat(pnts...)'); meth, color, alpha)
 end
 
 @doc raw"""
-    add_points!(b::Bloch, pnts::Matrix{Float64}; meth::Symbol = :s, color = nothing, alpha = 1.0)
+    add_points!(b::Bloch, pnts::Matrix{<:Real}; meth::Symbol = :s, color = nothing, alpha = 1.0)
 
 Add multiple points to the Bloch sphere visualization.
 
 # Arguments
 
 - `b::Bloch`: The Bloch sphere object to modify
-- `pnts::Matrix{Float64}`: `3×N` matrix of points (each column is a point)
+- `pnts::Matrix{<:Real}`: `3×N` matrix of points (each column is a point)
 - `meth::Symbol=:s`: Display method (`:s` for single point, `:m` for multiple, `:l` for line)
-- `color`: Color of the points (defaults to first default color if nothing)
+- `color`: Color of the points (defaults to first default color if `nothing`)
 - `alpha=1.0`: Transparency (`1.0` means opaque and `0.0` means transparent)
 ```
 """

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -381,13 +381,14 @@ function add_arc!(
 end
 
 @doc raw"""
-    add_states!(b::Bloch, states::Vector{QuantumObject})
+    add_states!(b::Bloch, states::Vector{QuantumObject}; kind::Symbol = :vector, kwargs...)
 
 Add one or more quantum states to the Bloch sphere visualization by converting them into Bloch vectors.
 
 # Arguments
 - `b::Bloch`: The Bloch sphere object to modify
 - `states::Vector{QuantumObject}`: One or more quantum states ([`Ket`](@ref), [`Bra`](@ref), or [`Operator`](@ref))
+- `kind::Symbol`: Type of object to plot (can be either `:vector` or `:point`). Default: `:vector`
 
 # Example
 
@@ -399,16 +400,18 @@ b = Bloch();
 add_states!(b, [x, y, z])
 ```
 """
-function add_states!(b::Bloch, states::Vector{<:QuantumObject})
+function add_states!(b::Bloch, states::Vector{<:QuantumObject}; kind::Symbol = :vector, kwargs...)
     vecs = map(state -> _state_to_bloch(state), states)
-    append!(b.vectors, vecs)
-    return b.vectors
+    if kind == :vector
+        add_vectors!(b, vecs)
+    elseif kind == :point
+        add_points!(b, hcat(vecs...), kwargs...)
+    else
+        throw(ArgumentError("Invalid kind = :$kind"))
+    end
+    return nothing
 end
-
-function add_states!(b::Bloch, state::QuantumObject)
-    push!(b.vectors, _state_to_bloch(state))
-    return b.vectors
-end
+add_states!(b::Bloch, state::QuantumObject; kind::Symbol = :vector, kwargs...) = add_states!(b, [state], kind = kind, kwargs...)
 
 _state_to_bloch(state::QuantumObject{Ket}) = _ket_to_bloch(state)
 _state_to_bloch(state::QuantumObject{Bra}) = _ket_to_bloch(state')

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -65,9 +65,9 @@ plot_fock_distribution(::Val{T}, ρ::QuantumObject{SType}; kwargs...) where {T,S
     throw(ArgumentError("The specified plotting library $T is not available. Try running `using $T` first."))
 
 @doc raw"""
-    Bloch()
+    Bloch(kwargs...)
 
-A structure representing a Bloch sphere visualization for quantum states.
+A structure representing a Bloch sphere visualization for quantum states. Available keyword arguments are listed in the following fields.
 
 # Fields
 
@@ -81,8 +81,8 @@ A structure representing a Bloch sphere visualization for quantum states.
 
 - `font_color::String`: Color of axis labels and text
 - `font_size::Int`: Font size for labels. Default: `20`
-- `frame_alpha::Float64`: Transparency of the wireframe
-- `frame_color::String`: Color of the wireframe
+- `frame_alpha::Float64`: Transparency of the wire frame
+- `frame_color::String`: Color of the wire frame
 
 ## Point properties
 
@@ -98,7 +98,7 @@ A structure representing a Bloch sphere visualization for quantum states.
 - `sphere_color::String`: Color of Bloch sphere surface
 - `sphere_alpha::Float64`: Transparency of sphere surface. Default: `0.2`
 
-# Vector properties
+## Vector properties
 
 - `vector_color`::Vector{String}: Colors for vectors
 - `vector_width`::Float64: Width of vectors
@@ -109,6 +109,7 @@ A structure representing a Bloch sphere visualization for quantum states.
 - `view::Vector{Int}`: Azimuthal and elevation viewing angles in degrees. Default: `[30, 30]`
 
 ## Label properties
+
 - `xlabel::Vector{AbstractString}`: Labels for x-axis. Default: `[L"x", ""]`
 - `xlpos::Vector{Float64}`: Positions of x-axis labels. Default: `[1.2, -1.2]`
 - `ylabel::Vector{AbstractString}`: Labels for y-axis. Default: `[L"y", ""]`

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -80,7 +80,7 @@ A structure representing a Bloch sphere visualization for quantum states.
 ## Style properties
 
 - `font_color::String`: Color of axis labels and text
-- `font_size::Int`: Font size for labels. Default: `15`
+- `font_size::Int`: Font size for labels. Default: `20`
 - `frame_alpha::Float64`: Transparency of the wireframe
 - `frame_color::String`: Color of the wireframe
 
@@ -122,7 +122,7 @@ A structure representing a Bloch sphere visualization for quantum states.
     lines::Vector{Tuple{Vector{Vector{Float64}},String}} = Vector{Tuple{Vector{Vector{Float64}},String}}()
     arcs::Vector{Vector{Vector{Float64}}} = Vector{Vector{Vector{Float64}}}()
     font_color::String = "black"
-    font_size::Int = 15
+    font_size::Int = 20
     frame_alpha::Float64 = 0.1
     frame_color::String = "gray"
     point_default_color::Vector{String} = ["blue", "red", "green", "#CC6600"]
@@ -515,10 +515,7 @@ Render the Bloch sphere visualization from the given [`Bloch`](@ref) object `b`.
 # Arguments
 
 - `b::Bloch`: The Bloch sphere object containing states, vectors, and settings to visualize.
-- `location`: Specifies where to display or save the rendered figure.
-  - If `nothing` (default), the figure is displayed interactively.
-  - If a file path (String), the figure is saved to the specified location.
-  - Other values depend on backend support.
+- `location::Union{GridPosition,Nothing}`: The location of the plot in the layout. If `nothing`, the plot is created in a new figure. Default is `nothing`.
 
 # Returns
 

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -411,7 +411,8 @@ function add_states!(b::Bloch, states::Vector{<:QuantumObject}; kind::Symbol = :
     end
     return nothing
 end
-add_states!(b::Bloch, state::QuantumObject; kind::Symbol = :vector, kwargs...) = add_states!(b, [state], kind = kind, kwargs...)
+add_states!(b::Bloch, state::QuantumObject; kind::Symbol = :vector, kwargs...) =
+    add_states!(b, [state], kind = kind, kwargs...)
 
 _state_to_bloch(state::QuantumObject{Ket}) = _ket_to_bloch(state)
 _state_to_bloch(state::QuantumObject{Bra}) = _ket_to_bloch(state')

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -102,7 +102,7 @@ A structure representing a Bloch sphere visualization for quantum states. Availa
 
 - `vector_color::Vector{String}`: Colors for vectors
 - `vector_width::Float64`: Width of vectors
-- `vector_arrowsize::Vector{Float64}`: Arrow size parameters as `[head_length, head_width, stem_width]`
+- `vector_arrowsize::Vector{Float64}`: Scales the size of the arrow head. The first two elements scale the radius (in `x/y` direction) and the last one is the length of the cone.
 
 ## Layout properties
 

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -211,7 +211,7 @@ Add a single point to the Bloch sphere visualization.
 function add_points!(b::Bloch, pnt::Vector{<:Real}; meth::Symbol = :s, color = nothing, alpha = 1.0)
     return add_points!(b, reshape(pnt, 3, 1); meth, color, alpha)
 end
-function add_points!(b::Bloch, pnts::Vector{Vector{<:Real}}; meth::Symbol = :s, color = nothing, alpha = 1.0)
+function add_points!(b::Bloch, pnts::Vector{<:Vector{<:Real}}; meth::Symbol = :s, color = nothing, alpha = 1.0)
     return add_points!(b, Matrix(hcat(pnts...)'); meth, color, alpha)
 end
 

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -69,7 +69,7 @@ plot_fock_distribution(::Val{T}, ρ::QuantumObject{SType}; kwargs...) where {T,S
 
 A structure representing a Bloch sphere visualization for quantum states. Available keyword arguments are listed in the following fields.
 
-# Fields
+# Fields:
 
 ## Data storage
 - `points::Vector{Matrix{Float64}}`: Points to plot on the Bloch sphere (3D coordinates)

--- a/test/ext-test/cpu/makie/makie_ext.jl
+++ b/test/ext-test/cpu/makie/makie_ext.jl
@@ -136,6 +136,7 @@ end
     @test isempty(b.vectors)
     @test isempty(b.lines)
     @test isempty(b.arcs)
+
     b = Bloch()
     add_points!(b, hcat([1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]))
     add_vectors!(b, [[1, 1, 0], [0, 1, 1]])
@@ -149,6 +150,9 @@ end
         @test false
         @info "Render threw unexpected error" exception=e
     end
+    b.vector_arrowsize = [0.7, 0.8, 1.5] # 1.5 is the length of arrow head (too long)
+    @test_throws ArgumentError render(b)
+
     b = Bloch()
     ψ₁ = normalize(basis(2, 0) + basis(2, 1))
     ψ₂ = normalize(basis(2, 0) - im * basis(2, 1))
@@ -167,14 +171,20 @@ end
     Pauli_Ops = [sigmax(), sigmay(), sigmaz()]
     ψ = rand_ket(2)
     ρ = rand_dm(2)
+    states = [ψ, ρ]
     x = basis(2, 0) + basis(2, 1)             # unnormalized Ket
     ρ1 = 0.3 * rand_dm(2) + 0.4 * rand_dm(2)  # unnormalized density operator
     ρ2 = Qobj(rand(ComplexF64, 2, 2))         # unnormalized and non-Hermitian Operator
-    add_states!(b, [ψ, ρ])
-    @test_logs (:warn,) (:warn,) (:warn,) (:warn,) add_states!(b, [x, ρ1, ρ2])
+    add_states!(b, states, kind = :vector)
+    add_states!(b, states, kind = :point)
+    @test length(b.vectors) == 2
+    @test length(b.points) == 1
     @test all(expect(Pauli_Ops, ψ) .≈ (b.vectors[1]))
     @test all(expect(Pauli_Ops, ρ) .≈ (b.vectors[2]))
+    @test all([b.vectors[j][k] ≈ b.points[1][k,j] for j in (1, 2) for k in (1, 2, 3)])
+    @test_logs (:warn,) (:warn,) (:warn,) (:warn,) add_states!(b, [x, ρ1, ρ2])
     @test length(b.vectors) == 5
+    @test_throws ArgumentError add_states!(b, states, kind = :wrong)
 
     th = range(0, 2π; length = 20)
     xp = cos.(th);

--- a/test/ext-test/cpu/makie/makie_ext.jl
+++ b/test/ext-test/cpu/makie/makie_ext.jl
@@ -181,7 +181,7 @@ end
     @test length(b.points) == 1
     @test all(expect(Pauli_Ops, ψ) .≈ (b.vectors[1]))
     @test all(expect(Pauli_Ops, ρ) .≈ (b.vectors[2]))
-    @test all([b.vectors[j][k] ≈ b.points[1][k,j] for j in (1, 2) for k in (1, 2, 3)])
+    @test all([b.vectors[j][k] ≈ b.points[1][k, j] for j in (1, 2) for k in (1, 2, 3)])
     @test_logs (:warn,) (:warn,) (:warn,) (:warn,) add_states!(b, [x, ρ1, ρ2])
     @test length(b.vectors) == 5
     @test_throws ArgumentError add_states!(b, states, kind = :wrong)


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
This PR does:
- set default font size to `20`
- add kwargs `kind` for `add_states!` (same as `qutip`)
- improve the handling of plot vector arrow length.
- fix all incorrect docstrings
- merge the codes in `_draw_reference_circles!` and `_draw_axes!` into `_draw_bloch_sphere!`
- remove redundant wire frame drawings