### PR TITLE
Improve `correlation_2op_1t` and `correlation_3op_1t`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix arithmetic operations (`+`, `-`, `*`) for quantum objects. ([#688])
 - Throw `ArgumentError` for the functions that should not allow time-dependent collapse operators (`c_ops`). ([#689])
 - Use FillArrays for `qeye` and better support to GPU for `steadystate` and `correlation` functions. ([#690])
+- Improve `correlation_2op_1t` and `correlation_3op_1t`. ([#692])
 
 ## [v0.44.0]
 Release date: 2026-03-11
@@ -480,3 +481,4 @@ Release date: 2024-11-13
 [#688]: https://github.com/qutip/QuantumToolbox.jl/issues/688
 [#689]: https://github.com/qutip/QuantumToolbox.jl/issues/689
 [#690]: https://github.com/qutip/QuantumToolbox.jl/issues/690
+[#692]: https://github.com/qutip/QuantumToolbox.jl/issues/692

--- a/src/correlations.jl
+++ b/src/correlations.jl
@@ -51,8 +51,9 @@ function correlation_3op_2t(
     kwargs2 = merge((saveat = collect(tlist),), (; kwargs...))
 
     # generate OperatorKet first, so sol.states will store OperatorKet (skip redundant reshaping)
+    # note that doesn't need to do the first mesolve if tlist == [0] (for 2op_1t and 3op_1t cases)
     ρ0_vec = mat2vec(ket2dm(ψ0))
-    ρt_list = mesolve(L, ρ0_vec, tlist; kwargs2...).states
+    ρt_list = (tlist == [0]) ? [ρ0_vec] : mesolve(L, ρ0_vec, tlist; kwargs2...).states
 
     C_A = sprepost(C, A)
     corr = map((t, ρt) -> mesolve(L, C_A * ρt, τlist .+ t, e_ops = [B]; kwargs...).expect[1, :], tlist, ρt_list)


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
As title. 

This PR skips the first `mesolve` in `correlation_3op_2t` if `tlist == [0]`.