### PR TITLE
Excitation number restricted (`ENR`) state space implementation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
+- Implement `EnrSpace` and corresponding functionality. ([#500]) 
+
 ## [v0.32.1]
 Release date: 2025-06-24
 
@@ -253,3 +255,4 @@ Release date: 2024-11-13
 [#487]: https://github.com/qutip/QuantumToolbox.jl/issues/487
 [#489]: https://github.com/qutip/QuantumToolbox.jl/issues/489
 [#494]: https://github.com/qutip/QuantumToolbox.jl/issues/494
+[#500]: https://github.com/qutip/QuantumToolbox.jl/issues/500

--- a/docs/src/resources/api.md
+++ b/docs/src/resources/api.md
@@ -18,6 +18,7 @@ end
 
 ```@docs
 Space
+EnrSpace
 Dimensions
 GeneralDimensions
 AbstractQuantumObject
@@ -122,6 +123,8 @@ coherent_dm
 thermal_dm
 maximally_mixed_dm
 rand_dm
+enr_fock
+enr_thermal_dm
 spin_state
 spin_coherent
 bell_state
@@ -152,6 +155,8 @@ QuantumToolbox.momentum
 phase
 fdestroy
 fcreate
+enr_destroy
+enr_identity
 tunneling
 qft
 eye
@@ -312,6 +317,7 @@ PhysicalConstants
 convert_unit
 row_major_reshape
 meshgrid
+enr_state_dictionaries
 ```
 
 ## [Visualization](@id doc-API:Visualization)

--- a/docs/src/users_guide/QuantumObject/QuantumObject.md
+++ b/docs/src/users_guide/QuantumObject/QuantumObject.md
@@ -66,14 +66,16 @@ Manually specifying the data for each quantum object is inefficient. Even more s
 
 ### States
 - [`zero_ket`](@ref): zero ket vector
-- [`fock`](@ref) or [`basis`](@ref): fock state ket vector
-- [`fock_dm`](@ref): density matrix of a fock state
+- [`fock`](@ref) or [`basis`](@ref): Fock state ket vector
+- [`fock_dm`](@ref): density matrix of a Fock state
 - [`coherent`](@ref): coherent state ket vector 
 - [`rand_ket`](@ref): random ket vector
 - [`coherent_dm`](@ref): density matrix of a coherent state
 - [`thermal_dm`](@ref): density matrix of a thermal state
 - [`maximally_mixed_dm`](@ref): density matrix of a maximally mixed state
 - [`rand_dm`](@ref): random density matrix
+- [`enr_fock`](@ref): Fock state in the excitation number restricted (ENR) space
+- [`enr_thermal_dm`](@ref): thermal state in the excitation number restricted (ENR) space
 - [`spin_state`](@ref): spin state
 - [`spin_coherent`](@ref): coherent spin state
 - [`bell_state`](@ref): Bell state
@@ -108,6 +110,8 @@ Manually specifying the data for each quantum object is inefficient. Even more s
 - [`spin_J_set`](@ref): a set of Spin-`j` operators ``(S_x, S_y, S_z)``
 - [`fdestroy`](@ref): fermion destruction operator
 - [`fcreate`](@ref): fermion creation operator
+- [`enr_destroy`](@ref): destruction operator in the excitation number restricted (ENR) space
+- [`enr_identity`](@ref): identity operator in the excitation number restricted (ENR) space
 - [`commutator`](@ref): commutator or anti-commutator
 - [`tunneling`](@ref): tunneling operator
 - [`qft`](@ref): discrete quantum Fourier transform matrix

--- a/src/QuantumToolbox.jl
+++ b/src/QuantumToolbox.jl
@@ -84,6 +84,7 @@ include("linear_maps.jl")
 
 # Quantum Object
 include("qobj/space.jl")
+include("qobj/energy_restricted.jl")
 include("qobj/dimensions.jl")
 include("qobj/quantum_object_base.jl")
 include("qobj/quantum_object.jl")

--- a/src/negativity.jl
+++ b/src/negativity.jl
@@ -71,7 +71,7 @@ Return the partial transpose of a density matrix ``\rho``, where `mask` is an ar
 - `ρ_pt::QuantumObject`: The density matrix with the selected subsystems transposed.
 """
 function partial_transpose(ρ::QuantumObject{Operator}, mask::Vector{Bool})
-    any(s -> s isa EnrSpace, QO.dimensions.to) && throw(ArgumentError("partial_transpose does not support EnrSpace"))
+    any(s -> s isa EnrSpace, ρ.dimensions.to) && throw(ArgumentError("partial_transpose does not support EnrSpace"))
 
     (length(mask) != length(ρ.dimensions)) &&
         throw(ArgumentError("The length of \`mask\` should be equal to the length of \`ρ.dims\`."))

--- a/src/negativity.jl
+++ b/src/negativity.jl
@@ -72,8 +72,9 @@ Return the partial transpose of a density matrix ``\rho``, where `mask` is an ar
 """
 function partial_transpose(ρ::QuantumObject{Operator}, mask::Vector{Bool})
     any(s -> s isa EnrSpace, QO.dimensions.to) && throw(ArgumentError("partial_transpose does not support EnrSpace"))
-    
-    (length(mask) != length(ρ.dimensions)) && throw(ArgumentError("The length of \`mask\` should be equal to the length of \`ρ.dims\`."))
+
+    (length(mask) != length(ρ.dimensions)) &&
+        throw(ArgumentError("The length of \`mask\` should be equal to the length of \`ρ.dims\`."))
 
     isa(ρ.dimensions, GeneralDimensions) &&
         (get_dimensions_to(ρ) != get_dimensions_from(ρ)) &&

--- a/src/qobj/arithmetic_and_attributes.jl
+++ b/src/qobj/arithmetic_and_attributes.jl
@@ -505,6 +505,8 @@ Quantum Object:   type=Operator()   dims=[2]   size=(2, 2)   ishermitian=true
 ```
 """
 function ptrace(QO::QuantumObject{Ket}, sel::Union{AbstractVector{Int},Tuple})
+    any(s -> s isa EnrSpace, QO.dimensions.to) && throw(ArgumentError("ptrace does not support EnrSpace"))
+
     _non_static_array_warning("sel", sel)
 
     if length(sel) == 0 # return full trace for empty sel
@@ -527,6 +529,8 @@ end
 ptrace(QO::QuantumObject{Bra}, sel::Union{AbstractVector{Int},Tuple}) = ptrace(QO', sel)
 
 function ptrace(QO::QuantumObject{Operator}, sel::Union{AbstractVector{Int},Tuple})
+    any(s -> s isa EnrSpace, QO.dimensions.to) && throw(ArgumentError("ptrace does not support EnrSpace"))
+
     # TODO: support for special cases when some of the subsystems have same `to` and `from` space
     isa(QO.dimensions, GeneralDimensions) &&
         (get_dimensions_to(QO) != get_dimensions_from(QO)) &&
@@ -714,6 +718,8 @@ function SparseArrays.permute(
     A::QuantumObject{ObjType},
     order::Union{AbstractVector{Int},Tuple},
 ) where {ObjType<:Union{Ket,Bra,Operator}}
+    any(s -> s isa EnrSpace, A.dimensions.to) && throw(ArgumentError("permute does not support EnrSpace"))
+
     (length(order) != length(A.dimensions)) &&
         throw(ArgumentError("The order list must have the same length as the number of subsystems (A.dims)"))
 

--- a/src/qobj/dimensions.jl
+++ b/src/qobj/dimensions.jl
@@ -17,7 +17,7 @@ struct Dimensions{N,T<:Tuple} <: AbstractDimensions{N,N}
     to::T
 
     # make sure the elements in the tuple are all AbstractSpace
-    Dimensions(to::NTuple{N,T}) where {N,T<:AbstractSpace} = new{N,typeof(to)}(to)
+    Dimensions(to::NTuple{N,AbstractSpace}) where {N} = new{N,typeof(to)}(to)
 end
 function Dimensions(dims::Union{AbstractVector{T},NTuple{N,T}}) where {T<:Integer,N}
     _non_static_array_warning("dims", dims)
@@ -48,7 +48,7 @@ struct GeneralDimensions{M,N,T1<:Tuple,T2<:Tuple} <: AbstractDimensions{M,N}
     from::T2 # space acting on the right
 
     # make sure the elements in the tuple are all AbstractSpace
-    GeneralDimensions(to::NTuple{M,T1}, from::NTuple{N,T2}) where {M,N,T1<:AbstractSpace,T2<:AbstractSpace} =
+    GeneralDimensions(to::NTuple{M,AbstractSpace}, from::NTuple{N,AbstractSpace}) where {M,N} =
         new{M,N,typeof(to),typeof(from)}(to, from)
 end
 function GeneralDimensions(dims::Union{AbstractVector{T},NTuple{N,T}}) where {T<:Union{AbstractVector,NTuple},N}

--- a/src/qobj/dimensions.jl
+++ b/src/qobj/dimensions.jl
@@ -43,7 +43,6 @@ Dimensions(dims::Any) = throw(
 A structure that describes the left-hand side (`to`) and right-hand side (`from`) Hilbert [`Space`](@ref) of an [`Operator`](@ref).
 """
 struct GeneralDimensions{M,N,T1<:Tuple,T2<:Tuple} <: AbstractDimensions{M,N}
-    # note that the number `N` should be the same for both `to` and `from`
     to::T1   # space acting on the left
     from::T2 # space acting on the right
 

--- a/src/qobj/dimensions.jl
+++ b/src/qobj/dimensions.jl
@@ -98,7 +98,7 @@ function _get_dims_string(dimensions::GeneralDimensions)
 end
 _get_dims_string(::Nothing) = "nothing" # for EigsolveResult.dimensions = nothing
 
-Base.:(==)(dim1::Dimensions, dim2::Dimensions) = (dim1.to == dim2.to)
+Base.:(==)(dim1::Dimensions, dim2::Dimensions) = dim1.to == dim2.to
 Base.:(==)(dim1::GeneralDimensions, dim2::GeneralDimensions) = (dim1.to == dim2.to) && (dim1.from == dim2.from)
 Base.:(==)(dim1::Dimensions, dim2::GeneralDimensions) = false
 Base.:(==)(dim1::GeneralDimensions, dim2::Dimensions) = false

--- a/src/qobj/dimensions.jl
+++ b/src/qobj/dimensions.jl
@@ -98,3 +98,8 @@ function _get_dims_string(dimensions::GeneralDimensions)
     return "[$(string(dims[1])), $(string(dims[2]))]"
 end
 _get_dims_string(::Nothing) = "nothing" # for EigsolveResult.dimensions = nothing
+
+Base.:(==)(dim1::Dimensions, dim2::Dimensions) = (dim1.to == dim2.to)
+Base.:(==)(dim1::GeneralDimensions, dim2::GeneralDimensions) = (dim1.to == dim2.to) && (dim1.from == dim2.from)
+Base.:(==)(dim1::Dimensions, dim2::GeneralDimensions) = false
+Base.:(==)(dim1::GeneralDimensions, dim2::Dimensions) = false

--- a/src/qobj/energy_restricted.jl
+++ b/src/qobj/energy_restricted.jl
@@ -43,7 +43,7 @@ julia> dims = (2, 2, 3);
 julia> n_excitations = 3;
 
 julia> EnrSpace(dims, n_excitations)
-EnrSpace((2, 2, 3), 3)
+EnrSpace([2, 2, 3], 3)
 ```
 
 !!! warning "Beware of type-stability!"

--- a/src/qobj/energy_restricted.jl
+++ b/src/qobj/energy_restricted.jl
@@ -118,7 +118,7 @@ end
 enr_identity(s_enr::EnrSpace) = QuantumObject(Diagonal(ones(ComplexF64, s_enr.size)), Operator(), Dimensions(s_enr))
 
 function enr_fock(
-    dims::Union{AbstractVector{T},NTuple{N,T}}, 
+    dims::Union{AbstractVector{T},NTuple{N,T}},
     excitations::Int,
     state::AbstractVector{T};
     sparse::Union{Bool,Val} = Val(false),
@@ -126,11 +126,7 @@ function enr_fock(
     s_enr = EnrSpace(dims, excitations)
     return enr_fock(s_enr, state, sparse = sparse)
 end
-function enr_fock(
-    s_enr::EnrSpace,
-    state::AbstractVector{T};
-    sparse::Union{Bool,Val} = Val(false),
-) where {T<:Integer}
+function enr_fock(s_enr::EnrSpace, state::AbstractVector{T}; sparse::Union{Bool,Val} = Val(false)) where {T<:Integer}
     if getVal(sparse)
         array = sparsevec([s_enr.state2idx[[state...]]], [1.0 + 0im], s_enr.size)
     else
@@ -141,10 +137,7 @@ function enr_fock(
     return QuantumObject(array, Ket(), s_enr)
 end
 
-function enr_destroy(
-    dims::Union{AbstractVector{T},NTuple{N,T}}, 
-    excitations::Int
-) where {T<:Integer,N}
+function enr_destroy(dims::Union{AbstractVector{T},NTuple{N,T}}, excitations::Int) where {T<:Integer,N}
     s_enr = EnrSpace(dims, excitations)
     return enr_destroy(s_enr)
 end
@@ -171,7 +164,11 @@ function enr_destroy(s_enr::EnrSpace{N}) where {N}
     return a_ops
 end
 
-function enr_thermal_dm(dims::Union{AbstractVector{T1},NTuple{N,T1}}, excitations::Int, n::Union{T2,AbstractVector{T2}}) where {T1<:Integer,T2<:Real,N}
+function enr_thermal_dm(
+    dims::Union{AbstractVector{T1},NTuple{N,T1}},
+    excitations::Int,
+    n::Union{T2,AbstractVector{T2}},
+) where {T1<:Integer,T2<:Real,N}
     s_enr = EnrSpace(dims, excitations)
     return enr_thermal_dm(s_enr, n)
 end

--- a/src/qobj/energy_restricted.jl
+++ b/src/qobj/energy_restricted.jl
@@ -1,0 +1,133 @@
+#=
+This file defines the energy restricted space structure.
+=#
+
+export EnrSpace, enr_state_dictionaries
+export enr_identity, enr_fock, enr_destroy, enr_thermal_dm
+
+struct EnrSpace{N} <: AbstractSpace
+    size::Int
+    dims::NTuple{N,Int}
+    n_excitations::Int
+    state2idx::Dict{SVector{N,Int},Int}
+    idx2state::Dict{Int,SVector{N,Int}}
+
+    function EnrSpace(dims::Union{Tuple,AbstractVector}, excitations::Int)
+        _non_static_array_warning("dims", dims)
+        dim_len = length(dims)
+        dims_T = NTuple{dim_len}(dims)
+
+        size, state2idx, idx2state = enr_state_dictionaries(dims, excitations)
+
+        return new{dim_len}(size, dims_T, excitations, state2idx, idx2state)
+    end
+end
+
+function Base.show(io::IO, s::EnrSpace)
+    print(io, "EnrSpace($(s.dims), $(s.n_excitations))")
+    return nothing
+end
+
+Base.:(==)(s_enr1::EnrSpace, s_enr2::EnrSpace) = (all([s_enr1.size, s_enr1.dims] .== [s_enr2.size, s_enr2.dims]))
+
+dimensions_to_dims(s_enr::EnrSpace) = s_enr.dims
+
+function enr_state_dictionaries(dims::Union{Tuple,AbstractVector}, excitations::Int)
+    len = length(dims)
+    nvec = zeros(Int, len)
+    result = SVector{len,Int}[nvec] # in the following, all nvec will first be converted (copied) to SVector and then push to result 
+    nexc = 0
+
+    while true
+        idx = len
+        nvec[end] += 1
+        nexc += 1
+        if nvec[idx] < dims[idx]
+            push!(result, nvec)
+        end
+        while (nexc == excitations) || (nvec[idx] == dims[idx])
+            #nvec[idx] = 0
+            idx -= 1
+            if idx < 1
+                enr_size = length(result)
+                return (enr_size, Dict(zip(result, 1:enr_size)), Dict(zip(1:enr_size, result)))
+            end
+
+            nexc -= nvec[idx+1] - 1
+            nvec[idx+1] = 0
+            nvec[idx] += 1
+            if nvec[idx] < dims[idx]
+                push!(result, nvec)
+            end
+        end
+    end
+end
+
+function enr_identity(dims::Union{Tuple,AbstractVector}, excitations::Int)
+    s_enr = EnrSpace(dims, excitations)
+    return QuantumObject(Diagonal(ones(ComplexF64, s_enr.size)), Operator(), Dimensions(s_enr))
+end
+
+function enr_fock(
+    dims::Union{Tuple,AbstractVector},
+    excitations::Int,
+    state::AbstractVector;
+    sparse::Union{Bool,Val} = Val(false),
+)
+    s_enr = EnrSpace(dims, excitations)
+    if getVal(sparse)
+        array = sparsevec([s_enr.state2idx[[state...]]], [1.0 + 0im], s_enr.size)
+    else
+        j = s_enr.state2idx[state]
+        array = [i == j ? 1.0 + 0im : 0.0 + 0im for i in 1:(s_enr.size)]
+
+        # s = zeros(ComplexF64, s_enr.size)
+        # s[s_enr.state2idx[state]] += 1
+        # s
+    end
+
+    return QuantumObject(array, Ket(), s_enr)
+end
+
+function enr_destroy(dims::Union{Tuple,AbstractVector}, excitations::Int)
+    s_enr = EnrSpace(dims, excitations)
+    N = s_enr.size
+    idx2state = s_enr.idx2state
+    state2idx = s_enr.state2idx
+
+    a_ops = ntuple(i -> QuantumObject(spzeros(ComplexF64, N, N), Operator(), s_enr), length(dims))
+
+    for (n1, state1) in idx2state
+        for (idx, s) in pairs(state1)
+            # if s > 0, the annihilation operator of mode idx has a non-zero
+            # entry with one less excitation in mode idx in the final state
+            if s > 0
+                state2 = Vector(state1)
+                state2[idx] -= 1
+                n2 = state2idx[state2]
+                a_ops[idx][n2, n1] = √s
+            end
+        end
+    end
+
+    return a_ops
+end
+
+function enr_thermal_dm(dims::Union{Tuple,AbstractVector}, excitations::Int, n::Union{Int,AbstractVector})
+    if n isa Number
+        nvec = Vector{typeof(n)}(n, length(dims))
+    else
+        length(n) == length(dims) || throw(ArgumentError("The Vector `n` has different length to `dims`."))
+        nvec = n
+    end
+
+    s_enr = EnrSpace(dims, excitations)
+    N = s_enr.size
+    idx2state = s_enr.idx2state
+
+    diags = [prod((nvec ./ (1 .+ nvec)) .^ idx2state[idx]) for idx in 1:N]
+
+    diags /= sum(diags)
+
+    return QuantumObject(Diagonal(diags), Operator(), s_enr)
+end

--- a/src/qobj/energy_restricted.jl
+++ b/src/qobj/energy_restricted.jl
@@ -94,7 +94,8 @@ function enr_state_dictionaries(dims::Union{AbstractVector{T},NTuple{N,T}}, n_ex
     L = length(dims)
     (L > 0) || throw(DomainError(dims, "The argument dims must be of non-zero length"))
     all(>=(1), dims) || throw(DomainError(dims, "All the elements of dims must be non-zero integers (≥ 1)"))
-    (n_excitations > 0) || throw(DomainError(n_excitations, "The argument n_excitations must be a non-zero integer (≥ 1)"))
+    (n_excitations > 0) ||
+        throw(DomainError(n_excitations, "The argument n_excitations must be a non-zero integer (≥ 1)"))
 
     nvec = zeros(Int, L) # Vector
     nexc = 0

--- a/src/qobj/quantum_object_base.jl
+++ b/src/qobj/quantum_object_base.jl
@@ -239,7 +239,8 @@ get_dimensions_from(
 ) where {ObjType<:Union{SuperOperator,OperatorBra,OperatorKet}} = A.dimensions.to
 
 # this creates a list of Space(1), it is used to generate `from` for Ket, and `to` for Bra
-space_one_list(dimensions::NTuple{N,AbstractSpace}) where {N} = ntuple(i -> Space(1), Val(sum(_get_dims_length, dimensions)))
+space_one_list(dimensions::NTuple{N,AbstractSpace}) where {N} =
+    ntuple(i -> Space(1), Val(sum(_get_dims_length, dimensions)))
 _get_dims_length(::Space) = 1
 _get_dims_length(::EnrSpace{N}) where {N} = N
 

--- a/src/qobj/quantum_object_base.jl
+++ b/src/qobj/quantum_object_base.jl
@@ -222,7 +222,7 @@ end
 
 # this returns `to` in GeneralDimensions representation
 get_dimensions_to(A::AbstractQuantumObject{Ket,<:Dimensions}) = A.dimensions.to
-get_dimensions_to(A::AbstractQuantumObject{Bra,<:Dimensions{N}}) where {N} = space_one_list(N)
+get_dimensions_to(A::AbstractQuantumObject{Bra,<:Dimensions}) = space_one_list(A.dimensions.to)
 get_dimensions_to(A::AbstractQuantumObject{Operator,<:Dimensions}) = A.dimensions.to
 get_dimensions_to(A::AbstractQuantumObject{Operator,<:GeneralDimensions}) = A.dimensions.to
 get_dimensions_to(
@@ -230,13 +230,18 @@ get_dimensions_to(
 ) where {ObjType<:Union{SuperOperator,OperatorBra,OperatorKet}} = A.dimensions.to
 
 # this returns `from` in GeneralDimensions representation
-get_dimensions_from(A::AbstractQuantumObject{Ket,<:Dimensions{N}}) where {N} = space_one_list(N)
+get_dimensions_from(A::AbstractQuantumObject{Ket,<:Dimensions}) = space_one_list(A.dimensions.to)
 get_dimensions_from(A::AbstractQuantumObject{Bra,<:Dimensions}) = A.dimensions.to
 get_dimensions_from(A::AbstractQuantumObject{Operator,<:Dimensions}) = A.dimensions.to
 get_dimensions_from(A::AbstractQuantumObject{Operator,<:GeneralDimensions}) = A.dimensions.from
 get_dimensions_from(
     A::AbstractQuantumObject{ObjType,<:Dimensions},
 ) where {ObjType<:Union{SuperOperator,OperatorBra,OperatorKet}} = A.dimensions.to
+
+# this creates a list of Space(1), it is used to generate `from` for Ket, and `to` for Bra
+space_one_list(dimensions::NTuple{N,AbstractSpace}) where {N} = ntuple(i -> Space(1), Val(sum(_get_dims_length, dimensions)))
+_get_dims_length(::Space) = 1
+_get_dims_length(::EnrSpace{N}) where {N} = N
 
 # functions for getting Float or Complex element type
 _FType(A::AbstractQuantumObject) = _FType(eltype(A))

--- a/src/qobj/space.jl
+++ b/src/qobj/space.jl
@@ -23,6 +23,3 @@ struct Space <: AbstractSpace
 end
 
 dimensions_to_dims(s::Space) = SVector{1,Int}(s.size)
-
-# this creates a list of Space(1), it is used to generate `from` for Ket, and `to` for Bra)
-space_one_list(N::Int) = ntuple(i -> Space(1), Val(N))

--- a/src/qobj/space.jl
+++ b/src/qobj/space.jl
@@ -26,16 +26,3 @@ dimensions_to_dims(s::Space) = SVector{1,Int}(s.size)
 
 # this creates a list of Space(1), it is used to generate `from` for Ket, and `to` for Bra)
 space_one_list(N::Int) = ntuple(i -> Space(1), Val(N))
-
-# TODO: introduce energy restricted space
-#=
-struct EnrSpace{N} <: AbstractSpace
-    size::Int
-    dims::SVector{N,Int}
-    n_excitations::Int
-    state2idx
-    idx2state
-end
-
-dimensions_to_dims(s::EnrSpace) = s.dims
-=#

--- a/test/core-test/enr_state_operator.jl
+++ b/test/core-test/enr_state_operator.jl
@@ -1,0 +1,28 @@
+@testitem "Excitation number restricted state space" begin
+    @testset "mesolve" begin
+        ε = 2π
+        ωc = 2π
+        g = 0.1ωc
+        γ = 0.01ωc
+        tlist = range(0, 20, 100)
+        N_cut = 2
+
+        sz = sigmaz() ⊗ qeye(N_cut)
+        sm = sigmam() ⊗ qeye(N_cut)
+        a = qeye(2) ⊗ destroy(N_cut)
+
+        H_JC = 0.5ε * sz + ωc * a' * a + g * (sm' * a + a' * sm)
+        ψ0 = basis(2, 0) ⊗ fock(N_cut, 0)
+        sol_JC = mesolve(H_JC, ψ0, tlist, [√γ * a]; e_ops = [sz], progress_bar = Val(false))
+
+        N_exc = 1
+        dims = [2, N_cut]
+        sm_enr, a_enr = enr_destroy(dims, N_exc)
+        sz_enr = 2 * sm_enr' * sm_enr - 1
+        ψ0_enr = enr_fock(dims, N_exc, [1, 0])
+        H_enr = ε * sm_enr' * sm_enr + ωc * a_enr' * a_enr + g * (sm_enr' * a_enr + a_enr' * sm_enr)
+        sol_enr = mesolve(H_enr, ψ0_enr, tlist, [√γ * a_enr]; e_ops = [sz_enr], progress_bar = Val(false))
+
+        @test all(isapprox.(sol_JC.expect, sol_enr.expect, atol = 1e-4))
+    end
+end

--- a/test/core-test/enr_state_operator.jl
+++ b/test/core-test/enr_state_operator.jl
@@ -8,7 +8,7 @@
         I_s = qeye(D1) ⊗ qeye(D2)
         size_s = prod(dims_s)
         space_s = (Space(D1), Space(D2))
-        
+
         # EnrSpace
         dims_enr = (2, 2, 3)
         excitations = 3
@@ -34,7 +34,8 @@
         for b in basis_list
             ρ_enr_compound += tensor(b', I_enr) * ρ_tot * tensor(b, I_enr)
         end
-        new_dims2 = GeneralDimensions((space_s..., Space(1), Space(1), Space(1)), (space_s..., Space(1), Space(1), Space(1)))
+        new_dims2 =
+            GeneralDimensions((space_s..., Space(1), Space(1), Space(1)), (space_s..., Space(1), Space(1), Space(1)))
         ρ_s_compound = Qobj(zeros(ComplexF64, size_s, size_s), dims = new_dims2)
         basis_list = [enr_fock(space_enr, space_enr.idx2state[idx]) for idx in 1:space_enr.size]
         for b in basis_list
@@ -72,7 +73,7 @@
         c_ops_enr = (√γ * a_enr,)
         sol_enr = mesolve(H_enr, ψ0_enr, tlist, c_ops_enr; e_ops = [sz_enr], progress_bar = Val(false))
         ρ_ss_enr = steadystate(H_enr, c_ops_enr)
-        
+
         # check mesolve result
         @test all(isapprox.(sol_JC.expect, sol_enr.expect, atol = 1e-4))
 

--- a/test/core-test/enr_state_operator.jl
+++ b/test/core-test/enr_state_operator.jl
@@ -1,5 +1,5 @@
 @testitem "Excitation number restricted state space" begin
-    @testset "mesolve" begin
+    @testset "mesolve, steadystate, and eigenstates" begin
         ε = 2π
         ωc = 2π
         g = 0.1ωc
@@ -7,22 +7,37 @@
         tlist = range(0, 20, 100)
         N_cut = 2
 
+        # normal mesolve and steadystate
         sz = sigmaz() ⊗ qeye(N_cut)
         sm = sigmam() ⊗ qeye(N_cut)
         a = qeye(2) ⊗ destroy(N_cut)
-
         H_JC = 0.5ε * sz + ωc * a' * a + g * (sm' * a + a' * sm)
-        ψ0 = basis(2, 0) ⊗ fock(N_cut, 0)
-        sol_JC = mesolve(H_JC, ψ0, tlist, [√γ * a]; e_ops = [sz], progress_bar = Val(false))
+        c_ops_JC = (√γ * a,)
+        ψ0_JC = basis(2, 0) ⊗ fock(N_cut, 0)
+        sol_JC = mesolve(H_JC, ψ0_JC, tlist, c_ops_JC; e_ops = [sz], progress_bar = Val(false))
+        ρ_ss_JC = steadystate(H_JC, c_ops_JC)
 
+        # ENR mesolve and steadystate
         N_exc = 1
-        dims = [2, N_cut]
+        dims = (2, N_cut)
         sm_enr, a_enr = enr_destroy(dims, N_exc)
         sz_enr = 2 * sm_enr' * sm_enr - 1
         ψ0_enr = enr_fock(dims, N_exc, [1, 0])
         H_enr = ε * sm_enr' * sm_enr + ωc * a_enr' * a_enr + g * (sm_enr' * a_enr + a_enr' * sm_enr)
-        sol_enr = mesolve(H_enr, ψ0_enr, tlist, [√γ * a_enr]; e_ops = [sz_enr], progress_bar = Val(false))
-
+        c_ops_enr = (√γ * a_enr,)
+        sol_enr = mesolve(H_enr, ψ0_enr, tlist, c_ops_enr; e_ops = [sz_enr], progress_bar = Val(false))
+        ρ_ss_enr = steadystate(H_enr, c_ops_enr)
+        
+        # check mesolve result
         @test all(isapprox.(sol_JC.expect, sol_enr.expect, atol = 1e-4))
+
+        # check steadystate result
+        @test expect(sz, ρ_ss_JC) ≈ expect(sz_enr, ρ_ss_enr) atol=1e-4
+
+        # check eigenstates
+        λ, v = eigenstates(H_enr)
+        @test all([H_enr * v[k] ≈ λ[k] * v[k] for k in eachindex(λ)])
+
+        qeye(3) ⊗ H_enr
     end
 end

--- a/test/core-test/enr_state_operator.jl
+++ b/test/core-test/enr_state_operator.jl
@@ -16,7 +16,7 @@
             8 => SVector{3}(1, 0, 1),
             9 => SVector{3}(1, 0, 2),
             10 => SVector{3}(1, 1, 0),
-            11 => SVector{3}(1, 1, 1)
+            11 => SVector{3}(1, 1, 1),
         )
         @test s_enr.idx2state == qutip_idx2state
     end

--- a/test/core-test/enr_state_operator.jl
+++ b/test/core-test/enr_state_operator.jl
@@ -1,4 +1,26 @@
 @testitem "Excitation number restricted state space" begin
+    using StaticArraysCore
+
+    @testset "EnrSpace" begin
+        s_enr = EnrSpace((2, 2, 3), 3)
+
+        # check if the idx2state is the same as qutip
+        qutip_idx2state = Dict(
+            1 => SVector{3}(0, 0, 0),
+            2 => SVector{3}(0, 0, 1),
+            3 => SVector{3}(0, 0, 2),
+            4 => SVector{3}(0, 1, 0),
+            5 => SVector{3}(0, 1, 1),
+            6 => SVector{3}(0, 1, 2),
+            7 => SVector{3}(1, 0, 0),
+            8 => SVector{3}(1, 0, 1),
+            9 => SVector{3}(1, 0, 2),
+            10 => SVector{3}(1, 1, 0),
+            11 => SVector{3}(1, 1, 1)
+        )
+        @test s_enr.idx2state == qutip_idx2state
+    end
+
     @testset "kron" begin
         # normal Space
         D1 = 4


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Add functionalities for ENR space, as [QuTiP](https://github.com/qutip/qutip/blob/9f6393cb96bfc76d4a603b1e0aacbea77bde7a55/qutip/core/energy_restricted.py).

- [x] Define `EnrSpace` and `enr_state_dictionaries`
- [x] Define basic functions
  - `enr_identity`
  - `enr_fock`
  - `enr_destroy`
  - `enr_thermal_dm`
- [x] Support `kron`
- [x] make sure `ptrace`, `permute`, and `partial_transpose` doesn't support `EnrSpace`