### PR TITLE
Fix stack overflow error in `QobjEvo` multiplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
 - Improve Bloch sphere rendering for animation. ([#520])
+- Fix stack overflow error in `QobjEvo` multiplication. ([#524], [#525])
 
 ## [v0.34.0]
 Release date: 2025-07-29
@@ -295,3 +296,5 @@ Release date: 2024-11-13
 [#515]: https://github.com/qutip/QuantumToolbox.jl/issues/515
 [#517]: https://github.com/qutip/QuantumToolbox.jl/issues/517
 [#520]: https://github.com/qutip/QuantumToolbox.jl/issues/520
+[#524]: https://github.com/qutip/QuantumToolbox.jl/issues/524
+[#525]: https://github.com/qutip/QuantumToolbox.jl/issues/525

--- a/src/qobj/arithmetic_and_attributes.jl
+++ b/src/qobj/arithmetic_and_attributes.jl
@@ -42,11 +42,22 @@ for op in (:(+), :(-), :(*))
             return QType($(op)(A.data, B.data), A.type, A.dimensions)
         end
         Base.$op(A::AbstractQuantumObject) = get_typename_wrapper(A)($(op)(A.data), A.type, A.dimensions)
+    end
 
-        Base.$op(n::T, A::AbstractQuantumObject) where {T<:Number} =
-            get_typename_wrapper(A)($(op)(n * I, A.data), A.type, A.dimensions)
-        Base.$op(A::AbstractQuantumObject, n::T) where {T<:Number} =
-            get_typename_wrapper(A)($(op)(A.data, n * I), A.type, A.dimensions)
+    if op == :(*)
+        @eval begin
+            Base.$op(n::T, A::AbstractQuantumObject) where {T<:Number} =
+                get_typename_wrapper(A)($(op)(n, A.data), A.type, A.dimensions)
+            Base.$op(A::AbstractQuantumObject, n::T) where {T<:Number} =
+                get_typename_wrapper(A)($(op)(A.data, n), A.type, A.dimensions)
+        end
+    else
+        @eval begin
+            Base.$op(n::T, A::AbstractQuantumObject) where {T<:Number} =
+                get_typename_wrapper(A)($(op)(n * I, A.data), A.type, A.dimensions)
+            Base.$op(A::AbstractQuantumObject, n::T) where {T<:Number} =
+                get_typename_wrapper(A)($(op)(A.data, n * I), A.type, A.dimensions)
+        end
     end
 end
 

--- a/test/core-test/quantum_objects_evo.jl
+++ b/test/core-test/quantum_objects_evo.jl
@@ -70,15 +70,18 @@
     end
 
     @testset "arithmetic" begin
-        a = MatrixOperator(sprand(ComplexF64, 100, 100, 0.1))
+        m = sprand(ComplexF64, 100, 100, 0.1)
+        a = MatrixOperator(m)
         a2 = QobjEvo(a)
         a3 = QobjEvo(a, type = SuperOperator())
+        a4 = QobjEvo(Qobj(m), (p, t) -> 1)
 
         @test +a2 == a2
         @test -(-a2) == a2
         @test a2 + 2 == 2 + a2
         @test (a2 + 2).data == a2.data + 2 * I
         @test a2 * 2 == 2 * a2
+        @test 1*a*a*1 == 1*(a*a) == (a*a)*1 == 1*(a*a)*1 # to check QobjEvo multiplication with Number is correct
 
         zero_like = zero(a2)
         iden_like = one(a3)


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Remove redundant usage of `LinearAlgebra.I` during the multiplication (`*`) between `AbstractQuantumObject` and `Number`

## Related issues or PRs
fix #524 
