### PR TITLE
Remove `Julia 1.11` from CI tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,11 +56,13 @@ jobs:
 
         include:
           # for core tests (intermediate versions)
-          - version: '1.11'
-            node:
-              os: 'ubuntu-latest'
-              arch: 'x64'
-            group: 'Core'
+          # comment this part first since Julia 1.11 security support ended [see https://endoflife.date/julia]
+          # but this can be re-enabled, for example, when latest version becomes 1.13, we can put 1.12 here
+          # - version: '1.11'
+          #   node:
+          #     os: 'ubuntu-latest'
+          #     arch: 'x64'
+          #   group: 'Core'
 
           # for extension tests
           - version: '1'


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
As shown in https://endoflife.date/julia, the security support of `Julia v1.11` has already ended. 

I suggest we remove the CI test for `Julia v1.11` also. Because it always fail at some memory tests.