### PR TITLE
Fix `cite()` bibtex output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
+- Fix `cite()` bibtex output. ([#552])
+
 ## [v0.36.0]
 Release date: 2025-09-29
 
@@ -323,3 +325,4 @@ Release date: 2024-11-13
 [#539]: https://github.com/qutip/QuantumToolbox.jl/issues/539
 [#544]: https://github.com/qutip/QuantumToolbox.jl/issues/544
 [#546]: https://github.com/qutip/QuantumToolbox.jl/issues/546
+[#552]: https://github.com/qutip/QuantumToolbox.jl/issues/552

--- a/src/versioninfo.jl
+++ b/src/versioninfo.jl
@@ -89,7 +89,7 @@ function cite(io::IO = stdout)
       author = {Mercurio, Alberto and Huang, Yi-Te and Cai, Li-Xun and Chen, Yueh-Nan and Savona, Vincenzo and Nori, Franco},
       journal = {{Quantum}},
       issn = {2521-327X},
-      publisher = {{Verein zur F{\"{o}}rderung des Open Access Publizierens in den Quantenwissenschaften}},
+      publisher = {{Verein zur F{\\"{o}}rderung des Open Access Publizierens in den Quantenwissenschaften}},
       volume = {9},
       pages = {1866},
       month = sep,
@@ -98,5 +98,5 @@ function cite(io::IO = stdout)
       url = {https://doi.org/10.22331/q-2025-09-29-1866}
     }
     """
-    return println(io, citation)
+    return print(io, citation)
 end

--- a/test/core-test/utilities.jl
+++ b/test/core-test/utilities.jl
@@ -10,14 +10,14 @@
           """  author = {Mercurio, Alberto and Huang, Yi-Te and Cai, Li-Xun and Chen, Yueh-Nan and Savona, Vincenzo and Nori, Franco},\n""" *
           """  journal = {{Quantum}},\n""" *
           """  issn = {2521-327X},\n""" *
-          """  publisher = {{Verein zur F{\"{o}}rderung des Open Access Publizierens in den Quantenwissenschaften}},\n""" *
+          """  publisher = {{Verein zur F{\\"{o}}rderung des Open Access Publizierens in den Quantenwissenschaften}},\n""" *
           """  volume = {9},\n""" *
           """  pages = {1866},\n""" *
           """  month = sep,\n""" *
           """  year = {2025},\n""" *
           """  doi = {10.22331/q-2025-09-29-1866},\n""" *
           """  url = {https://doi.org/10.22331/q-2025-09-29-1866}\n""" *
-          """}\n\n"""
+          """}\n"""
 
     @testset "n_thermal" begin
         ω1 = rand(Float64)


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Fix incorrect bibtex in `cite()`: 
```
publisher = {{Verein zur F{\\"{o}}rderung ... }},
```
(need double `\` in `String` to show single `\` in output).

Furthermore, this PR also remove the redundant line break at the end.