### PR TITLE
Use FillArrays for `qeye` and better support to GPU for `steadystate` and `correlation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `StochasticDiffEqHighOrder` as dependency instead of `StochasticDiffEq` for stochastic solvers. ([#682])
 - Fix arithmetic operations (`+`, `-`, `*`) for quantum objects. ([#688])
 - Throw `ArgumentError` for the functions that should not allow time-dependent collapse operators (`c_ops`). ([#689])
+- Use FillArrays for `qeye` and better support to GPU for `steadystate` and `correlation` functions. ([#690])
 
 ## [v0.44.0]
 Release date: 2026-03-11
@@ -478,3 +479,4 @@ Release date: 2024-11-13
 [#683]: https://github.com/qutip/QuantumToolbox.jl/issues/683
 [#688]: https://github.com/qutip/QuantumToolbox.jl/issues/688
 [#689]: https://github.com/qutip/QuantumToolbox.jl/issues/689
+[#690]: https://github.com/qutip/QuantumToolbox.jl/issues/690

--- a/src/correlations.jl
+++ b/src/correlations.jl
@@ -120,7 +120,7 @@ function correlation_2op_2t(
         reverse::Bool = false,
         kwargs...,
     ) where {HOpType <: Union{Operator, SuperOperator}, StateOpType <: Union{Ket, Operator}}
-    C = one(A) # same as qeye_like(A), use A instead of H (cause H might be SuperOperator)
+    C = eye(get_size(A.dimensions)[1], type = Operator(), dims = A.dims) # same as qeye_like(A), use A instead of H (cause H might be SuperOperator)
     if reverse
         corr = correlation_3op_2t(H, ψ0, tlist, τlist, c_ops, A, B, C; kwargs...)
     else

--- a/src/qobj/operators.jl
+++ b/src/qobj/operators.jl
@@ -466,7 +466,7 @@ Note that `type` can only be either [`Operator`](@ref) or [`SuperOperator`](@ref
 !!! note
     `qeye` is a synonym of `eye`.
 """
-eye(::Type{T}, N::Int; type = Operator(), dims = nothing) where {T <: Number} = QuantumObject(Diagonal(ones(T, N)); type, dims) # dims = nothing will be handled by Qobj generation
+eye(::Type{T}, N::Int; type = Operator(), dims = nothing) where {T <: Number} = QuantumObject(Eye{T}(N); type, dims) # dims = nothing will be handled by Qobj generation
 eye(N::Int; type = Operator(), dims = nothing) = eye(ComplexF64, N; type, dims)
 
 @doc raw"""

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -9,11 +9,18 @@ export SteadyStateSolver,
 abstract type SteadyStateSolver end
 
 @doc raw"""
-    SteadyStateDirectSolver()
+    SteadyStateDirectSolver(
+        factorization = lu
+    )
 
 A solver which solves [`steadystate`](@ref) by finding the inverse of Liouvillian [`SuperOperator`](@ref) using the standard method given in `LinearAlgebra`.
+
+# Arguments
+- `factorization::Function=lu`: The factorization method to use for solving the linear system. The default is `lu`, which performs LU factorization.
 """
-struct SteadyStateDirectSolver <: SteadyStateSolver end
+Base.@kwdef struct SteadyStateDirectSolver{FT <: Function} <: SteadyStateSolver
+    factorization::FT = lu
+end
 
 @doc raw"""
     SteadyStateEigenSolver()
@@ -198,10 +205,11 @@ function _steadystate(L::QuantumObject{SuperOperator}, solver::SteadyStateDirect
     fill!(rows, 1)
     copyto!(cols, N .* (idx_range .- 1) .+ idx_range)
     fill!(vals, weight)
-    Tn = sparse(rows, cols, vals, N^2, N^2)
+    Tn = _sparse_similar(L_tmp, rows, cols, vals, N^2, N^2)
     L_tmp = L_tmp + Tn
 
-    ρss_vec = L_tmp \ v0 # This is still not supported on GPU, yet
+    F = solver.factorization(L_tmp)
+    ρss_vec = F \ v0 # This is still not supported on GPU, yet
     ρss = reshape(ρss_vec, N, N)
     ρss = (ρss + ρss') / 2 # Hermitianize
     return QuantumObject(ρss, Operator(), state_dimensions)

--- a/test/ext-test/gpu/cuda_ext.jl
+++ b/test/ext-test/gpu/cuda_ext.jl
@@ -77,10 +77,6 @@ CUDA.versioninfo()
     @test typeof(CuSparseMatrixCSR(Xsc).data) == CuSparseMatrixCSR{ComplexF64, Int32}
     @test typeof(CuSparseMatrixCSR{ComplexF32}(Xsc).data) == CuSparseMatrixCSR{ComplexF32, Int32}
 
-    # type conversion of CUDA Diagonal arrays
-    @test cu(qeye(10), word_size = Val(32)).data isa Diagonal{ComplexF32, <:CuVector{ComplexF32}}
-    @test cu(qeye(10), word_size = Val(64)).data isa Diagonal{ComplexF64, <:CuVector{ComplexF64}}
-
     # Sparse To Dense
     # @test to_dense(cu(ψsi; word_size = 64)).data isa CuVector{Int64} # TODO: Fix this in CUDA.jl
     @test to_dense(cu(ψsf; word_size = 64)).data isa CuVector{Float64}
@@ -160,28 +156,38 @@ end
 
     H_gpu_csr = CuSparseMatrixCSR(H_gpu_csc)
     c_ops_gpu_csr = [CuSparseMatrixCSR(c_op) for c_op in c_ops_gpu_csc]
-    ρ_ss_gpu_csr = steadystate(H_gpu_csr, c_ops_gpu_csr, solver = SteadyStateLinearSolver())
+    ρ_ss_gpu_csr = steadystate(H_gpu_csr, c_ops_gpu_csr) # Direct solver using CUDSS
 
     @test ρ_ss_cpu.data ≈ Array(ρ_ss_gpu_csc.data) atol = 1.0e-8 * length(ρ_ss_cpu)
     @test ρ_ss_cpu.data ≈ Array(ρ_ss_gpu_csr.data) atol = 1.0e-8 * length(ρ_ss_cpu)
 end
 
-@testset "CUDA spectrum" begin
+@testset "CUDA Correlations and Spectrum" begin
     N = 10
-    a = cu(destroy(N))
+    Id = qeye(N)
+    a = destroy(N) |> CUSPARSE.CuSparseMatrixCSR
     H = a' * a
     c_ops = [sqrt(0.1 * (0.01 + 1)) * a, sqrt(0.1 * (0.01)) * a']
-    solver = Lanczos(steadystate_solver = SteadyStateLinearSolver())
+    solver = Lanczos()
 
-    ω_l = range(0, 3, length = 1000)
-    spec = spectrum(H, ω_l, c_ops, a', a; solver = solver)
+    t_l = range(0, 333 * π, length = 1000)
+    corr1 = correlation_2op_1t(H, nothing, t_l, c_ops, a', a; progress_bar = Val(false))
+    corr2 = correlation_3op_1t(H, nothing, t_l, c_ops, Id, a', a; progress_bar = Val(false))
+    ω_l1, spec1 = spectrum_correlation_fft(t_l, corr1)
 
-    spec = collect(spec)
-    spec = spec ./ maximum(spec)
+    ω_l2 = range(0, 3, length = 1000)
+    spec2 = spectrum(H, ω_l2, c_ops, a', a; solver = solver)
 
-    test_func = maximum(real.(spec)) * (0.1 / 2)^2 ./ ((ω_l .- 1) .^ 2 .+ (0.1 / 2)^2)
-    idxs = test_func .> 0.05
-    @test sum(abs2.(spec[idxs] .- test_func[idxs])) / sum(abs2.(test_func[idxs])) < 0.01
+    spec1 = spec1 ./ maximum(spec1)
+    spec2 = collect(spec2) ./ maximum(spec2)
+
+    test_func1 = maximum(real.(spec1)) * (0.1 / 2)^2 ./ ((ω_l1 .- 1) .^ 2 .+ (0.1 / 2)^2)
+    test_func2 = maximum(real.(spec2)) * (0.1 / 2)^2 ./ ((ω_l2 .- 1) .^ 2 .+ (0.1 / 2)^2)
+    idxs1 = test_func1 .> 0.05
+    idxs2 = test_func2 .> 0.05
+    @test sum(abs2.(spec1[idxs1] .- test_func1[idxs1])) / sum(abs2.(test_func1[idxs1])) < 0.01
+    @test sum(abs2.(spec2[idxs2] .- test_func2[idxs2])) / sum(abs2.(test_func2[idxs2])) < 0.01
+    @test all(corr1 .≈ corr2)
 
     # TODO: Fix this
     # @testset "Type Inference spectrum" begin


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
`qeye` now return a `FillArray` diagonal matrix. This allows it to support operations on multiple array types, GPU included.

I have also added support to `correlation` functions and added related tests.