### PR TITLE
Improve efficiency of generation of Bloch-Redfield tensor and fix documentation typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
+- Improve efficiency of `bloch_redfield_tensor` by avoiding unnecessary conversions. ([#509])
+
 ## [v0.33.0]
 Release date: 2025-07-22
 
@@ -267,3 +269,4 @@ Release date: 2024-11-13
 [#504]: https://github.com/qutip/QuantumToolbox.jl/issues/504
 [#506]: https://github.com/qutip/QuantumToolbox.jl/issues/506
 [#507]: https://github.com/qutip/QuantumToolbox.jl/issues/507
+[#509]: https://github.com/qutip/QuantumToolbox.jl/issues/509

--- a/docs/src/users_guide/settings.md
+++ b/docs/src/users_guide/settings.md
@@ -13,7 +13,7 @@ Here, we list out each setting along with the specific functions that will use i
 
 - `tidyup_tol::Float64 = 1e-14` : tolerance for [`tidyup`](@ref) and [`tidyup!`](@ref).
 - `auto_tidyup::Bool = true` : Automatically tidyup during the following situations:
-    * Solving for eigenstates, including [`eigenstates`](@ref), [`eigsolve`](@ref), and [`eigsolve_al`](@ref).
+    * Solving for eigenstates, including [`eigenstates`](@ref), [`eigsolve`](@ref), [`eigsolve_al`](@ref), [`bloch_redfield_tensor`](@ref), [`brterm`](@ref) and [`brmesolve`](@ref).
 - (to be announced)
 
 ## Change default settings

--- a/docs/src/users_guide/settings.md
+++ b/docs/src/users_guide/settings.md
@@ -13,7 +13,8 @@ Here, we list out each setting along with the specific functions that will use i
 
 - `tidyup_tol::Float64 = 1e-14` : tolerance for [`tidyup`](@ref) and [`tidyup!`](@ref).
 - `auto_tidyup::Bool = true` : Automatically tidyup during the following situations:
-    * Solving for eigenstates, including [`eigenstates`](@ref), [`eigsolve`](@ref), [`eigsolve_al`](@ref), [`bloch_redfield_tensor`](@ref), [`brterm`](@ref) and [`brmesolve`](@ref).
+    * Solving for eigenstates, including [`eigenstates`](@ref), [`eigsolve`](@ref), [`eigsolve_al`](@ref)
+    * Creating [`bloch_redfield_tensor`](@ref) or [`brterm`](@ref), and solving [`brmesolve`](@ref).
 - (to be announced)
 
 ## Change default settings

--- a/docs/src/users_guide/time_evolution/brmesolve.md
+++ b/docs/src/users_guide/time_evolution/brmesolve.md
@@ -162,7 +162,7 @@ H = -Δ/2.0 * sigmax() - ε0/2 * sigmaz()
 
 ohmic_spectrum(ω) = (ω == 0.0) ? γ1 : γ1 / 2 * (ω / (2 * π)) * (ω > 0.0)
 
-R, U = bloch_redfield_tensor(H, [(sigmax(), ohmic_spectrum)])
+R, U = bloch_redfield_tensor(H, ((sigmax(), ohmic_spectrum), ))
 
 R
 ```
@@ -183,6 +183,8 @@ H = - Δ/2.0 * sigmax() - ϵ0/2.0 * sigmaz()
 ohmic_spectrum(ω) = (ω == 0.0) ? γ1 : γ1 / 2 * (ω / (2 * π)) * (ω > 0.0)
 
 a_ops = ((sigmax(), ohmic_spectrum),)
+R = bloch_redfield_tensor(H, a_ops; fock_basis = Val(true))
+
 e_ops = [sigmax(), sigmay(), sigmaz()]
 
 # same initial random ket state in QuTiP doc 
@@ -192,7 +194,7 @@ e_ops = [sigmax(), sigmay(), sigmaz()]
 ])
 
 tlist = LinRange(0, 15.0, 1000)
-sol = brmesolve(H, ψ0, tlist, a_ops, e_ops=e_ops)
+sol = mesolve(R, ψ0, tlist, e_ops=e_ops)
 expt_list = real(sol.expect)
 
 # plot the evolution of state on Bloch sphere

--- a/src/time_evolution/brmesolve.jl
+++ b/src/time_evolution/brmesolve.jl
@@ -112,6 +112,13 @@ function _brterm(
     ac_term = (A_mat .* spectrum) * A_mat
     bd_term = A_mat * (A_mat .* trans(spectrum))
 
+    # Remove small values before passing in the Liouville space
+    if settings.auto_tidyup
+        tidyup!(A_mat)
+        tidyup!(ac_term)
+        tidyup!(bd_term)
+    end
+
     if sec_cutoff != -1
         m_cut = similar(skew)
         map!(x -> abs(x) < sec_cutoff, m_cut, skew)

--- a/src/time_evolution/brmesolve.jl
+++ b/src/time_evolution/brmesolve.jl
@@ -37,7 +37,7 @@ function bloch_redfield_tensor(
     U = QuantumObject(rst.vectors, Operator(), H.dimensions)
     sec_cutoff = float(sec_cutoff)
 
-    H_new = getVal(fock_basis) ? H : QuantumObject(Diagonal(real.(rst.values)), Operator(), H.dimensions)
+    H_new = getVal(fock_basis) ? H : QuantumObject(Diagonal(rst.values), Operator(), H.dimensions)
     c_ops_new = isnothing(c_ops) ? nothing : map(x -> getVal(fock_basis) ? x : U' * x * U, c_ops)
     R = liouvillian(H_new, c_ops_new)
 
@@ -112,13 +112,6 @@ function _brterm(
     ac_term = (A_mat .* spectrum) * A_mat
     bd_term = A_mat * (A_mat .* trans(spectrum))
 
-    # Remove small values before passing in the Liouville space
-    if settings.auto_tidyup
-        tidyup!(A_mat)
-        tidyup!(ac_term)
-        tidyup!(bd_term)
-    end
-
     if sec_cutoff != -1
         m_cut = similar(skew)
         map!(x -> abs(x) < sec_cutoff, m_cut, skew)
@@ -127,6 +120,13 @@ function _brterm(
 
         vec_skew = vec(skew)
         M_cut = @. abs(vec_skew - vec_skew') < sec_cutoff
+    end
+
+    # Remove small values before passing in the Liouville space
+    if settings.auto_tidyup
+        tidyup!(A_mat)
+        tidyup!(ac_term)
+        tidyup!(bd_term)
     end
 
     out =

--- a/src/time_evolution/brmesolve.jl
+++ b/src/time_evolution/brmesolve.jl
@@ -97,7 +97,7 @@ function _brterm(
     a_op::T,
     spectra::F,
     sec_cutoff::Real,
-    fock_basis::Union{Val{true},Val{false}},
+    fock_basis::Union{Bool,Val},
 ) where {T<:QuantumObject{Operator},F<:Function}
     _check_br_spectra(spectra)
 

--- a/test/core-test/brmesolve.jl
+++ b/test/core-test/brmesolve.jl
@@ -5,8 +5,8 @@
     A_op = a+a'
     spectra(x) = (x>0) * 0.5
     for sec_cutoff in [0, 0.1, 1, 3, -1]
-        R = bloch_redfield_tensor(H, [(A_op, spectra)], [a^2], sec_cutoff = sec_cutoff, fock_basis = true)
-        R_eig, evecs = bloch_redfield_tensor(H, [(A_op, spectra)], [a^2], sec_cutoff = sec_cutoff, fock_basis = false)
+        R = bloch_redfield_tensor(H, ((A_op, spectra), ), [a^2], sec_cutoff = sec_cutoff, fock_basis = Val(true))
+        R_eig, evecs = bloch_redfield_tensor(H, ((A_op, spectra), ), [a^2], sec_cutoff = sec_cutoff, fock_basis = Val(false))
         @test isa(R, QuantumObject)
         @test isa(R_eig, QuantumObject)
         @test isa(evecs, QuantumObject)
@@ -27,7 +27,7 @@ end
 
     # this test applies for limited cutoff
     lindblad = lindblad_dissipator(a)
-    computation = brterm(H, A_op, spectra, sec_cutoff = 1.5, fock_basis = true)
+    computation = brterm(H, A_op, spectra, sec_cutoff = 1.5, fock_basis = Val(true))
     @test isapprox(lindblad, computation, atol = 1e-15)
 end
 
@@ -38,8 +38,8 @@ end
     A_op = a+a'
     spectra(x) = x>0
     for sec_cutoff in [0, 0.1, 1, 3, -1]
-        R = brterm(H, A_op, spectra, sec_cutoff = sec_cutoff, fock_basis = true)
-        R_eig, evecs = brterm(H, A_op, spectra, sec_cutoff = sec_cutoff, fock_basis = false)
+        R = brterm(H, A_op, spectra, sec_cutoff = sec_cutoff, fock_basis = Val(true))
+        R_eig, evecs = brterm(H, A_op, spectra, sec_cutoff = sec_cutoff, fock_basis = Val(false))
         @test isa(R, QuantumObject)
         @test isa(R_eig, QuantumObject)
         @test isa(evecs, QuantumObject)
@@ -76,8 +76,8 @@ end
     a = destroy(N) + destroy(N)^2/2
     A_op = a+a'
     for spectra in spectra_list
-        R = brterm(H, A_op, spectra, sec_cutoff = 0.1, fock_basis = true)
-        R_eig, evecs = brterm(H, A_op, spectra, sec_cutoff = 0.1, fock_basis = false)
+        R = brterm(H, A_op, spectra, sec_cutoff = 0.1, fock_basis = Val(true))
+        R_eig, evecs = brterm(H, A_op, spectra, sec_cutoff = 0.1, fock_basis = Val(false))
         @test isa(R, QuantumObject)
         @test isa(R_eig, QuantumObject)
         @test isa(evecs, QuantumObject)
@@ -112,4 +112,4 @@ end
 
         @test all(me.expect .== brme.expect)
     end
-end;
+end

--- a/test/core-test/brmesolve.jl
+++ b/test/core-test/brmesolve.jl
@@ -5,8 +5,9 @@
     A_op = a+a'
     spectra(x) = (x>0) * 0.5
     for sec_cutoff in [0, 0.1, 1, 3, -1]
-        R = bloch_redfield_tensor(H, ((A_op, spectra), ), [a^2], sec_cutoff = sec_cutoff, fock_basis = Val(true))
-        R_eig, evecs = bloch_redfield_tensor(H, ((A_op, spectra), ), [a^2], sec_cutoff = sec_cutoff, fock_basis = Val(false))
+        R = bloch_redfield_tensor(H, ((A_op, spectra),), [a^2], sec_cutoff = sec_cutoff, fock_basis = Val(true))
+        R_eig, evecs =
+            bloch_redfield_tensor(H, ((A_op, spectra),), [a^2], sec_cutoff = sec_cutoff, fock_basis = Val(false))
         @test isa(R, QuantumObject)
         @test isa(R_eig, QuantumObject)
         @test isa(evecs, QuantumObject)


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
The current implementation of the `bloch_redfield_tensor` function rotates the basis at the end. This is very inefficient as the rotation superoperator is a large dense matrix.

In this PR, I rotate the basis (if asked) directly during the computation. Avoiding to define the rotation operator. This surely improves the `fock_basis=false` case, and partially improves the true case.
