### PR TITLE
Make sure state generating functions return dense array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add keyword argument `assume_hermitian` to `liouvillian`. This allows users to disable the assumption that the Hamiltonian is Hermitian. ([#581])
 - Use LinearSolve's internal methods for preconditioners in `SteadyStateLinearSolver`. ([#588])
 - Use `FillArrays.jl` for handling superoperators. This makes the code cleaner and potentially more efficient. ([#589])
+- Make sure state generating functions return dense array by default. ([#591])
 
 ## [v0.38.1]
 Release date: 2025-10-27
@@ -366,3 +367,4 @@ Release date: 2024-11-13
 [#581]: https://github.com/qutip/QuantumToolbox.jl/issues/581
 [#588]: https://github.com/qutip/QuantumToolbox.jl/issues/588
 [#589]: https://github.com/qutip/QuantumToolbox.jl/issues/589
+[#591]: https://github.com/qutip/QuantumToolbox.jl/issues/591

--- a/src/entropy.jl
+++ b/src/entropy.jl
@@ -36,9 +36,9 @@ Mixed state:
 julia> ρ = maximally_mixed_dm(2)
 
 Quantum Object:   type=Operator()   dims=[2]   size=(2, 2)   ishermitian=true
-2×2 Diagonal{ComplexF64, Vector{ComplexF64}}:
- 0.5-0.0im      ⋅    
-     ⋅      0.5-0.0im
+2×2 Matrix{ComplexF64}:
+ 0.5+0.0im  0.0+0.0im
+ 0.0+0.0im  0.5+0.0im
 
 julia> entropy_vn(ρ, base=2)
 1.0


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
As title, this PR fixes:

- `thermal_dm` : was returning `Matrix{Float64}`, fixed to be `Matrix{ComplexF64}`
- `maximally_mixed_dm` : was returning `Eye`, fixed to be `Matrix{ComplexF64}`
- `w_state` : was returning `SparseVector`, fixed to be `Vector{ComplexF64}`
- `ghz_state`: was returning `SparseVector`, fixed to be `Vector{ComplexF64}`