### PR TITLE
Fix `Makie` warning message

### DIFF
--- a/ext/QuantumToolboxMakieExt.jl
+++ b/ext/QuantumToolboxMakieExt.jl
@@ -24,10 +24,8 @@ import Makie:
     scatter!,
     arrows3d!,
     text!,
-    Point3f,
     mesh!,
     RGBf,
-    Vec3f,
     Point3f,
     NoShading,
     cameracontrols,
@@ -660,7 +658,7 @@ function _plot_arcs!(b::Bloch, lscene)
             dot(cross(v1, vm), n) < 0 && (θ -= 2π)
         end
         t_range = range(0, θ, length = 100)
-        arc_points = [Point3f((v1 * cos(t) + cross(n, v1) * sin(t))) for t in t_range]
+        arc_points = [Point3f(v1 * cos(t) + cross(n, v1) * sin(t)) for t in t_range]
         lines!(lscene, arc_points; color = "blue", linestyle = :solid)
     end
     return nothing
@@ -685,8 +683,8 @@ function _plot_vectors!(b::Bloch, lscene)
 
         arrows3d!(
             lscene,
-            [Point3f(0, 0, 0)],
-            [v],
+            Point3f(0),
+            Point3f(v),
             color = color,
             shaftradius = b.vector_width,
             tiplength = b.vector_tiplength,

--- a/ext/QuantumToolboxMakieExt.jl
+++ b/ext/QuantumToolboxMakieExt.jl
@@ -689,7 +689,7 @@ function _plot_vectors!(b::Bloch, lscene)
             shaftradius = b.vector_width,
             tiplength = b.vector_tiplength,
             tipradius = b.vector_tipradius,
-            rasterize = 3,
+            # rasterize = 3, #TODO: maybe uncomment this after https://github.com/MakieOrg/Makie.jl/issues/5259 is fixed
         )
     end
     return nothing


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Try to fix the following warning message from `Makie` while rendering `Bloch` sphere vectors:

```
Arrows3D{Tuple{Vector{GeometryBasics.Point{3, Float32}}, Vector{Vector{Float64}}}} is not supported by cairo right now
```

Also, remove some redundant imports from our `QuantumToolboxMakieExt`.