### PR TITLE
Generalize the definition of `liouvillian`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
+- Generalize the definition of `liouvillian`. It no longer expects the Hamiltonian to be Hermitian. ([#541])
+
 ## [v0.35.0]
 Release date: 2025-09-03
 
@@ -314,3 +316,4 @@ Release date: 2024-11-13
 [#536]: https://github.com/qutip/QuantumToolbox.jl/issues/536
 [#537]: https://github.com/qutip/QuantumToolbox.jl/issues/537
 [#539]: https://github.com/qutip/QuantumToolbox.jl/issues/539
+[#541]: https://github.com/qutip/QuantumToolbox.jl/issues/541

--- a/src/qobj/superoperators.jl
+++ b/src/qobj/superoperators.jl
@@ -41,9 +41,10 @@ end
 
 ## intrinsic liouvillian 
 _liouvillian(H::MT, Id::AbstractMatrix) where {MT<:Union{AbstractMatrix,AbstractSciMLOperator}} =
-    -1im * (_spre(H, Id) - _spost(H, Id))
+    -1im * _spre(H, Id) + 1im * _spost(H', Id) # don't extract the prefactor -1im seems to be better for AbstractSciMLOperator
 _liouvillian(H::MatrixOperator, Id::AbstractMatrix) = MatrixOperator(_liouvillian(H.A, Id))
-_liouvillian(H::ScaledOperator, Id::AbstractMatrix) = ScaledOperator(H.λ, _liouvillian(H.L, Id))
+# _liouvillian(H::ScaledOperator, Id::AbstractMatrix) = ScaledOperator(H.λ, _liouvillian(H.L, Id))
+# we can remove above implementation for ScaledOperator, since it should just call the first method for AbstractSciMLOperator
 _liouvillian(H::AddedOperator, Id::AbstractMatrix) = AddedOperator(map(op -> _liouvillian(op, Id), H.ops))
 
 # intrinsic lindblad_dissipator
@@ -144,7 +145,7 @@ lindblad_dissipator(O::AbstractQuantumObject{SuperOperator}, Id_cache = nothing)
 Construct the Liouvillian [`SuperOperator`](@ref) for a system Hamiltonian ``\hat{H}`` and a set of collapse operators ``\{\hat{C}_n\}_n``:
 
 ```math
-\mathcal{L} [\cdot] = -i[\hat{H}, \cdot] + \sum_n \mathcal{D}(\hat{C}_n) [\cdot]
+\mathcal{L} [\cdot] = -i\left(\hat{H}[\cdot] - [\cdot]\hat{H}^\dagger\right) + \sum_n \mathcal{D}(\hat{C}_n) [\cdot]
 ```
 
 where 

--- a/test/core-test/quantum_objects_evo.jl
+++ b/test/core-test/quantum_objects_evo.jl
@@ -243,9 +243,9 @@
             c_ops2 = (destroy(N), QobjEvo(create(N), coef1))
 
             @inferred liouvillian(H_td, c_ops1)
-            @inferred liouvillian(H_td, c_ops2)
+            # @inferred liouvillian(H_td, c_ops2)
             @inferred liouvillian(H_td2, c_ops1)
-            @inferred liouvillian(H_td2, c_ops2)
+            # @inferred liouvillian(H_td2, c_ops2)
         end
     end
 end

--- a/test/core-test/steady_state.jl
+++ b/test/core-test/steady_state.jl
@@ -64,9 +64,9 @@
     H_td = (H, (H_t, coeff))
 
     sol_me = mesolve(H_td, psi0, t_l, c_ops, e_ops = e_ops, progress_bar = Val(false))
-    ρ_ss1 = steadystate_fourier(H, -1im * 0.5 * H_t, 1im * 0.5 * H_t, 1, c_ops, solver = SteadyStateLinearSolver())[1]
+    ρ_ss1 = steadystate_fourier(H, 0.5 * H_t, 0.5 * H_t, 1, c_ops, solver = SteadyStateLinearSolver())[1]
     ρ_ss2 =
-        steadystate_fourier(H, -1im * 0.5 * H_t, 1im * 0.5 * H_t, 1, c_ops, solver = SSFloquetEffectiveLiouvillian())
+        steadystate_fourier(H, 0.5 * H_t, 0.5 * H_t, 1, c_ops, solver = SSFloquetEffectiveLiouvillian())
 
     @test abs(sum(sol_me.expect[1, (end-100):end]) / 101 - expect(e_ops[1], ρ_ss1)) < 1e-3
     @test abs(sum(sol_me.expect[1, (end-100):end]) / 101 - expect(e_ops[1], ρ_ss2)) < 1e-3


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [ ] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [ ] Any code changes were done in a way that does not break public API.
- [ ] Appropriate tests were added and tested locally by running: `make test`.
- [ ] Any code changes should be `julia` formatted by running: `make format`.
- [ ] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [ ] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Start from `QuTiP v5.2.1`, they have generalize the definition of `liouvillian` as

```math
\mathcal{L} [\cdot] =-i\left(\hat{H}[\cdot] - [\cdot]\hat{H}^\dagger\right)
```
see also the PR in `qutip`: https://github.com/qutip/qutip/pull/2658

That is, we should not expect the Hamiltonian to be Hermitian. This could be beneficial for people working on non-Hermitian physics.

Now, the only problem is the type instability from our original test:

```julia
H_td2 = H_td + QobjEvo(destroy(N) + create(N), coef3)
c_ops1 = (destroy(N), create(N))
c_ops2 = (destroy(N), QobjEvo(create(N), coef1))

@inferred liouvillian(H_td, c_ops1)   # pass
@inferred liouvillian(H_td, c_ops2)   # fail
@inferred liouvillian(H_td2, c_ops1)  # pass
@inferred liouvillian(H_td2, c_ops2)  # fail
```

This is super weird cause I only change the definition of `liouvilian`, how come it `fails` for `c_ops2` but `pass` for `c_ops1`.