### PR TITLE
Fix arithmetic operations (`+`, `-`, `*`) for quantum objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `rand_unitary`
 - Fix benchmarks instability for autodiff. ([#681])
 - Use `StochasticDiffEqHighOrder` as dependency instead of `StochasticDiffEq` for stochastic solvers. ([#682])
+- Fix arithmetic operations (`+`, `-`, `*`) for quantum objects. ([#688])
 
 ## [v0.44.0]
 Release date: 2026-03-11
@@ -474,3 +475,4 @@ Release date: 2024-11-13
 [#681]: https://github.com/qutip/QuantumToolbox.jl/issues/681
 [#682]: https://github.com/qutip/QuantumToolbox.jl/issues/682
 [#683]: https://github.com/qutip/QuantumToolbox.jl/issues/683
+[#688]: https://github.com/qutip/QuantumToolbox.jl/issues/688

--- a/src/qobj/arithmetic_and_attributes.jl
+++ b/src/qobj/arithmetic_and_attributes.jl
@@ -34,6 +34,7 @@ for op in (:(+), :(-), :(*), :(/), :(^))
     end
 end
 
+# addition and subtraction for quantum object
 for op in (:(+), :(-))
     @eval begin
         # unary operations
@@ -57,8 +58,12 @@ for op in (:(+), :(-))
     end
 end
 
-Base.:(*)(A::AbstractQuantumObject, n::T) where {T <: Number} = get_typename_wrapper(A)(A.data * n, A.type, A.dimensions)
-Base.:(*)(n::T, A::AbstractQuantumObject) where {T <: Number} = get_typename_wrapper(A)(n * A.data, A.type, A.dimensions)
+# multiplication (quantum object with Number)
+## we treat the Number as a scalar multiplied by identity matrix for GPU compatibility
+Base.:(*)(n::T, A::AbstractQuantumObject) where {T <: Number} = get_typename_wrapper(A)((n * I) * A.data, A.type, A.dimensions)
+Base.:(*)(A::AbstractQuantumObject, n::T) where {T <: Number} = n * A # it is necessary to call the method above (otherwise we will obtain incorrect type for Ket and OperatorKet)
+
+# multiplication (two quantum objects)
 function Base.:(*)(A::AbstractQuantumObject{Operator}, B::AbstractQuantumObject{Operator})
     check_mul_dimensions(A, B)
     QType = promote_op_type(A, B)

--- a/src/qobj/arithmetic_and_attributes.jl
+++ b/src/qobj/arithmetic_and_attributes.jl
@@ -34,9 +34,19 @@ for op in (:(+), :(-), :(*), :(/), :(^))
     end
 end
 
-for op in (:(+), :(-)) # the multiplication of two QuantumObject is handled separately below (since the return QuantumObjectType can change)
+for op in (:(+), :(-))
     @eval begin
-        # A and B should have same QuantumObjectType
+        # unary operations
+        Base.$op(A::AbstractQuantumObject) = get_typename_wrapper(A)($(op)(A.data), A.type, A.dimensions)
+
+        # binary operations between Number and QuantumObject (must be Operator or SuperOperator)
+        # the number is treated as a scalar multiplied by identity matrix
+        Base.$op(n::T, A::AbstractQuantumObject{ObjType}) where {T <: Number, ObjType <: Union{Operator, SuperOperator}} =
+            get_typename_wrapper(A)($(op)(n * I, A.data), A.type, A.dimensions)
+        Base.$op(A::AbstractQuantumObject{ObjType}, n::T) where {ObjType <: Union{Operator, SuperOperator}, T <: Number} =
+            get_typename_wrapper(A)($(op)(A.data, n * I), A.type, A.dimensions)
+
+        # binary operations between two QuantumObjects (should have same QuantumObjectType)
         function Base.$op(A::AbstractQuantumObject{AObjType}, B::AbstractQuantumObject{BObjType}) where {AObjType <: QuantumObjectType, BObjType <: QuantumObjectType}
             # avoid the case where A and B have same dimensions but different type, and throw error message
             (AObjType == BObjType) || throw(ArgumentError("Invalid type for A $($op) B, where A is $AObjType and B is $BObjType"))
@@ -47,17 +57,8 @@ for op in (:(+), :(-)) # the multiplication of two QuantumObject is handled sepa
     end
 end
 
-for op in (:(+), :(-), :(*))
-    @eval begin
-        Base.$op(A::AbstractQuantumObject) = get_typename_wrapper(A)($(op)(A.data), A.type, A.dimensions)
-
-        Base.$op(n::T, A::AbstractQuantumObject) where {T <: Number} =
-            get_typename_wrapper(A)($(op)(n * I, A.data), A.type, A.dimensions)
-        Base.$op(A::AbstractQuantumObject, n::T) where {T <: Number} =
-            get_typename_wrapper(A)($(op)(A.data, n * I), A.type, A.dimensions)
-    end
-end
-
+Base.:(*)(A::AbstractQuantumObject, n::T) where {T <: Number} = get_typename_wrapper(A)(A.data * n, A.type, A.dimensions)
+Base.:(*)(n::T, A::AbstractQuantumObject) where {T <: Number} = get_typename_wrapper(A)(n * A.data, A.type, A.dimensions)
 function Base.:(*)(A::AbstractQuantumObject{Operator}, B::AbstractQuantumObject{Operator})
     check_mul_dimensions(A, B)
     QType = promote_op_type(A, B)

--- a/test/core-test/quantum_objects.jl
+++ b/test/core-test/quantum_objects.jl
@@ -205,7 +205,10 @@
 
     @testset "arithmetic" begin
         a = sprand(ComplexF64, 100, 100, 0.1)
+        b = rand(ComplexF64, 100)
         a2 = Qobj(a)
+        b2 = Qobj(b, type = Ket())
+        b3 = b2'
         a3 = Qobj(a, type = SuperOperator())
         a4 = to_sparse(a2)
         a4_copy = copy(a4)
@@ -218,11 +221,17 @@
         @test real(a2).data == real(a)
         @test imag(a2).data == imag(a)
         @test +a2 == a2
+        @test +b2 == b2
+        @test +b3 == b3
         @test -(-a2) == a2
+        @test -(-b2) == b2
+        @test -(-b3) == b3
         @test a2^3 ≈ a2 * a2 * a2
         @test a2 + 2 == 2 + a2
         @test (a2 + 2).data == a2.data + 2 * I
         @test a2 * 2 == 2 * a2
+        @test b2 * 2 == 2 * b2
+        @test b3 * 2 == 2 * b3
 
         zero_like = qzero_like(a2)
         iden_like = qeye_like(a3)


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
This PR fixes a bug related to the basic arithmetic operationswhich seems to be existing for a long time in our package.

The bug is that the following two cases of multiplication (`*`) gives different result types:

```julia
typeof(2 * basis(2, 0)) # Vector{ComplexF64}
typeof(basis(2, 0) * 2) # Matrix{ComplexF64}
```