### PR TITLE
Fix CUDA compat version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -43,7 +43,7 @@ QuantumToolboxMakieExt = "Makie"
 
 [compat]
 ArrayInterface = "6, 7"
-CUDA = "<5.9"
+CUDA = "5.0 - 5.8"
 ChainRulesCore = "1"
 DiffEqBase = "6"
 DiffEqCallbacks = "4.2.1 - 4"


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
I noticed that setting `CUDA = "<5.9"` also includes `CUDA v1 ~ v4`.

We should set it as
```
CUDA = "5.0 - 5.8"
```

If they fix the bug in `CUDA v5.Y.Z`, then we can set it as
```
CUDA = "5.0 - 5.8, 5.Y.Z - 5"
```