### PR TITLE
add `ArgumentError` for the functions that should not allow time-dependent `c_ops`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix benchmarks instability for autodiff. ([#681])
 - Use `StochasticDiffEqHighOrder` as dependency instead of `StochasticDiffEq` for stochastic solvers. ([#682])
 - Fix arithmetic operations (`+`, `-`, `*`) for quantum objects. ([#688])
+- Throw `ArgumentError` for the functions that should not allow time-dependent collapse operators (`c_ops`). ([#689])
 
 ## [v0.44.0]
 Release date: 2026-03-11
@@ -476,3 +477,4 @@ Release date: 2024-11-13
 [#682]: https://github.com/qutip/QuantumToolbox.jl/issues/682
 [#683]: https://github.com/qutip/QuantumToolbox.jl/issues/683
 [#688]: https://github.com/qutip/QuantumToolbox.jl/issues/688
+[#689]: https://github.com/qutip/QuantumToolbox.jl/issues/689

--- a/src/spectrum.jl
+++ b/src/spectrum.jl
@@ -73,6 +73,7 @@ function spectrum(
     !isendomorphic(H.dimensions) && _non_endomorphic_dims_error("Hamiltonian or Liouvillian for spectrum", H.dimensions)
 
     L = liouvillian(H, c_ops)
+    (L isa QuantumObject) || throw(ArgumentError("spectrum only supports (time-independent) QuantumObject in c_ops"))
     check_mul_dimensions(L, A)
     check_dimensions(A, B)
 

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -361,6 +361,8 @@ function steadystate_fourier(
     check_dimensions(H_0, H_p, H_m)
 
     L_0 = liouvillian(H_0, c_ops)
+    (L_0 isa QuantumObject) || throw(ArgumentError("steadystate_fourier only supports (time-independent) QuantumObject in c_ops"))
+
     L_p = liouvillian(H_p)
     L_m = liouvillian(H_m)
     return _steadystate_fourier(L_0, L_p, L_m, ωd, solver; n_max = n_max, tol = tol, kwargs...)

--- a/src/time_evolution/liouvillian_dressed_nonsecular.jl
+++ b/src/time_evolution/liouvillian_dressed_nonsecular.jl
@@ -87,7 +87,7 @@ function liouvillian_dressed_nonsecular(
         D₁ + D₂
     end
 
-    settings.auto_tidyup && tidyup!(L)
+    settings.auto_tidyup && (L isa QuantumObject) && tidyup!(L) # tidyup! only supports QuantumObject
 
     return E, U, L
 end

--- a/src/time_evolution/time_evolution.jl
+++ b/src/time_evolution/time_evolution.jl
@@ -588,7 +588,9 @@ function liouvillian_floquet(
         OpType2 <: Union{Operator, SuperOperator},
         OpType3 <: Union{Operator, SuperOperator},
     }
-    return liouvillian_floquet(liouvillian(H, c_ops), liouvillian(Hₚ), liouvillian(Hₘ), ω, n_max = n_max, tol = tol)
+    L₀ = liouvillian(H, c_ops)
+    (L₀ isa QuantumObject) || throw(ArgumentError("liouvillian_floquet only supports (time-independent) QuantumObject in c_ops"))
+    return liouvillian_floquet(L₀, liouvillian(Hₚ), liouvillian(Hₘ), ω, n_max = n_max, tol = tol)
 end
 
 function _liouvillian_floquet(

--- a/test/core-test/code-quality/code_quality.jl
+++ b/test/core-test/code-quality/code_quality.jl
@@ -4,6 +4,6 @@
     end
 
     @testset "JET.jl" begin
-        JET.test_package(QuantumToolbox; target_defined_modules = true, ignore_missing_comparison = true)
+        JET.test_package(QuantumToolbox; target_modules = (QuantumToolbox,), ignore_missing_comparison = true)
     end
 end


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
As title, this PR avoids time-dependent `c_ops` for the following functions:

- `spectrum`
- `steadystate_fourier`
- `liouvillian_floquet`

Note that this PR also fix the code-quality test warning, by changing keyword argument `target_defined_modules` to `target_modules`, since it will be deprecated by JET.jl soon.