### PR TITLE
Use `Base.depwarn` for deprecated functionality

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,34 +1,53 @@
 #=
 This file gathers all the deprecated names (structures, functions, or variables) which will be removed in the future major release.
 
-- Before the major release, the deprecated names will just throw errors when they are called.
+- Before the major release, the deprecated names will show warnings or just throw errors when they are called.
 - If the deprecated names were once exported, we will still export them here until next major release.
 - If we decide to push a major release, cleanup this file.
 
-Example:
-
+Example 1 [throw errors if the deprecation is fundamental, and there is no replacement for it]:
+```
 export deprecated_foo
+deprecated_foo(args...; kwargs...) = error("`deprecated_foo` is deprecated and will be removed in next major release.")
+```
 
+Example 2 ["force" show warning and tell the users that there is a replacement for the deprecated function]:
+
+```
+export deprecated_foo
 function deprecated_foo(args...; kwargs...)
-    error("`deprecated_foo` has been deprecated and will be removed in next major release, please use `new_foo` instead.")
+    Base.depwarn("`deprecated_foo` is deprecated and will be removed in next major release, use `new_foo` instead.", :deprecated_foo, force = true)
+    new_foo(args...; kwargs...)
 end
+```
 =#
 
 export FFTCorrelation
-export sparse_to_dense, dense_to_sparse
-
 FFTCorrelation() = error(
-    "`FFTCorrelation` has been deprecated and will be removed in next major release, please use `spectrum_correlation_fft` to calculate the spectrum with FFT method instead.",
+    "`FFTCorrelation` is deprecated and will be removed in next major release, use `spectrum_correlation_fft` to calculate the spectrum with FFT method instead.",
 )
 
-sparse_to_dense(args...) = error(
-    "`sparse_to_dense` has been deprecated and will be removed in next major release, please use `to_dense` instead.",
-)
-dense_to_sparse(args...) = error(
-    "`dense_to_sparse` has been deprecated and will be removed in next major release, please use `to_sparse` instead.",
-)
+export sparse_to_dense
+function sparse_to_dense(args...)
+    Base.depwarn(
+        "`sparse_to_dense` is deprecated and will be removed in next major release, use `to_dense` instead.",
+        :sparse_to_dense,
+        force = true,
+    )
+    return to_dense(args...)
+end
 
