### PR TITLE
Fix keyword argument handling for `SteadyStateODESolver`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
 - Add support of `QobjEvo` for `steadystate` (ODE solver only). ([#536])
+- Fix keyword argument handling for `SteadyStateODESolver`. ([#537])
 
 ## [v0.34.1]
 Release date: 2025-08-23
@@ -304,3 +305,4 @@ Release date: 2024-11-13
 [#520]: https://github.com/qutip/QuantumToolbox.jl/issues/520
 [#531]: https://github.com/qutip/QuantumToolbox.jl/issues/531
 [#536]: https://github.com/qutip/QuantumToolbox.jl/issues/536
+[#537]: https://github.com/qutip/QuantumToolbox.jl/issues/537

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support of `QobjEvo` for `steadystate` (ODE solver only). ([#536])
 - Changes to `SteadyStateODESolver`. ([#537])
-  - Introduce the terminate tolerances for `steadystate` terminate condition (two new fields: `terminate_reltol = 1e-5` and `terminate_abstol = 1e-7`)
-  - Fix keyword argument handling for `SteadyStateODESolver`.
+  - Introduce the tolerances for `steadystate` terminate condition (two new fields: `terminate_reltol = 1e-5` and `terminate_abstol = 1e-7`)
+  - Fix keyword argument handling for `SteadyStateODESolver` before passing to `mesolve`.
 
 ## [v0.34.1]
 Release date: 2025-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
 - Add support of `QobjEvo` for `steadystate` (ODE solver only). ([#536])
-- Fix keyword argument handling for `SteadyStateODESolver`. ([#537])
+- Changes to `SteadyStateODESolver`. ([#537])
+  - Introduce the terminate tolerances for calculating `steadystate` (two new fields: `terminate_abstol = 1e-5` and `terminate_abstol = 1e-7`)
+  - Fix keyword argument handling for `SteadyStateODESolver`.
 
 ## [v0.34.1]
 Release date: 2025-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support of `QobjEvo` for `steadystate` (ODE solver only). ([#536])
 - Changes to `SteadyStateODESolver`. ([#537])
-  - Introduce the terminate tolerances for calculating `steadystate` (two new fields: `terminate_abstol = 1e-5` and `terminate_abstol = 1e-7`)
+  - Introduce the terminate tolerances for `steadystate` terminate condition (two new fields: `terminate_reltol = 1e-5` and `terminate_abstol = 1e-7`)
   - Fix keyword argument handling for `SteadyStateODESolver`.
 
 ## [v0.34.1]

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -47,11 +47,11 @@ end
         alg = Tsit5(),
         ψ0 = nothing,
         tmax = Inf,
-        )
+        terminate_reltol = 1e-5,
+        terminate_abstol = 1e-7
+    )
 
-An ordinary differential equation (ODE) solver for solving [`steadystate`](@ref).
-
-Solve the stationary state based on time evolution (ordinary differential equations; `OrdinaryDiffEq.jl`) with a given initial state.
+An ordinary differential equation (ODE) solver for solving [`steadystate`](@ref). It solves the stationary state based on [`mesolve`](@ref) with a termination condition.
 
 The termination condition of the stationary state ``|\rho\rangle\rangle`` is that either the following condition is `true`:
 
@@ -69,14 +69,21 @@ or
 - `alg::OrdinaryDiffEqAlgorithm=Tsit5()`: The algorithm to solve the ODE.
 - `ψ0::Union{Nothing,QuantumObject}=nothing`: The initial state of the system. If not specified, a random pure state will be generated.
 - `tmax::Real=Inf`: The final time step for the steady state problem.
+- `terminate_reltol` = The relative tolerance for stationary state terminate condition. Default to `1e-5`.
+- `terminate_abstol` = The absolute tolerance for stationary state terminate condition. Default to `1e-7`.
 
-For more details about the solvers, please refer to [`OrdinaryDiffEq.jl`](https://docs.sciml.ai/OrdinaryDiffEq/stable/).
+!!! warning "Tolerances for terminate condition"
+    The terminate condition tolerances `terminate_reltol` and `terminate_abstol` should be larger than `reltol` and `abstol` of [`mesolve`](@ref), respectively.
+
+For more details about the solving `alg`orithms, please refer to [`OrdinaryDiffEq.jl`](https://docs.sciml.ai/OrdinaryDiffEq/stable/).
 """
 Base.@kwdef struct SteadyStateODESolver{MT<:OrdinaryDiffEqAlgorithm,ST<:Union{Nothing,QuantumObject},T<:Real} <:
                    SteadyStateSolver
     alg::MT = Tsit5()
     ψ0::ST = nothing
     tmax::T = Inf
+    terminate_reltol::Real = 10 * DEFAULT_ODE_SOLVER_OPTIONS.reltol
+    terminate_abstol::Real = 10 * DEFAULT_ODE_SOLVER_OPTIONS.abstol
 end
 
 @doc raw"""
@@ -200,27 +207,25 @@ function _steadystate(L::QuantumObject{SuperOperator}, solver::SteadyStateDirect
 end
 
 function _steadystate(L::AbstractQuantumObject{SuperOperator}, solver::SteadyStateODESolver; kwargs...)
-    tmax = solver.tmax
-
     ψ0 = isnothing(solver.ψ0) ? rand_ket(L.dimensions) : solver.ψ0
-    abstol = haskey(kwargs, :abstol) ? kwargs[:abstol] : DEFAULT_ODE_SOLVER_OPTIONS.abstol
-    reltol = haskey(kwargs, :reltol) ? kwargs[:reltol] : DEFAULT_ODE_SOLVER_OPTIONS.reltol
-
     ftype = _float_type(ψ0)
-    _terminate_func = SteadyStateODECondition(similar(mat2vec(ket2dm(ψ0)).data))
-    cb = TerminateSteadyState(abstol, reltol, _terminate_func)
-    sol = mesolve(
-        L,
-        ψ0,
-        [ftype(0), ftype(tmax)];
-        alg = solver.alg,
-        progress_bar = Val(false),
-        save_everystep = false,
-        saveat = ftype[],
-        callback = cb,
-        kwargs...,
-    )
+    tlist = [ftype(0), ftype(solver.tmax)]
 
+    # overwrite some kwargs and throw warning message to tell the users that we are ignoring these settings
+    haskey(kwargs, :progress_bar) && @warn "Ignore keyword argument 'progress_bar' for SteadyStateODESolver"
+    haskey(kwargs, :save_everystep) && @warn "Ignore keyword argument 'save_everystep' for SteadyStateODESolver"
+    haskey(kwargs, :saveat) && @warn "Ignore keyword argument 'saveat' for SteadyStateODESolver"
+    kwargs2 = merge(kwargs, (progress_bar = Val(false), save_everystep = false, saveat = ftype[]))
+
+    # add terminate condition (callback)
+    cb = TerminateSteadyState(
+        solver.terminate_abstol,
+        solver.terminate_reltol,
+        SteadyStateODECondition(similar(mat2vec(ket2dm(ψ0)).data)),
+    )
+    kwargs3 = _merge_kwargs_with_callback(kwargs2, cb)
+
+    sol = mesolve(L, ψ0, tlist; kwargs3...)
     ρss = sol.states[end]
     return ρss
 end

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -77,13 +77,18 @@ or
 
 For more details about the solving `alg`orithms, please refer to [`OrdinaryDiffEq.jl`](https://docs.sciml.ai/OrdinaryDiffEq/stable/).
 """
-Base.@kwdef struct SteadyStateODESolver{MT<:OrdinaryDiffEqAlgorithm,ST<:Union{Nothing,QuantumObject},T<:Real} <:
-                   SteadyStateSolver
+Base.@kwdef struct SteadyStateODESolver{
+    MT<:OrdinaryDiffEqAlgorithm,
+    ST<:Union{Nothing,QuantumObject},
+    T1<:Real,
+    T2<:Real,
+    T3<:Real,
+} <: SteadyStateSolver
     alg::MT = Tsit5()
     ψ0::ST = nothing
-    tmax::T = Inf
-    terminate_reltol::Real = 10 * DEFAULT_ODE_SOLVER_OPTIONS.reltol
-    terminate_abstol::Real = 10 * DEFAULT_ODE_SOLVER_OPTIONS.abstol
+    tmax::T1 = Inf
+    terminate_reltol::T2 = 10 * DEFAULT_ODE_SOLVER_OPTIONS.reltol
+    terminate_abstol::T3 = 10 * DEFAULT_ODE_SOLVER_OPTIONS.abstol
 end
 
 @doc raw"""

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -80,15 +80,15 @@ For more details about the solving `alg`orithms, please refer to [`OrdinaryDiffE
 Base.@kwdef struct SteadyStateODESolver{
     MT<:OrdinaryDiffEqAlgorithm,
     ST<:Union{Nothing,QuantumObject},
-    T1<:Real,
-    T2<:Real,
-    T3<:Real,
+    TT<:Real,
+    RT<:Real,
+    AT<:Real,
 } <: SteadyStateSolver
     alg::MT = Tsit5()
     ψ0::ST = nothing
-    tmax::T1 = Inf
-    terminate_reltol::T2 = 10 * DEFAULT_ODE_SOLVER_OPTIONS.reltol
-    terminate_abstol::T3 = 10 * DEFAULT_ODE_SOLVER_OPTIONS.abstol
+    tmax::TT = Inf
+    terminate_reltol::RT = 10 * DEFAULT_ODE_SOLVER_OPTIONS.reltol
+    terminate_abstol::AT = 10 * DEFAULT_ODE_SOLVER_OPTIONS.abstol
 end
 
 @doc raw"""

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -215,7 +215,10 @@ function _steadystate(L::AbstractQuantumObject{SuperOperator}, solver::SteadySta
     haskey(kwargs, :progress_bar) && @warn "Ignore keyword argument 'progress_bar' for SteadyStateODESolver"
     haskey(kwargs, :save_everystep) && @warn "Ignore keyword argument 'save_everystep' for SteadyStateODESolver"
     haskey(kwargs, :saveat) && @warn "Ignore keyword argument 'saveat' for SteadyStateODESolver"
-    kwargs2 = merge(kwargs, (progress_bar = Val(false), save_everystep = false, saveat = ftype[]))
+    kwargs2 = merge(
+        NamedTuple(kwargs), # we convert to NamedTuple just in case if kwargs is empty
+        (progress_bar = Val(false), save_everystep = false, saveat = ftype[]),
+    )
 
     # add terminate condition (callback)
     cb = TerminateSteadyState(


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
This PR introduces two new fields
- `terminate_reltol = 1e-5`
- `terminate_abstol = 1e-7`

for `SteadyStateODESolver`, in order to separate from the tolerances which pass to `mesolve` through `steadystate(...; kwargs...)`.

Also, this PR fixes several `kwargs` handling for `SteadyStateODESolver` before passing to `mesolve`.

