### PR TITLE
Optimize and fix thermal_dm for nbar=0

### DIFF
--- a/test/core-test/states_and_operators.jl
+++ b/test/core-test/states_and_operators.jl
@@ -52,6 +52,12 @@
         )
         @test typeof(ρTs.data) <: AbstractSparseMatrix
         @test ρTd ≈ ρTs
+
+        ρTd0 = thermal_dm(5, 0.0)
+        ρTs0 = thermal_dm(5, 0.0; sparse = true)
+        @test tr(ρTd0) ≈ 1.0
+        @test tr(ρTs0) ≈ 1.0
+        @test ρTd0 ≈ ρTs0
     end
 
     @testset "maximally mixed state" begin


### PR DESCRIPTION
## Checklist

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

## Description
Fix `thermal_dm` for `nbar=0`, which previous returns `NaN` results.

```julia
julia> thermal_dm(3, 0.0)

Quantum Object:   type=Operator()   dims=[3]   size=(3, 3)   ishermitian=false
3×3 Matrix{ComplexF64}:
 NaN+NaN*im  0.0+0.0im   0.0+0.0im
 0.0+0.0im   NaN+NaN*im  0.0+0.0im
 0.0+0.0im   0.0+0.0im   NaN+NaN*im
```

The main fix is to avoid evaluating `exp(-β * 0)` when filling the diagonal data array. Other changes that improves performances includes
* pre-computing the normalization factor to avoid looping through the array twice
* use precomputed value/specialized expressions for small `j` (this mainly matters for `BigFloat` results and doesn't hurt for machine size numbers)
* Use a loop directly since the syntax of using branches in comprehension, while allowed and totally works, is not as elegant anymore. It also reduces reliance on inlining a little bit.

Here's the measured performance difference compared to master. For dense matrix at larger size the performance is going to be dominated by filling the matrix but for most other cases the performance difference is ~10-30%.

```diff
--- master      2025-12-15 17:55:40.759069248 -0500
+++ pr  2025-12-15 17:55:50.030156180 -0500
@@ -1,35 +1,35 @@
 julia> @btime thermal_dm($(3), $(0.2));
-  97.823 ns (6 allocations: 448 bytes)
+  62.755 ns (4 allocations: 336 bytes)

 julia> @btime thermal_dm($(30), $(0.2));
-  824.015 ns (7 allocations: 15.27 KiB)
+  738.646 ns (5 allocations: 14.71 KiB)

 julia> @btime thermal_dm($(300), $(0.2));
-  33.833 μs (9 allocations: 1.38 MiB)
+  32.459 μs (6 allocations: 1.38 MiB)

 julia> @btime thermal_dm($(3), $(big(0.2)));
-  8.222 μs (73 allocations: 6.34 KiB)
+  7.458 μs (37 allocations: 3.04 KiB)

 julia> @btime thermal_dm($(30), $(big(0.2)));
-  73.375 μs (641 allocations: 69.90 KiB)
+  65.209 μs (281 allocations: 35.77 KiB)

 julia> @btime thermal_dm($(300), $(big(0.2)));
-  780.091 μs (6361 allocations: 1.91 MiB)
+  696.049 μs (2761 allocations: 1.58 MiB)

 julia> @btime thermal_dm($(3), $(0.2); sparse=$(Val(true)));
-  312.675 ns (25 allocations: 1.17 KiB)
+  222.500 ns (23 allocations: 1.06 KiB)

 julia> @btime thermal_dm($(30), $(0.2); sparse=$(Val(true)));
-  825.236 ns (25 allocations: 4.94 KiB)
+  564.070 ns (23 allocations: 4.38 KiB)

 julia> @btime thermal_dm($(300), $(0.2); sparse=$(Val(true)));
-  6.017 μs (37 allocations: 40.95 KiB)
+  4.375 μs (34 allocations: 36.20 KiB)

 julia> @btime thermal_dm($(3), $(big(0.2)); sparse=$(Val(true)));
-  8.250 μs (82 allocations: 6.13 KiB)
+  7.458 μs (46 allocations: 2.84 KiB)

 julia> @btime thermal_dm($(30), $(big(0.2)); sparse=$(Val(true)));
-  72.292 μs (595 allocations: 53.56 KiB)
+  63.876 μs (235 allocations: 19.44 KiB)

 julia> @btime thermal_dm($(300), $(big(0.2)); sparse=$(Val(true)));
-  723.216 μs (5785 allocations: 526.22 KiB)
+  640.298 μs (2185 allocations: 184.15 KiB)
```
