### PR TITLE
Remove internal function `_check_dims_to`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
-
+- Remove internal function `_check_dims_to`. ([#657])
 
 ## [v0.43.0]
 Release date: 2026-02-04
@@ -437,3 +437,4 @@ Release date: 2024-11-13
 [#649]: https://github.com/qutip/QuantumToolbox.jl/issues/649
 [#650]: https://github.com/qutip/QuantumToolbox.jl/issues/650
 [#653]: https://github.com/qutip/QuantumToolbox.jl/issues/653
+[#657]: https://github.com/qutip/QuantumToolbox.jl/issues/657

--- a/src/entropy.jl
+++ b/src/entropy.jl
@@ -75,14 +75,16 @@ function entropy_relative(
         base::Int = 0,
         tol::Real = 1.0e-15,
     ) where {ObjType1 <: Union{Ket, Operator}, ObjType2 <: Union{Ket, Operator}}
-    _check_dims_to(ρ, σ)
+    ρ_dm = ket2dm(ρ)
+    σ_dm = ket2dm(σ)
+    check_dimensions(ρ_dm, σ_dm)
 
     # the logic of this code follows the detail given in the reference of the docstring
     # consider the eigen decompositions:
     #   ρ = Σ_i p_i |i⟩⟨i|
     #   σ = Σ_j q_j |j⟩⟨j|
-    ρ_result = eigenstates(ket2dm(ρ))
-    σ_result = eigenstates(ket2dm(σ))
+    ρ_result = eigenstates(ρ_dm)
+    σ_result = eigenstates(σ_dm)
 
     # make sure all p_i and q_j are real
     any(p_i -> imag(p_i) >= tol, ρ_result.values) && error("Input `ρ` has non-real eigenvalues.")

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -17,13 +17,14 @@ Here, the definition is from [Nielsen-Chuang2011](@citet). It is the square root
 Note that `ρ` and `σ` must be either [`Ket`](@ref) or [`Operator`](@ref).
 """
 function fidelity(ρ::QuantumObject{Operator}, σ::QuantumObject{Operator})
+    check_dimensions(ρ, σ)
     sqrt_ρ = sqrt(ρ)
     eigval = abs.(eigvals(sqrt_ρ * σ * sqrt_ρ))
     return sum(sqrt, eigval)
 end
-fidelity(ρ::QuantumObject{Operator}, ψ::QuantumObject{Ket}) = sqrt(abs(expect(ρ, ψ)))
+fidelity(ρ::QuantumObject{Operator}, ψ::QuantumObject{Ket}) = sqrt(abs(expect(ρ, ψ))) # check_dimensions in expect
 fidelity(ψ::QuantumObject{Ket}, σ::QuantumObject{Operator}) = fidelity(σ, ψ)
-fidelity(ψ::QuantumObject{Ket}, ϕ::QuantumObject{Ket}) = abs(dot(ψ, ϕ))
+fidelity(ψ::QuantumObject{Ket}, ϕ::QuantumObject{Ket}) = abs(dot(ψ, ϕ)) # check_dimensions in dot
 
 @doc raw"""
     tracedist(ρ::QuantumObject, σ::QuantumObject)
@@ -36,7 +37,7 @@ Note that `ρ` and `σ` must be either [`Ket`](@ref) or [`Operator`](@ref).
 tracedist(
     ρ::QuantumObject{ObjType1},
     σ::QuantumObject{ObjType2},
-) where {ObjType1 <: Union{Ket, Operator}, ObjType2 <: Union{Ket, Operator}} = norm(ket2dm(ρ) - ket2dm(σ), 1) / 2
+) where {ObjType1 <: Union{Ket, Operator}, ObjType2 <: Union{Ket, Operator}} = norm(ket2dm(ρ) - ket2dm(σ), 1) / 2 # check_dimensions in :(-)
 
 @doc raw"""
     hilbert_dist(ρ::QuantumObject, σ::QuantumObject)
@@ -53,9 +54,7 @@ function hilbert_dist(
         ρ::QuantumObject{ObjType1},
         σ::QuantumObject{ObjType2},
     ) where {ObjType1 <: Union{Ket, Operator}, ObjType2 <: Union{Ket, Operator}}
-    _check_dims_to(ρ, σ)
-
-    A = ket2dm(ρ) - ket2dm(σ)
+    A = ket2dm(ρ) - ket2dm(σ) # check_dimensions in :(-)
     return tr(A' * A)
 end
 
@@ -74,9 +73,14 @@ function hellinger_dist(
         ρ::QuantumObject{ObjType1},
         σ::QuantumObject{ObjType2},
     ) where {ObjType1 <: Union{Ket, Operator}, ObjType2 <: Union{Ket, Operator}}
+    # check dimensions first
+    ρ_dm = ket2dm(ρ)
+    σ_dm = ket2dm(σ)
+    check_dimensions(ρ_dm, σ_dm)
+
     # Ket (pure state) doesn't need to do square root
-    sqrt_ρ = isket(ρ) ? ket2dm(ρ) : sqrt(ρ)
-    sqrt_σ = isket(σ) ? ket2dm(σ) : sqrt(σ)
+    sqrt_ρ = isket(ρ) ? ρ_dm : sqrt(ρ_dm)
+    sqrt_σ = isket(σ) ? σ_dm : sqrt(σ_dm)
 
     # `max` is to avoid numerical instabilities
     # it happens when ρ = σ, sum(eigvals) might be slightly larger than 1
@@ -93,7 +97,7 @@ Here, the definition of [`fidelity`](@ref) ``F`` is from [Nielsen-Chuang2011](@c
 
 Note that `ρ` and `σ` must be either [`Ket`](@ref) or [`Operator`](@ref).
 """
-bures_dist(ρ::QuantumObject, σ::QuantumObject) = sqrt(2 * (1 - fidelity(ρ, σ)))
+bures_dist(ρ::QuantumObject, σ::QuantumObject) = sqrt(2 * (1 - fidelity(ρ, σ))) # check_dimensions in fidelity
 
 @doc raw"""
     bures_angle(ρ::QuantumObject, σ::QuantumObject)
@@ -105,4 +109,4 @@ Here, the definition of [`fidelity`](@ref) ``F`` is from [Nielsen-Chuang2011](@c
 
 Note that `ρ` and `σ` must be either [`Ket`](@ref) or [`Operator`](@ref).
 """
-bures_angle(ρ::QuantumObject, σ::QuantumObject) = acos(fidelity(ρ, σ))
+bures_angle(ρ::QuantumObject, σ::QuantumObject) = acos(fidelity(ρ, σ)) # check_dimensions in fidelity

--- a/src/qobj/functions.jl
+++ b/src/qobj/functions.jl
@@ -52,13 +52,13 @@ julia> round.(expect([a' * a, a' + a, a], [ψ1, ψ2]), digits = 1)
  0.0+0.0im  0.6+0.8im
 ```
 """
-expect(O::AbstractQuantumObject{Operator}, ψ::QuantumObject{Ket}) = dot(ψ.data, O.data, ψ.data)
+expect(O::AbstractQuantumObject{Operator}, ψ::QuantumObject{Ket}) = dot(ψ, O, ψ) # check_mul_dimensions in dot
 expect(O::AbstractQuantumObject{Operator}, ψ::QuantumObject{Bra}) = expect(O, ψ')
-expect(O::QuantumObject{Operator}, ρ::QuantumObject{Operator}) = tr(O * ρ)
+expect(O::QuantumObject{Operator}, ρ::QuantumObject{Operator}) = tr(O * ρ) # check_mul_dimensions in :(*)
 expect(
     O::QuantumObject{Operator, DimsType, <:Union{<:Hermitian{TF}, <:Symmetric{TR}}},
     ψ::QuantumObject{Ket},
-) where {DimsType <: AbstractDimensions, TF <: Number, TR <: Real} = real(dot(ψ.data, O.data, ψ.data))
+) where {DimsType <: AbstractDimensions, TF <: Number, TR <: Real} = real(dot(ψ, O, ψ)) # check_mul_dimensions in dot
 expect(
     O::QuantumObject{Operator, DimsType, <:Union{<:Hermitian{TF}, <:Symmetric{TR}}},
     ψ::QuantumObject{Bra},
@@ -66,7 +66,7 @@ expect(
 expect(
     O::QuantumObject{Operator, DimsType, <:Union{<:Hermitian{TF}, <:Symmetric{TR}}},
     ρ::QuantumObject{Operator},
-) where {DimsType <: AbstractDimensions, TF <: Number, TR <: Real} = real(tr(O * ρ))
+) where {DimsType <: AbstractDimensions, TF <: Number, TR <: Real} = real(tr(O * ρ)) # check_mul_dimensions in :(*)
 expect(
     O::AbstractVector{<:AbstractQuantumObject{Operator, DimsType, <:Union{<:Hermitian{TF}, <:Symmetric{TR}}}},
     ρ::QuantumObject,

--- a/src/qobj/quantum_object_base.jl
+++ b/src/qobj/quantum_object_base.jl
@@ -133,28 +133,6 @@ function check_dimensions(Qobj_tuple::NTuple{N, AbstractQuantumObject}) where {N
 end
 check_dimensions(A::AbstractQuantumObject...) = check_dimensions(A)
 
-# Used in the _check_dims_to function
-function _check_square_dims_and_get_to(A::AbstractQuantumObject)
-    ((isoper(A) || issuper(A)) && !isendomorphism(A.dimensions)) && throw(ErrorException("The dimensions $(A.dims) are not square."))
-
-    (isbra(A) || isoperbra(A)) && throw(ArgumentError("Cchecking the `to` dimensions does not make sense for Bra or OperatorBra objects."))
-
-    return A.dimensions.to
-end
-
-#=
-This checks the dimensions.to of the objects. In order to this to make sense,
-we need to check that the diemensions are square, and that we don't have `Bra` or `OperatorBra`
-as arguments.
-=#
-function _check_dims_to(Qobj_tuple::NTuple{N, AbstractQuantumObject}) where {N}
-    hilbert_dims_list = map(_check_square_dims_and_get_to, Qobj_tuple)
-    allequal(hilbert_dims_list) ||
-        throw(DimensionMismatch("The quantum objects should live in the same Hilbert space."))
-    return nothing
-end
-_check_dims_to(A::AbstractQuantumObject...) = _check_dims_to(A)
-
 function _check_QuantumObject(::Ket, dimensions::ProductDimensions, m::Int, n::Int)
     (n != 1) && throw(DimensionMismatch(("The size $((m, n)) of the array is not compatible with Ket")))
     obj_size = get_hilbert_size(dimensions)


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
As title, we can simplify the check of `Dimensions` in these cases.