### PR TITLE
Use `expm1` in `n_thermal` for stability.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
-
+- Use `expm1` in `n_thermal` for stability. ([#717])
 
 ## [v0.46.0]
 Release date: 2026-05-11
@@ -507,3 +507,4 @@ Release date: 2024-11-13
 [#697]: https://github.com/qutip/QuantumToolbox.jl/issues/697
 [#698]: https://github.com/qutip/QuantumToolbox.jl/issues/698
 [#708]: https://github.com/qutip/QuantumToolbox.jl/issues/708
+[#717]: https://github.com/qutip/QuantumToolbox.jl/issues/717

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -44,11 +44,12 @@ n(\omega, \omega_{\textrm{th}}) = \frac{1}{e^{\omega/\omega_{\textrm{th}}} - 1},
 where ``\hbar`` is the reduced Planck constant, and ``k_B`` is the Boltzmann constant.
 """
 function n_thermal(ω::T1, ω_th::T2) where {T1 <: Real, T2 <: Real}
+    T = _float_type(promote_type(T1, T2))
     if ω_th <= 0 || ω <= 0
-        return zero(promote_type(T1, T2))
+        return zero(T)
     end
 
-    n = 1 / expm1(ω / ω_th)
+    n = 1 / expm1(T(ω) / T(ω_th))
 
     return n
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -44,9 +44,13 @@ n(\omega, \omega_{\textrm{th}}) = \frac{1}{e^{\omega/\omega_{\textrm{th}}} - 1},
 where ``\hbar`` is the reduced Planck constant, and ``k_B`` is the Boltzmann constant.
 """
 function n_thermal(ω::T1, ω_th::T2) where {T1 <: Real, T2 <: Real}
-    x = exp(ω / ω_th)
-    n = ((x != 1) && (ω_th > 0)) ? 1 / (x - 1) : 0
-    return _float_type(promote_type(T1, T2))(n)
+    if ω_th <= 0 || ω <= 0
+        return zero(promote_type(T1, T2))
+    end
+
+    n = 1 / expm1(ω / ω_th)
+
+    return n
 end
 
 @doc raw"""


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
In the `n_thermal` function we are currently computing `y = exp(x)` and then `y - 1`. This can be directly done with the `expm1`, which is specifically designed to handle the `x <<1` case.