### PR TITLE
Use `Base.AbstractVecOrTuple` instead of handwritten `VectorOrTuple`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restructure `Dimensions` and `Space` to align with `qutip` (`Python`) ([#659]). Note that this update basically overwrites many changes made in PR [#600]:
   - Replace `ProductDimensions` and `HilbertSpace` structures with `Dimensions` + `Space`/`TensorSpace`/`LiouvilleSpace`.
   - Remove `get_hilbert_size` and `get_liouville_size`, and use `get_size` instead.
-- Use `VectorOrTuple` for type definitions. ([#679])
+- Use `AbstractVecOrTuple` for type definitions. ([#679])
 - Allow specifying random number generator by keyword argument `rng` for the following random `Qobj` generating functions ([#680]): 
   - `rand_ket`
   - `rand_dm`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restructure `Dimensions` and `Space` to align with `qutip` (`Python`) ([#659]). Note that this update basically overwrites many changes made in PR [#600]:
   - Replace `ProductDimensions` and `HilbertSpace` structures with `Dimensions` + `Space`/`TensorSpace`/`LiouvilleSpace`.
   - Remove `get_hilbert_size` and `get_liouville_size`, and use `get_size` instead.
-- Use `AbstractVecOrTuple` for type definitions. ([#679])
+- Use `Base.AbstractVecOrTuple` for type definitions. ([#679], [#683])
 - Allow specifying random number generator by keyword argument `rng` for the following random `Qobj` generating functions ([#680]): 
   - `rand_ket`
   - `rand_dm`
   - `rand_unitary`
 - Fix benchmarks instability for autodiff. ([#681])
 - Use `StochasticDiffEqHighOrder` as dependency instead of `StochasticDiffEq` for stochastic solvers. ([#682])
-- Use `Base.AbstractVecOrTuple` instead of handwritten `VectorOrTuple`. ([#683])
 
 ## [v0.44.0]
 Release date: 2026-03-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `rand_unitary`
 - Fix benchmarks instability for autodiff. ([#681])
 - Use `StochasticDiffEqHighOrder` as dependency instead of `StochasticDiffEq` for stochastic solvers. ([#682])
-- Use `Base.AbstractVecOrTuple` instead of handwritten `VectorOrTuple`. ([#682])
+- Use `Base.AbstractVecOrTuple` instead of handwritten `VectorOrTuple`. ([#683])
 
 ## [v0.44.0]
 Release date: 2026-03-11
@@ -473,4 +473,4 @@ Release date: 2024-11-13
 [#679]: https://github.com/qutip/QuantumToolbox.jl/issues/679
 [#680]: https://github.com/qutip/QuantumToolbox.jl/issues/680
 [#681]: https://github.com/qutip/QuantumToolbox.jl/issues/681
-[#682]: https://github.com/qutip/QuantumToolbox.jl/issues/682
+[#683]: https://github.com/qutip/QuantumToolbox.jl/issues/683

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -472,4 +472,5 @@ Release date: 2024-11-13
 [#679]: https://github.com/qutip/QuantumToolbox.jl/issues/679
 [#680]: https://github.com/qutip/QuantumToolbox.jl/issues/680
 [#681]: https://github.com/qutip/QuantumToolbox.jl/issues/681
+[#682]: https://github.com/qutip/QuantumToolbox.jl/issues/682
 [#683]: https://github.com/qutip/QuantumToolbox.jl/issues/683

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `rand_unitary`
 - Fix benchmarks instability for autodiff. ([#681])
 - Use `StochasticDiffEqHighOrder` as dependency instead of `StochasticDiffEq` for stochastic solvers. ([#682])
+- Use `Base.AbstractVecOrTuple` instead of handwritten `VectorOrTuple`. ([#682])
 
 ## [v0.44.0]
 Release date: 2026-03-11

--- a/src/QuantumToolbox.jl
+++ b/src/QuantumToolbox.jl
@@ -4,6 +4,7 @@ module QuantumToolbox
 using LinearAlgebra
 using SparseArrays
 
+import Base: AbstractVecOrTuple
 import Distributed: RemoteChannel
 import LinearAlgebra: checksquare
 import Pkg

--- a/src/entropy.jl
+++ b/src/entropy.jl
@@ -144,8 +144,8 @@ Here, ``S`` is the [Von Neumann entropy](https://en.wikipedia.org/wiki/Von_Neuma
 """
 function entropy_mutual(
         ρAB::QuantumObject{ObjType, <:Dimensions{<:TensorSpace{N}, <:TensorSpace{N}}}, # the dimensions to == from, and should both be TensorSpace
-        selA::Union{Int, VectorOrTuple{Int}},
-        selB::Union{Int, VectorOrTuple{Int}};
+        selA::Union{Int, AbstractVecOrTuple{Int}},
+        selB::Union{Int, AbstractVecOrTuple{Int}};
         kwargs...,
     ) where {ObjType <: Union{Ket, Operator}, N}
     # check if selA and selB matches the dimensions of ρAB
@@ -177,7 +177,7 @@ Here, ``S`` is the [Von Neumann entropy](https://en.wikipedia.org/wiki/Von_Neuma
 """
 entropy_conditional(
     ρAB::QuantumObject{ObjType, <:Dimensions{N, N}},
-    selB::Union{Int, VectorOrTuple{Int}};
+    selB::Union{Int, AbstractVecOrTuple{Int}};
     kwargs...,
 ) where {ObjType <: Union{Ket, Operator}, N} = entropy_vn(ρAB; kwargs...) - entropy_vn(ptrace(ρAB, selB); kwargs...)
 
@@ -194,7 +194,7 @@ Calculates the [entanglement entropy](https://en.wikipedia.org/wiki/Entropy_of_e
 """
 function entanglement(
         ρ::QuantumObject{OpType},
-        sel::Union{Int, VectorOrTuple{Int}},
+        sel::Union{Int, AbstractVecOrTuple{Int}},
         kwargs...,
     ) where {OpType <: Union{Ket, Operator}}
     p = purity(ρ)

--- a/src/qobj/arithmetic_and_attributes.jl
+++ b/src/qobj/arithmetic_and_attributes.jl
@@ -503,7 +503,7 @@ Quantum Object:   type=Operator()   dims=([2], [2])   size=(2, 2)   ishermitian=
  0.0+0.0im  0.5+0.0im
 ```
 """
-function ptrace(QO::QuantumObject{Ket, <:Dimensions{<:TensorSpace{N}}}, sel::VectorOrTuple{T}) where {N, T <: Integer}
+function ptrace(QO::QuantumObject{Ket, <:Dimensions{<:TensorSpace{N}}}, sel::AbstractVecOrTuple{T}) where {N, T <: Integer}
     any(s -> s isa EnrSpace, QO.dimensions.to) && throw(ArgumentError("ptrace does not support EnrSpace"))
 
     _non_static_array_warning("sel", sel)
@@ -524,9 +524,9 @@ function ptrace(QO::QuantumObject{Ket, <:Dimensions{<:TensorSpace{N}}}, sel::Vec
     return QuantumObject(ρtr, type = Operator(), dims = Dimensions(dkeep))
 end
 
-ptrace(QO::QuantumObject{Bra, <:Dimensions{Space, <:TensorSpace{N}}}, sel::VectorOrTuple{T}) where {N, T <: Integer} = ptrace(QO', sel)
+ptrace(QO::QuantumObject{Bra, <:Dimensions{Space, <:TensorSpace{N}}}, sel::AbstractVecOrTuple{T}) where {N, T <: Integer} = ptrace(QO', sel)
 
-function ptrace(QO::QuantumObject{Operator, <:Dimensions{<:TensorSpace{N}}}, sel::VectorOrTuple{T}) where {N, T <: Integer}
+function ptrace(QO::QuantumObject{Operator, <:Dimensions{<:TensorSpace{N}}}, sel::AbstractVecOrTuple{T}) where {N, T <: Integer}
     ((QO.dimensions.to isa EnrSpace) || any(s -> s isa EnrSpace, QO.dimensions.to)) && throw(ArgumentError("ptrace does not support EnrSpace"))
 
     # TODO: support for special cases when some of the subsystems have same `to` and `from` space
@@ -551,7 +551,7 @@ function ptrace(QO::QuantumObject{Operator, <:Dimensions{<:TensorSpace{N}}}, sel
 end
 
 # Special cases for single-subsystem (N=1) where TensorSpace collapses to Space
-function ptrace(QO::QuantumObject{Ket, <:Dimensions{Space, Space}}, sel::VectorOrTuple{T}) where {T <: Integer}
+function ptrace(QO::QuantumObject{Ket, <:Dimensions{Space, Space}}, sel::AbstractVecOrTuple{T}) where {T <: Integer}
     _non_static_array_warning("sel", sel)
 
     N_sel = length(sel)
@@ -564,7 +564,7 @@ function ptrace(QO::QuantumObject{Ket, <:Dimensions{Space, Space}}, sel::VectorO
         return ket2dm(QO)  # ptrace should always return Operator
     end
 end
-function ptrace(QO::QuantumObject{Operator, <:Dimensions{Space, Space}}, sel::VectorOrTuple{T}) where {T <: Integer}
+function ptrace(QO::QuantumObject{Operator, <:Dimensions{Space, Space}}, sel::AbstractVecOrTuple{T}) where {T <: Integer}
     !isendomorphic(QO.dimensions) && _non_endomorphic_dims_error("operator for ptrace", QO.dimensions)
 
     _non_static_array_warning("sel", sel)
@@ -579,7 +579,7 @@ function ptrace(QO::QuantumObject{Operator, <:Dimensions{Space, Space}}, sel::Ve
         return QO
     end
 end
-ptrace(QO::QuantumObject{Bra, <:Dimensions{Space, Space}}, sel::VectorOrTuple{T}) where {T <: Integer} = ptrace(QO', sel)
+ptrace(QO::QuantumObject{Bra, <:Dimensions{Space, Space}}, sel::AbstractVecOrTuple{T}) where {T <: Integer} = ptrace(QO', sel)
 
 ptrace(QO::QuantumObject, sel::Int) = ptrace(QO, SVector(sel))
 
@@ -742,7 +742,7 @@ true
 """
 function SparseArrays.permute(
         A::QuantumObject{ObjType, <:Dimensions},
-        order::VectorOrTuple{T},
+        order::AbstractVecOrTuple{T},
     ) where {ObjType <: Union{Ket, Bra, Operator}, T <: Integer}
 
     # check validity of order (other checks will be handled in `_dims_and_perm` since it depends on ObjType)

--- a/src/qobj/dimensions.jl
+++ b/src/qobj/dimensions.jl
@@ -61,15 +61,15 @@ struct Dimensions{T1 <: AbstractSpace, T2 <: AbstractSpace}
 end
 
 # by defining alias type, it is easier to represent the nested dims structure:
-const DimsListType{T1, T2} = Tuple{<:VectorOrTuple{T1}, <:VectorOrTuple{T2}}
+const DimsListType{T1, T2} = Tuple{<:AbstractVecOrTuple{T1}, <:AbstractVecOrTuple{T2}}
 
-function _list_to_tensor_space(dims::VectorOrTuple{T}, argname::String) where {T <: Integer}
+function _list_to_tensor_space(dims::AbstractVecOrTuple{T}, argname::String) where {T <: Integer}
     _non_static_array_warning(argname, dims)
     return TensorSpace(Tuple(Space.(dims)))
 end
 
 # endomorphic dimensions from integer tuple/vector
-function Dimensions(dims::VectorOrTuple{T}) where {T <: Integer}
+function Dimensions(dims::AbstractVecOrTuple{T}) where {T <: Integer}
     L = length(dims)
     (L > 0) || throw(DomainError(dims, "The argument dims must be of non-zero length"))
 
@@ -95,9 +95,9 @@ function Dimensions(dims::DimsListType{T, T}) where {T <: Integer}
 end
 
 # LiouvilleSpace dimensions for OperatorKet/OperatorBra/SuperOperator from 3-level nested tuple/vector of integers
-Dimensions(dims::DimsListType{T1, T2}) where {T1 <: VectorOrTuple, T2 <: Integer} = Dimensions(LiouvilleSpace(Dimensions(dims[1])), _list_to_tensor_space(dims[2], "dims[2]"))
-Dimensions(dims::DimsListType{T1, T2}) where {T1 <: Integer, T2 <: VectorOrTuple} = Dimensions(_list_to_tensor_space(dims[1], "dims[1]"), LiouvilleSpace(Dimensions(dims[2])))
-Dimensions(dims::DimsListType{T1, T2}) where {T1 <: VectorOrTuple, T2 <: VectorOrTuple} = Dimensions(LiouvilleSpace(Dimensions(dims[1])), LiouvilleSpace(Dimensions(dims[2])))
+Dimensions(dims::DimsListType{T1, T2}) where {T1 <: AbstractVecOrTuple, T2 <: Integer} = Dimensions(LiouvilleSpace(Dimensions(dims[1])), _list_to_tensor_space(dims[2], "dims[2]"))
+Dimensions(dims::DimsListType{T1, T2}) where {T1 <: Integer, T2 <: AbstractVecOrTuple} = Dimensions(_list_to_tensor_space(dims[1], "dims[1]"), LiouvilleSpace(Dimensions(dims[2])))
+Dimensions(dims::DimsListType{T1, T2}) where {T1 <: AbstractVecOrTuple, T2 <: AbstractVecOrTuple} = Dimensions(LiouvilleSpace(Dimensions(dims[1])), LiouvilleSpace(Dimensions(dims[2])))
 
 # Error for invalid input
 Dimensions(dims::Any) = throw(
@@ -141,7 +141,7 @@ Returns `(m, n)` where `m` is the product of the `dimensions.to`, and `n` is the
 If `dimensions` is an `Integer` or a vector/tuple of `Integer`s, it is automatically treated as `Dimensions(dimensions, dimensions)`.
 """
 get_size(dimensions::Dimensions) = (get_size(dimensions.to), get_size(dimensions.from))
-get_size(dimensions::Union{T, VectorOrTuple{T}}) where {T <: Integer} = get_size(Dimensions(dimensions))
+get_size(dimensions::Union{T, AbstractVecOrTuple{T}}) where {T <: Integer} = get_size(Dimensions(dimensions))
 
 Base.transpose(dimensions::Dimensions) = Dimensions(dimensions.from, dimensions.to) # switch `to` and `from`
 Base.adjoint(dimensions::Dimensions) = transpose(dimensions)

--- a/src/qobj/energy_restricted.jl
+++ b/src/qobj/energy_restricted.jl
@@ -56,7 +56,7 @@ struct EnrSpace{N} <: AbstractSpace
     state2idx::Dict{SVector{N, Int}, Int}
     idx2state::Dict{Int, SVector{N, Int}}
 
-    function EnrSpace(dims::VectorOrTuple{T}, n_excitations::Int) where {T <: Integer}
+    function EnrSpace(dims::AbstractVecOrTuple{T}, n_excitations::Int) where {T <: Integer}
         # all arguments will be checked in `enr_state_dictionaries`
         size, state2idx, idx2state = enr_state_dictionaries(dims, n_excitations)
 
@@ -92,7 +92,7 @@ Return the number of states, and lookup-dictionaries for translating a state (`S
 - `state2idx`: A dictionary for looking up a state index from a state (`SVector`)
 - `idx2state`: A dictionary for looking up state (`SVector`) from a state index
 """
-function enr_state_dictionaries(dims::VectorOrTuple{T}, n_excitations::Int) where {T <: Integer}
+function enr_state_dictionaries(dims::AbstractVecOrTuple{T}, n_excitations::Int) where {T <: Integer}
     # argument checks
     _non_static_array_warning("dims", dims)
     L = length(dims)
@@ -144,7 +144,7 @@ The `state` argument is a list of integers that specifies the state (in the numb
 """
 function enr_fock(
         ::Type{T},
-        dims::VectorOrTuple{Td},
+        dims::AbstractVecOrTuple{Td},
         n_excitations::Int,
         state::AbstractVector{Td};
         sparse::Union{Bool, Val} = Val(false),
@@ -163,7 +163,7 @@ function enr_fock(::Type{T}, s_enr::EnrSpace, state::AbstractVector{Td}; sparse:
 
     return QuantumObject(array, Ket(), s_enr)
 end
-enr_fock(dims::VectorOrTuple{Td}, n_excitations::Int, state::AbstractVector{Td}; sparse::Union{Bool, Val} = Val(false)) where {Td <: Integer} =
+enr_fock(dims::AbstractVecOrTuple{Td}, n_excitations::Int, state::AbstractVector{Td}; sparse::Union{Bool, Val} = Val(false)) where {Td <: Integer} =
     enr_fock(ComplexF64, dims, n_excitations, state; sparse)
 enr_fock(s_enr::EnrSpace, state::AbstractVector{Td}; sparse::Union{Bool, Val} = Val(false)) where {Td <: Integer} = enr_fock(ComplexF64, s_enr, state; sparse)
 
@@ -181,7 +181,7 @@ The argument `n` is a list that specifies the expectation values for number of p
     It is highly recommended to use `enr_thermal_dm(dims, n_excitations, n)` with `dims` as `Tuple` or `SVector` from [StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl) to keep type stability. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
 """
 function enr_thermal_dm(
-        dims::VectorOrTuple{T1},
+        dims::AbstractVecOrTuple{T1},
         n_excitations::Int,
         n::Union{T2, AbstractVector{T2}};
         sparse::Union{Bool, Val} = Val(false),
@@ -227,7 +227,7 @@ The arguments `dims` and `n_excitations` are used to generate [`EnrSpace`](@ref)
 !!! warning "Beware of type-stability!"
     It is highly recommended to use `enr_destroy(dims, n_excitations)` with `dims` as `Tuple` or `SVector` from [StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl) to keep type stability. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
 """
-function enr_destroy(::Type{T}, dims::VectorOrTuple{Td}, n_excitations::Int) where {T <: FloatOrComplex, Td <: Integer}
+function enr_destroy(::Type{T}, dims::AbstractVecOrTuple{Td}, n_excitations::Int) where {T <: FloatOrComplex, Td <: Integer}
     s_enr = EnrSpace(dims, n_excitations)
     return enr_destroy(T, s_enr)
 end
@@ -257,7 +257,7 @@ function enr_destroy(::Type{T}, s_enr::EnrSpace{N}) where {T <: FloatOrComplex, 
 
     return ntuple(i -> QuantumObject(sparse(I_list[i], J_list[i], V_list[i], D, D), Operator(), s_enr), Val(N))
 end
-enr_destroy(dims::VectorOrTuple{Td}, n_excitations::Int) where {Td <: Integer} = enr_destroy(ComplexF64, dims, n_excitations)
+enr_destroy(dims::AbstractVecOrTuple{Td}, n_excitations::Int) where {Td <: Integer} = enr_destroy(ComplexF64, dims, n_excitations)
 enr_destroy(s_enr::EnrSpace{N}) where {N} = enr_destroy(ComplexF64, s_enr)
 
 @doc raw"""
@@ -271,10 +271,10 @@ The arguments `dims` and `n_excitations` are used to generate [`EnrSpace`](@ref)
 !!! warning "Beware of type-stability!"
     It is highly recommended to use `enr_identity(dims, n_excitations)` with `dims` as `Tuple` or `SVector` from [StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl) to keep type stability. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
 """
-function enr_identity(::Type{T}, dims::VectorOrTuple{Td}, n_excitations::Int) where {T <: Number, Td <: Integer}
+function enr_identity(::Type{T}, dims::AbstractVecOrTuple{Td}, n_excitations::Int) where {T <: Number, Td <: Integer}
     s_enr = EnrSpace(dims, n_excitations)
     return enr_identity(T, s_enr)
 end
 enr_identity(::Type{T}, s_enr::EnrSpace) where {T <: Number} = QuantumObject(Diagonal(ones(T, s_enr.size)), Operator(), s_enr)
-enr_identity(dims::VectorOrTuple{Td}, n_excitations::Int) where {Td <: Integer} = enr_identity(ComplexF64, dims, n_excitations)
+enr_identity(dims::AbstractVecOrTuple{Td}, n_excitations::Int) where {Td <: Integer} = enr_identity(ComplexF64, dims, n_excitations)
 enr_identity(s_enr::EnrSpace) = enr_identity(ComplexF64, s_enr)

--- a/src/qobj/operators.jl
+++ b/src/qobj/operators.jl
@@ -37,11 +37,11 @@ rand_unitary(::Type{T}, dimensions::Int, distribution::Union{Symbol, Val} = Val(
     rand_unitary(T, SVector(dimensions), makeVal(distribution); rng)
 rand_unitary(
     ::Type{T},
-    dimensions::Union{Dimensions, VectorOrTuple{Int}},
+    dimensions::Union{Dimensions, AbstractVecOrTuple{Int}},
     distribution::Union{Symbol, Val} = Val(:haar);
     rng::AbstractRNG = default_rng(),
 ) where {T <: FloatOrComplex} = rand_unitary(T, dimensions, makeVal(distribution); rng)
-function rand_unitary(::Type{T}, dimensions::Union{Dimensions, VectorOrTuple{Int}}, ::Val{:haar}; rng::AbstractRNG = default_rng()) where {T <: FloatOrComplex}
+function rand_unitary(::Type{T}, dimensions::Union{Dimensions, AbstractVecOrTuple{Int}}, ::Val{:haar}; rng::AbstractRNG = default_rng()) where {T <: FloatOrComplex}
     N = get_size(dimensions)[1]
 
     # generate N x N matrix Z of complex standard normal random variates
@@ -58,7 +58,7 @@ function rand_unitary(::Type{T}, dimensions::Union{Dimensions, VectorOrTuple{Int
 end
 function rand_unitary(
         ::Type{T},
-        dimensions::Union{Dimensions, VectorOrTuple{Int}},
+        dimensions::Union{Dimensions, AbstractVecOrTuple{Int}},
         ::Val{:exp};
         rng::AbstractRNG = default_rng()
     ) where {T <: FloatOrComplex}
@@ -72,9 +72,9 @@ function rand_unitary(
     H = QuantumObject((Z + Z') / 2; type = Operator(), dims = dimensions)
     return to_dense(_rand_unitary_exp(H))
 end
-rand_unitary(::Type{T}, dimensions::Union{Dimensions, VectorOrTuple{Int}}, ::Val{Td}; rng::AbstractRNG = default_rng()) where {T <: FloatOrComplex, Td} =
+rand_unitary(::Type{T}, dimensions::Union{Dimensions, AbstractVecOrTuple{Int}}, ::Val{Td}; rng::AbstractRNG = default_rng()) where {T <: FloatOrComplex, Td} =
     throw(ArgumentError("Invalid distribution: $(Td)"))
-rand_unitary(dimensions::Union{Int, Dimensions, VectorOrTuple{Int}}, distribution::Union{Symbol, Val} = Val(:haar); rng::AbstractRNG = default_rng()) =
+rand_unitary(dimensions::Union{Int, Dimensions, AbstractVecOrTuple{Int}}, distribution::Union{Symbol, Val} = Val(:haar); rng::AbstractRNG = default_rng()) =
     rand_unitary(ComplexF64, dimensions, distribution; rng)
 
 # we make H sparse here because the following method currently does not exist : exp(::Matrix{Complex{BigFloat}})
@@ -593,9 +593,9 @@ where ``\omega = \exp(\frac{2 \pi i}{N})``.
     It is highly recommended to use `qft(dimensions)` with `dimensions` as `Tuple` or `SVector` from [StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl) to keep type stability. See the [related Section](@ref doc:Type-Stability) about type stability for more details.
 """
 qft(::Type{T}, dimensions::Int) where {T <: Complex} = QuantumObject(_qft_op(T, dimensions), Operator(), dimensions)
-qft(::Type{T}, dimensions::Union{Dimensions, VectorOrTuple{Int}}) where {T <: Complex} =
+qft(::Type{T}, dimensions::Union{Dimensions, AbstractVecOrTuple{Int}}) where {T <: Complex} =
     QuantumObject(_qft_op(T, get_size(dimensions)[1]), Operator(), dimensions)
-qft(dimensions::Union{Int, Dimensions, VectorOrTuple{Int}}) = qft(ComplexF64, dimensions)
+qft(dimensions::Union{Int, Dimensions, AbstractVecOrTuple{Int}}) = qft(ComplexF64, dimensions)
 
 function _qft_op(::Type{T}, N::Int) where {T <: Complex}
     N_T = T(N)

--- a/src/qobj/quantum_object_base.jl
+++ b/src/qobj/quantum_object_base.jl
@@ -198,9 +198,9 @@ end
 ## (backward compatibility, but avoid support for OperatorKet/OperatorBra/SuperOperator since it causes ambiguity)
 _gen_dimensions(type::ObjType, dims::Integer) where {ObjType <: Union{Ket, Bra, Operator}} = _gen_dimensions(type, Space(dims))
 
-## dims::VectorOrTuple{Int} : vector or tuple of integers
+## dims::AbstractVecOrTuple{Int} : vector or tuple of integers
 ## (backward compatibility, but avoid support for OperatorKet/OperatorBra/SuperOperator since it causes ambiguity)
-_gen_dimensions(type::ObjType, dims::VectorOrTuple{T}) where {ObjType <: Union{Ket, Bra, Operator}, T <: Integer} = _gen_dimensions(type, _list_to_tensor_space(dims, "dims"))
+_gen_dimensions(type::ObjType, dims::AbstractVecOrTuple{T}) where {ObjType <: Union{Ket, Bra, Operator}, T <: Integer} = _gen_dimensions(type, _list_to_tensor_space(dims, "dims"))
 
 ## dims::AbstractSpace
 _gen_dimensions(::Ket, dims::AbstractSpace) = Dimensions(dims, Space(1))

--- a/src/qobj/states.jl
+++ b/src/qobj/states.jl
@@ -20,9 +20,9 @@ The `dimensions` can be either the following types:
     It is highly recommended to use `zero_ket(dimensions)` with `dimensions` as `Tuple` or `SVector` from [StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl) to keep type stability. See the [related Section](@ref doc:Type-Stability) about type stability for more details.
 """
 zero_ket(::Type{T}, dimensions::Int) where {T <: Number} = QuantumObject(zeros(T, dimensions), Ket(), dimensions)
-zero_ket(::Type{T}, dimensions::Union{Dimensions, VectorOrTuple{Int}}) where {T <: Number} =
+zero_ket(::Type{T}, dimensions::Union{Dimensions, AbstractVecOrTuple{Int}}) where {T <: Number} =
     QuantumObject(zeros(T, get_size(dimensions)[1]), Ket(), dimensions)
-zero_ket(dimensions::Union{Int, Dimensions, VectorOrTuple{Int}}) = zero_ket(ComplexF64, dimensions)
+zero_ket(dimensions::Union{Int, Dimensions, AbstractVecOrTuple{Int}}) = zero_ket(ComplexF64, dimensions)
 
 @doc raw"""
     fock([T::Type=ComplexF64,] N::Int, j::Int=0; dims::Union{Int,AbstractVector{Int},Tuple}=N, sparse::Union{Bool,Val}=Val(false))
@@ -38,7 +38,7 @@ It is also possible to specify the list of dimensions `dims` if different subsys
 !!! note
     `basis(N, j; dims = dims, sparse = sparse)` is a synonym of `fock(N, j; dims = dims, sparse = sparse)`.
 """
-function fock(::Type{T}, N::Int, j::Int = 0; dims::Union{Int, VectorOrTuple{Int}} = N, sparse::Union{Bool, Val} = Val(false)) where {T <: Number}
+function fock(::Type{T}, N::Int, j::Int = 0; dims::Union{Int, AbstractVecOrTuple{Int}} = N, sparse::Union{Bool, Val} = Val(false)) where {T <: Number}
     (0 <= j < N) || throw(ArgumentError("Invalid argument j, must satisfy: 0 ≤ j ≤ N-1"))
     if getVal(sparse)
         array = sparsevec([j + 1], [one(T)], N)
@@ -48,7 +48,7 @@ function fock(::Type{T}, N::Int, j::Int = 0; dims::Union{Int, VectorOrTuple{Int}
     end
     return QuantumObject(array; type = Ket(), dims = dims)
 end
-fock(N::Int, j::Int = 0; dims::Union{Int, VectorOrTuple{Int}} = N, sparse::Union{Bool, Val} = Val(false)) = fock(ComplexF64, N, j; dims, sparse)
+fock(N::Int, j::Int = 0; dims::Union{Int, AbstractVecOrTuple{Int}} = N, sparse::Union{Bool, Val} = Val(false)) = fock(ComplexF64, N, j; dims, sparse)
 
 @doc raw"""
     coherent(N::Int, α::Number)
@@ -74,12 +74,12 @@ The random number generator can be specified via the keyword argument `rng`.
     If you want to keep type stability, it is recommended to use `rand_ket(dimensions)` with `dimensions` as `Tuple` or `SVector` from [StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl) to keep type stability. See the [related Section](@ref doc:Type-Stability) about type stability for more details.
 """
 rand_ket(::Type{T}, dimensions::Int; rng::AbstractRNG = default_rng()) where {T <: Complex} = rand_ket(T, SVector(dimensions); rng)
-function rand_ket(::Type{T}, dimensions::Union{Dimensions, VectorOrTuple{Int}}; rng::AbstractRNG = default_rng()) where {T <: Complex}
+function rand_ket(::Type{T}, dimensions::Union{Dimensions, AbstractVecOrTuple{Int}}; rng::AbstractRNG = default_rng()) where {T <: Complex}
     N = get_size(dimensions)[1]
     ψ = rand(rng, T, N) .- (one(T) / 2 + one(T) * im / 2)
     return QuantumObject(normalize!(ψ); type = Ket(), dims = dimensions)
 end
-rand_ket(dimensions::Union{Int, Dimensions, VectorOrTuple{Int}}; rng::AbstractRNG = default_rng()) = rand_ket(ComplexF64, dimensions; rng)
+rand_ket(dimensions::Union{Int, Dimensions, AbstractVecOrTuple{Int}}; rng::AbstractRNG = default_rng()) = rand_ket(ComplexF64, dimensions; rng)
 
 @doc raw"""
     fock_dm([T::Type=ComplexF64,] N::Int, j::Int=0; dims::Union{Int,AbstractVector{Int},Tuple}=N, sparse::Union{Bool,Val}=Val(false))
@@ -95,13 +95,13 @@ function fock_dm(
         ::Type{T},
         N::Int,
         j::Int = 0;
-        dims::Union{Int, VectorOrTuple{Int}} = N,
+        dims::Union{Int, AbstractVecOrTuple{Int}} = N,
         sparse::Union{Bool, Val} = Val(false),
     ) where {T <: Number}
     ψ = fock(T, N, j; dims, sparse)
     return ket2dm(ψ)
 end
-fock_dm(N::Int, j::Int = 0; dims::Union{Int, VectorOrTuple{Int}} = N, sparse::Union{Bool, Val} = Val(false)) = fock_dm(ComplexF64, N, j; dims, sparse)
+fock_dm(N::Int, j::Int = 0; dims::Union{Int, AbstractVecOrTuple{Int}} = N, sparse::Union{Bool, Val} = Val(false)) = fock_dm(ComplexF64, N, j; dims, sparse)
 
 @doc raw"""
     coherent_dm(N::Int, α::Number)
@@ -148,11 +148,11 @@ The `dimensions` can be either the following types:
 """
 maximally_mixed_dm(::Type{T}, dimensions::Int) where {T <: FloatOrComplex} =
     QuantumObject(diagm(0 => fill(1 / T(dimensions), dimensions))::Matrix{T}, Operator(), SVector(dimensions)) # TODO: remove `::Matrix{T}` if JET.jl fix https://github.com/aviatesk/JET.jl/issues/790
-function maximally_mixed_dm(::Type{T}, dimensions::Union{Dimensions, VectorOrTuple{Int}}) where {T <: FloatOrComplex}
+function maximally_mixed_dm(::Type{T}, dimensions::Union{Dimensions, AbstractVecOrTuple{Int}}) where {T <: FloatOrComplex}
     N = get_size(dimensions)[1]
     return QuantumObject(diagm(0 => fill(1 / T(N), N)), Operator(), dimensions)
 end
-maximally_mixed_dm(dimensions::Union{Int, Dimensions, VectorOrTuple{Int}}) = maximally_mixed_dm(ComplexF64, dimensions)
+maximally_mixed_dm(dimensions::Union{Int, Dimensions, AbstractVecOrTuple{Int}}) = maximally_mixed_dm(ComplexF64, dimensions)
 
 @doc raw"""
     rand_dm([T::Type=ComplexF64,] dimensions; rank::Int=get_size(dimensions)[1], rng::AbstractRNG=default_rng())
@@ -178,7 +178,7 @@ rand_dm(::Type{T}, dimensions::Int; rank::Int = dimensions, rng::AbstractRNG = d
     rand_dm(T, SVector(dimensions); rank, rng)
 function rand_dm(
         ::Type{T},
-        dimensions::Union{Dimensions, VectorOrTuple{Int}};
+        dimensions::Union{Dimensions, AbstractVecOrTuple{Int}};
         rank::Int = get_size(dimensions)[1],
         rng::AbstractRNG = default_rng(),
     ) where {T <: Complex}
@@ -191,7 +191,7 @@ function rand_dm(
     ρ /= tr(ρ)
     return QuantumObject(ρ; type = Operator(), dims = dimensions)
 end
-rand_dm(dimensions::Union{Int, Dimensions, VectorOrTuple{Int}}; rank::Int = get_size(dimensions)[1], rng::AbstractRNG = default_rng()) =
+rand_dm(dimensions::Union{Int, Dimensions, AbstractVecOrTuple{Int}}; rank::Int = get_size(dimensions)[1], rng::AbstractRNG = default_rng()) =
     rand_dm(ComplexF64, dimensions; rank, rng)
 
 @doc raw"""

--- a/src/spin_lattice.jl
+++ b/src/spin_lattice.jl
@@ -34,7 +34,7 @@ julia> op.dims
 ([2, 2, 2, 2, 2, 2, 2, 2], [2, 2, 2, 2, 2, 2, 2, 2])
 ```
 """
-function multisite_operator(dims::VectorOrTuple{T}, pairs::Pair{<:Integer, <:QuantumObject}...) where {T <: Integer}
+function multisite_operator(dims::AbstractVecOrTuple{T}, pairs::Pair{<:Integer, <:QuantumObject}...) where {T <: Integer}
     sites_unsorted = collect(first.(pairs))
     idxs = sortperm(sites_unsorted)
     _sites = sites_unsorted[idxs]

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -173,7 +173,6 @@ end
 
 # alias of abstract types
 const FloatOrComplex = Union{AbstractFloat, Complex}
-const VectorOrTuple{T} = Union{AbstractVector{T}, NTuple{N, T} where {N}}
 
 # functions for getting Float or Complex element type
 _float_type(::AbstractArray{T}) where {T <: Number} = _float_type(T)


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Describe the proposed change here.

## Related issues or PRs
As title.
