### PR TITLE
Check for orthogonality breakdown in `Lanczos`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
+- Check for orthogonality breakdown in `Lanczos` solver for `spectrum`. ([#501])
+
 ## [v0.32.1]
 Release date: 2025-06-24
 
@@ -253,3 +255,4 @@ Release date: 2024-11-13
 [#487]: https://github.com/qutip/QuantumToolbox.jl/issues/487
 [#489]: https://github.com/qutip/QuantumToolbox.jl/issues/489
 [#494]: https://github.com/qutip/QuantumToolbox.jl/issues/494
+[#501]: https://github.com/qutip/QuantumToolbox.jl/issues/501

--- a/src/spectrum.jl
+++ b/src/spectrum.jl
@@ -276,8 +276,8 @@ function _spectrum(
         βₖδₖ = dot(wₖ, vₖ)
         if βₖδₖ ≈ 0.0
             if solver.verbose > 0
-                warn("spectrum(): solver::Lanczos experienced orthogonality breakdown after $(k) iterations")
-                warn("spectrum(): βₖδₖ = $(βₖδₖ)")
+                @warn "spectrum(): solver::Lanczos experienced orthogonality breakdown after $(k) iterations"
+                @warn "spectrum(): βₖδₖ = $(βₖδₖ)"
             end
             break
         end

--- a/test/core-test/correlations_and_spectrum.jl
+++ b/test/core-test/correlations_and_spectrum.jl
@@ -50,6 +50,10 @@
         @test last(outlines) == "spectrum(): Consider increasing maxiter and/or tol"
     end
 
+    @testset "Orthogonal input vectors Lanczos" begin
+        @test_throws AssertionError spectrum(H, ω_l2, [c_ops[1]], a', a; solver = Lanczos())
+    end
+
     # tlist and τlist checks
     t_fft_wrong = [0, 1, 10]
     t_wrong1 = [1, 2, 3]


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description

Check for breakdown of orthogonality and orthogonal initial vectors in the `Lanczos` solver.

## Related issues or PRs

Fixes #501.