-correlation_3op_2t(
+export dense_to_sparse
+function dense_to_sparse(args...)
+    Base.depwarn(
+        "`dense_to_sparse` is deprecated and will be removed in next major release, use `to_sparse` instead.",
+        :dense_to_sparse,
+        force = true,
+    )
+    return to_sparse(args...)
+end
+
+function correlation_3op_2t(
     H::QuantumObject{HOpType},
     ψ0::QuantumObject{StateOpType},
     t_l::AbstractVector,
@@ -38,11 +57,16 @@ correlation_3op_2t(
     C::QuantumObject{Operator},
     c_ops::Union{Nothing,AbstractVector,Tuple} = nothing;
     kwargs...,
-) where {HOpType<:Union{Operator,SuperOperator},StateOpType<:Union{Ket,Operator}} = error(
-    "The parameter order of `correlation_3op_2t` has been changed, please use `?correlation_3op_2t` to check the updated docstring.",
-)
+) where {HOpType<:Union{Operator,SuperOperator},StateOpType<:Union{Ket,Operator}}
+    Base.depwarn(
+        "The argument order of `correlation_3op_2t(H, ψ0, t_l, τ_l, A, B, C, c_ops)` is changed to `correlation_3op_2t(H, ψ0, t_l, τ_l, c_ops, A, B, C)`, use `?correlation_3op_2t` to check the updated docstring.",
+        :correlation_3op_2t,
+        force = true,
+    )
+    return correlation_3op_2t(H, ψ0, t_l, τ_l, c_ops, A, B, C; kwargs...)
+end
 
-correlation_3op_1t(
+function correlation_3op_1t(
     H::QuantumObject{HOpType},
     ψ0::QuantumObject{StateOpType},
     τ_l::AbstractVector,
@@ -51,11 +75,16 @@ correlation_3op_1t(
     C::QuantumObject{Operator},
     c_ops::Union{Nothing,AbstractVector,Tuple} = nothing;
     kwargs...,
-) where {HOpType<:Union{Operator,SuperOperator},StateOpType<:Union{Ket,Operator}} = error(
-    "The parameter order of `correlation_3op_1t` has been changed, please use `?correlation_3op_1t` to check the updated docstring.",
-)
+) where {HOpType<:Union{Operator,SuperOperator},StateOpType<:Union{Ket,Operator}}
+    Base.depwarn(
+        "The argument order of `correlation_3op_1t(H, ψ0, τ_l, A, B, C, c_ops)` is changed to `correlation_3op_1t(H, ψ0, τ_l, c_ops, A, B, C)`, use `?correlation_3op_1t` to check the updated docstring.",
+        :correlation_3op_1t,
+        force = true,
+    )
+    return correlation_3op_1t(H, ψ0, τ_l, c_ops, A, B, C; kwargs...)
+end
 
-correlation_2op_2t(
+function correlation_2op_2t(
     H::QuantumObject{HOpType},
     ψ0::QuantumObject{StateOpType},
     t_l::AbstractVector,
@@ -65,11 +94,16 @@ correlation_2op_2t(
     c_ops::Union{Nothing,AbstractVector,Tuple} = nothing;
     reverse::Bool = false,
     kwargs...,
-) where {HOpType<:Union{Operator,SuperOperator},StateOpType<:Union{Ket,Operator}} = error(
-    "The parameter order of `correlation_2op_2t` has been changed, please use `?correlation_2op_2t` to check the updated docstring.",
-)
+) where {HOpType<:Union{Operator,SuperOperator},StateOpType<:Union{Ket,Operator}}
+    Base.depwarn(
+        "The argument order of `correlation_2op_2t(H, ψ0, t_l, τ_l, A, B, c_ops)` is changed to `correlation_2op_2t(H, ψ0, t_l, τ_l, c_ops, A, B)`, use `?correlation_2op_2t` to check the updated docstring.",
+        :correlation_2op_2t,
+        force = true,
+    )
+    return correlation_2op_2t(H, ψ0, t_l, τ_l, c_ops, A, B; reverse = reverse, kwargs...)
+end
 
-correlation_2op_1t(
+function correlation_2op_1t(
     H::QuantumObject{HOpType},
     ψ0::QuantumObject{StateOpType},
     τ_l::AbstractVector,
@@ -78,10 +112,21 @@ correlation_2op_1t(
     c_ops::Union{Nothing,AbstractVector,Tuple} = nothing;
     reverse::Bool = false,
     kwargs...,
-) where {HOpType<:Union{Operator,SuperOperator},StateOpType<:Union{Ket,Operator}} = error(
-    "The parameter order of `correlation_2op_1t` has been changed, please use `?correlation_2op_1t` to check the updated docstring.",
-)
+) where {HOpType<:Union{Operator,SuperOperator},StateOpType<:Union{Ket,Operator}}
+    Base.depwarn(
+        "The argument order of `correlation_2op_1t(H, ψ0, τ_l, A, B, c_ops)` is changed to `correlation_2op_1t(H, ψ0, τ_l, c_ops, A, B)`, use `?correlation_2op_1t` to check the updated docstring.",
+        :correlation_2op_1t,
+        force = true,
+    )
+    return correlation_2op_1t(H, ψ0, τ_l, c_ops, A, B; reverse = reverse, kwargs...)
+end
 
-MultiSiteOperator(dims::Union{AbstractVector,Tuple}, pairs::Pair{<:Integer,<:QuantumObject}...) = error(
-    "`MultiSiteOperator` has been deprecated and will be removed in next major release, please use `multisite_operator` instead.",
-)
+export MultiSiteOperator
+function MultiSiteOperator(args...)
+    Base.depwarn(
+        "`MultiSiteOperator` is deprecated and will be removed in next major release, use `multisite_operator` instead.",
+        :MultiSiteOperator,
+        force = true,
+    )
+    return multisite_operator(args...)
+end

--- a/test/core-test/correlations_and_spectrum.jl
+++ b/test/core-test/correlations_and_spectrum.jl
@@ -68,12 +68,13 @@
     @test_throws ArgumentError correlation_3op_2t(H, nothing, t_wrong2, t_wrong1, c_ops, Id, a', a)
     @test_throws ArgumentError correlation_3op_2t(H, nothing, t_wrong2, t_wrong2, c_ops, Id, a', a)
 
-    @testset "Deprecated Errors" begin
+    @testset "Deprecated Errors and Warnings" begin
         ρ0 = rand_dm(N)
+        t_l = [0.0, 1.0] # make time list shorter
         @test_throws ErrorException FFTCorrelation()
-        @test_throws ErrorException correlation_3op_2t(H, ρ0, t_l, t_l, a, a', a, c_ops)
-        @test_throws ErrorException correlation_3op_1t(H, ρ0, t_l, a, a', a, c_ops)
-        @test_throws ErrorException correlation_2op_2t(H, ρ0, t_l, t_l, a', a, c_ops)
-        @test_throws ErrorException correlation_2op_1t(H, ρ0, t_l, a', a, c_ops)
+        @test_logs (:warn,) correlation_3op_2t(H, ρ0, t_l, t_l, a, a', a, c_ops; progress_bar = Val(false))
+        @test_logs (:warn,) correlation_3op_1t(H, ρ0, t_l, a, a', a, c_ops; progress_bar = Val(false))
+        @test_logs (:warn,) correlation_2op_2t(H, ρ0, t_l, t_l, a', a, c_ops; progress_bar = Val(false))
+        @test_logs (:warn,) correlation_2op_1t(H, ρ0, t_l, a', a, c_ops; progress_bar = Val(false))
     end
 end

--- a/test/core-test/low_rank_dynamics.jl
+++ b/test/core-test/low_rank_dynamics.jl
@@ -60,7 +60,7 @@
     tl = range(0, 10, 100)
 
     # Full solution
-    sol_me = mesolve(H, ρ, tl, c_ops; e_ops = [e_ops...])
+    sol_me = mesolve(H, ρ, tl, c_ops; e_ops = [e_ops...], progress_bar = Val(false))
     Strue = entropy_vn(sol_me.states[end], base = 2) / latt.N
 
     # Low rank solution
@@ -82,4 +82,6 @@
 
     @test real(sol_me.expect[1, :]) ≈ real(sol_lr.expect[1, :]) atol = 1e-1
     @test S_lr ≈ Strue atol = 1e-1
+
+    @test_logs (:warn,) MultiSiteOperator(latt, 1 => sigmax()) # deprecated warning
 end

--- a/test/core-test/quantum_objects.jl
+++ b/test/core-test/quantum_objects.jl
@@ -351,9 +351,9 @@
         @test typeof(SparseMatrixCSC(Ms).data) == SparseMatrixCSC{Int64,Int64}
         @test typeof(SparseMatrixCSC{ComplexF64}(Ms).data) == SparseMatrixCSC{ComplexF64,Int64}
 
-        @testset "Deprecated Errors" begin
-            @test_throws ErrorException sparse_to_dense(vs)
-            @test_throws ErrorException dense_to_sparse(vd)
+        @testset "Deprecated Warnings" begin
+            @test_logs (:warn,) sparse_to_dense(vs)
+            @test_logs (:warn,) dense_to_sparse(vd)
         end
     end
 


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
As title