### PR TITLE
Use Julia 1.11 for AutoDiff_Ext tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,7 +68,7 @@ jobs:
               os: 'ubuntu-latest'
               arch: 'x64'
             group: 'Makie_Ext'
-          - version: '1'
+          - version: '1.11'
             node:
               os: 'ubuntu-latest'
               arch: 'x64'


### PR DESCRIPTION
## Description
This PR fixes the CI configuration for the AutoDiff extension tests. Autodiff doesn't work on Julia 1.12, so the test matrix has been updated to run AutoDiff_Ext tests on Julia 1.11 instead of the latest Julia version.

## Changes
- Updated `.github/workflows/CI.yml` to use Julia 1.11 for AutoDiff_Ext tests instead of Julia 1 (latest)

## Motivation
This ensures that the AutoDiff extension tests pass until compatibility with Julia 1.12 can be resolved.