### PR TITLE
Add Bravyi-Kitaev fermion-to-qubit mapping for `fdestroy`/`fcreate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improvement for `multisite_operator` ([#722]):
   - Add a convenient method when the Hilbert space dimension of all sites are equal.
   - Improve the documentation and docstring. 
-- Efficient Jordan Wigner transformation for `fdestroy` and `fcreate`. ([#723])
-- Add Bravyi-Kitaev fermion-to-qubit mapping for `fdestroy` and `fcreate` via the keyword argument `mode = :BK` (`mode = :JW` for Jordan-Wigner remains the default). ([#724])
+- Updates for `fdestroy` and `fcreate`:
+  - Efficient Jordan Wigner transformation. ([#723])
+  - Add Bravyi-Kitaev fermion-to-qubit mapping via the keyword argument `method = :BK` (`method = :JW` for Jordan-Wigner transformation remains the default). ([#724])
 
 ## [v0.47.0]
 Release date: 2026-05-19
@@ -517,7 +518,6 @@ Release date: 2024-11-13
 [#689]: https://github.com/qutip/QuantumToolbox.jl/issues/689
 [#690]: https://github.com/qutip/QuantumToolbox.jl/issues/690
 [#692]: https://github.com/qutip/QuantumToolbox.jl/issues/692
-<<<<<<< HEAD
 [#697]: https://github.com/qutip/QuantumToolbox.jl/issues/697
 [#698]: https://github.com/qutip/QuantumToolbox.jl/issues/698
 [#708]: https://github.com/qutip/QuantumToolbox.jl/issues/708
@@ -526,6 +526,4 @@ Release date: 2024-11-13
 [#718]: https://github.com/qutip/QuantumToolbox.jl/issues/718
 [#722]: https://github.com/qutip/QuantumToolbox.jl/issues/722
 [#723]: https://github.com/qutip/QuantumToolbox.jl/issues/723
-=======
 [#724]: https://github.com/qutip/QuantumToolbox.jl/issues/724
->>>>>>> 2053e461 (Add Bravyi-Kitaev fermion-to-qubit mapping for `fdestroy`/`fcreate`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add a convenient method when the Hilbert space dimension of all sites are equal.
   - Improve the documentation and docstring. 
 - Efficient Jordan Wigner transformation for `fdestroy` and `fcreate`. ([#723])
+- Add Bravyi-Kitaev fermion-to-qubit mapping for `fdestroy` and `fcreate` via the keyword argument `mode = :BK` (`mode = :JW` for Jordan-Wigner remains the default). ([#724])
 
 ## [v0.47.0]
 Release date: 2026-05-19
@@ -516,6 +517,7 @@ Release date: 2024-11-13
 [#689]: https://github.com/qutip/QuantumToolbox.jl/issues/689
 [#690]: https://github.com/qutip/QuantumToolbox.jl/issues/690
 [#692]: https://github.com/qutip/QuantumToolbox.jl/issues/692
+<<<<<<< HEAD
 [#697]: https://github.com/qutip/QuantumToolbox.jl/issues/697
 [#698]: https://github.com/qutip/QuantumToolbox.jl/issues/698
 [#708]: https://github.com/qutip/QuantumToolbox.jl/issues/708
@@ -524,3 +526,6 @@ Release date: 2024-11-13
 [#718]: https://github.com/qutip/QuantumToolbox.jl/issues/718
 [#722]: https://github.com/qutip/QuantumToolbox.jl/issues/722
 [#723]: https://github.com/qutip/QuantumToolbox.jl/issues/723
+=======
+[#724]: https://github.com/qutip/QuantumToolbox.jl/issues/724
+>>>>>>> 2053e461 (Add Bravyi-Kitaev fermion-to-qubit mapping for `fdestroy`/`fcreate`)

--- a/docs/src/resources/bibliography.bib
+++ b/docs/src/resources/bibliography.bib
@@ -5,7 +5,21 @@
   publisher = {Springer Berlin, Heidelberg},
   author = {Gardiner, Crispin and Zoller, Peter},
   year = {2004},
-  month = aug 
+  month = aug
+}
+
+@article{OBrien-Strelchuk2024,
+  title = {Ultrafast hybrid fermion-to-qubit mapping},
+  DOI = {10.1103/PhysRevB.109.115149},
+  url = {https://doi.org/10.1103/PhysRevB.109.115149},
+  publisher = {American Physical Society},
+  author = {O'Brien, Oliver and Strelchuk, Sergii},
+  journal = {Physical Review B},
+  volume = {109},
+  issue = {11},
+  pages = {115149},
+  year = {2024},
+  month = mar
 }
 
 @book{Nielsen-Chuang2011,

--- a/src/qobj/operators.jl
+++ b/src/qobj/operators.jl
@@ -529,7 +529,7 @@ _fermionic_operator(::Type{T}, ::Val{N}, j::Int, ::Val{:BK}, ::Val{:destroy}) wh
     _Bravyi_Kitaev(T, N, j, one(T))
 _fermionic_operator(::Type{T}, ::Val{N}, j::Int, ::Val{:BK}, ::Val{:create}) where {T <: FloatOrComplex, N} =
     _Bravyi_Kitaev(T, N, j, -one(T))
-_fermionic_operator(::Type{T}, :Val{N}, j::Int, ::Val{method}, _) where {T <: FloatOrComplex, N, method} =
+_fermionic_operator(::Type{T}, ::Val{N}, j::Int, ::Val{method}, _) where {T <: FloatOrComplex, N, method} =
     throw(ArgumentError("The fermion-to-qubit mapping `method` should be either `:JW` or `:BK`, got `:$method`."))
 
 function _Jordan_Wigner(::Type{T}, ::Val{N}, j::Int, op::QuantumObject{Operator}) where {T <: FloatOrComplex, N}

--- a/src/qobj/operators.jl
+++ b/src/qobj/operators.jl
@@ -566,7 +566,7 @@ function _BK_parity_set(α::Int)
     P = Int[]
     β = α - 1 # prefix parity = sites with index less than j
     while β >= 0
-        push!(P, β)
+        pushfirst!(P, β)      # use pushfirst! so that P is sorted in ascending order
         β = (β & (β + 1)) - 1 # drop the lowest set block of bits
     end
     return P
@@ -576,36 +576,52 @@ function _BK_flip_set(α::Int)
     i = 0
     while ((α >> i) & 1) == 1 # while α_i is 1
         β = α & ~(1 << i)     # set i-th bit to 0
-        push!(F, β)
+        pushfirst!(F, β)      # use pushfirst! so that F is sorted in ascending order
         i += 1
     end
     return F
 end
 
-# build the Pauli string ⨂ᵢ op over the (0-based) sites in `set`; falls back to the identity when `set` is empty
-# the `set` is using 0-based indexing, so shift by 1 to obtain the 1-based site-indices
-_BK_Pauli_string(::Type{T}, dims, set, op::QuantumObject) where {T <: FloatOrComplex} =
-    isempty(set) ? qeye(T, prod(dims); dims = dims) : multisite_operator(dims, map(i -> (i + 1) => op, set)...)
+function _BK_Pauli_string(
+        dims::NTuple{N, Int}, sites::Vector{Int}, op::QuantumObject{Operator, Dimensions{Space, Space}, <:SparseMatrixCSC{T}}
+    ) where {T <: FloatOrComplex, N}
+    isempty(sites) && return qeye(T, prod(dims); dims = dims)
+
+    # DON'T USE multisite_operator HERE !
+    # because the length of `sites` obtained from those _BK_XXX_set is not fixed, which can cause type-instability
+    # but current implementation of _BK_XXX_set is indeed the fastest method (as far as we have tested)
+    # Thus, we directly construct the Kronecker product (part of the code in multisite_operator without pre-handling the site-indices)
+    _dims = collect(dims) # avoid tuple-slice instability for runtime site indices
+    data = kron(Eye{T}(prod(_dims[1:(sites[1] - 1)])), op.data)
+    for i in 2:length(sites)
+        data = kron(data, Eye{T}(prod(_dims[(sites[i - 1] + 1):(sites[i] - 1)])), op.data)
+    end
+    data = kron(data, Eye{T}(prod(_dims[(sites[end] + 1):end])))
+
+    return QuantumObject(data; type = Operator(), dims = dims)
+end
 
 # the type of `sign` should be same as the first argument (which is specified by `_fermionic_operator`)
 function _Bravyi_Kitaev(::Type{T}, ::Val{N}, j::Int, sign::T) where {T <: FloatOrComplex, N}
     (N < 1) && throw(ArgumentError("The total number of sites (N) cannot be less than 1"))
     (1 <= j <= N) || throw(ArgumentError("The site index (j) should satisfy: 1 ≤ j ≤ N"))
 
-    # use j-1 because these functions consider 0-based indexing, which aligns with the convention of [Phys. Rev. B 109, 115149 (2024)]
-    U = _BK_update_set(N, j - 1)
-    P = _BK_parity_set(j - 1)
-    F = _BK_flip_set(j - 1)
+    # use j-1 because these _BK_XXXX_set functions consider 0-based indexing, which aligns with the convention of [Phys. Rev. B 109, 115149 (2024)]
+    # and add `1`` back because our site-indices are 1-based
+    U = _BK_update_set(N, j - 1) .+ 1
+    P = _BK_parity_set(j - 1) .+ 1
+    F = _BK_flip_set(j - 1) .+ 1
     R = setdiff(P, F)
 
     dims = ntuple(i -> 2, Val(N))
-
-    XU = _BK_Pauli_string(T, dims, U, sigmax(T))
-    ZR = _BK_Pauli_string(T, dims, R, sigmaz(T))
-    ZP = _BK_Pauli_string(T, dims, P, sigmaz(T))
-
-    Xj = multisite_operator(dims, j => sigmax(T))
-    Yj = multisite_operator(dims, j => sigmay(T))
+    σx = sigmax(T)
+    σy = sigmay(T)
+    σz = sigmaz(T)
+    XU = _BK_Pauli_string(dims, U, σx)
+    ZR = _BK_Pauli_string(dims, R, σz)
+    ZP = _BK_Pauli_string(dims, P, σz)
+    Xj = multisite_operator(dims, j => σx)
+    Yj = multisite_operator(dims, j => σy)
 
     return (XU * (Xj * ZP + (sign * im) * (Yj * ZR))) / 2
 end

--- a/src/qobj/operators.jl
+++ b/src/qobj/operators.jl
@@ -521,15 +521,15 @@ fcreate(::Type{T}, N::Union{Int, Val}, j::Int; method::Union{Symbol, Val} = Val(
     _fermionic_operator(T, makeVal(N), j, makeVal(method), Val(:create))
 fcreate(N::Union{Int, Val}, j::Int; kwargs...) = fcreate(ComplexF64, N, j; kwargs...)
 
-_fermionic_operator(::Type{T}, ::Val{N}, j::Int, ::Val{:JW}, ::Val{:destroy}) where {T <: FloatOrComplex, N} =
+_fermionic_operator(::Type{T}, N::Val, j::Int, ::Val{:JW}, ::Val{:destroy}) where {T <: FloatOrComplex} =
     _Jordan_Wigner(T, N, j, sigmap(T))
-_fermionic_operator(::Type{T}, ::Val{N}, j::Int, ::Val{:JW}, ::Val{:create}) where {T <: FloatOrComplex, N} =
+_fermionic_operator(::Type{T}, N::Val, j::Int, ::Val{:JW}, ::Val{:create}) where {T <: FloatOrComplex} =
     _Jordan_Wigner(T, N, j, sigmam(T))
-_fermionic_operator(::Type{T}, ::Val{N}, j::Int, ::Val{:BK}, ::Val{:destroy}) where {T <: FloatOrComplex, N} =
+_fermionic_operator(::Type{T}, N::Val, j::Int, ::Val{:BK}, ::Val{:destroy}) where {T <: FloatOrComplex} =
     _Bravyi_Kitaev(T, N, j, one(T))
-_fermionic_operator(::Type{T}, ::Val{N}, j::Int, ::Val{:BK}, ::Val{:create}) where {T <: FloatOrComplex, N} =
+_fermionic_operator(::Type{T}, N::Val, j::Int, ::Val{:BK}, ::Val{:create}) where {T <: FloatOrComplex} =
     _Bravyi_Kitaev(T, N, j, -one(T))
-_fermionic_operator(::Type{T}, ::Val{N}, j::Int, ::Val{method}, _) where {T <: FloatOrComplex, N, method} =
+_fermionic_operator(::Type{T}, ::Val, ::Int, ::Val{method}, _) where {T <: FloatOrComplex, method} =
     throw(ArgumentError("The fermion-to-qubit mapping `method` should be either `:JW` or `:BK`, got `:$method`."))
 
 function _Jordan_Wigner(::Type{T}, ::Val{N}, j::Int, op::QuantumObject{Operator}) where {T <: FloatOrComplex, N}

--- a/src/qobj/operators.jl
+++ b/src/qobj/operators.jl
@@ -470,19 +470,19 @@ eye(::Type{T}, N::Int; type = Operator(), dims = nothing) where {T <: Number} = 
 eye(N::Int; type = Operator(), dims = nothing) = eye(ComplexF64, N; type, dims)
 
 @doc raw"""
-    fdestroy([T::Type=ComplexF64,] N::Union{Int,Val}, j::Int; mode::Union{Symbol,Val}=Val(:JW))
+    fdestroy([T::Type=ComplexF64,] N::Union{Int,Val}, j::Int; method::Union{Symbol,Val}=Val(:JW))
 
-Construct a fermionic destruction operator [with element type `T = ComplexF64` (default)] acting on the `j`-th site, where the fock space has totally `N`-sites.
+Construct a fermionic destruction operator [with element type `T = ComplexF64` (default)] acting on the `j`-th site, where the Hilbert space has totally `N`-sites.
 
 The site index `j` should satisfy: `1 ≤ j ≤ N`.
 
-The fermion-to-qubit mapping is selected by the keyword argument `mode`:
+The fermion-to-qubit mapping is selected by the keyword argument `method`:
 
-- `mode = :JW` (default): the [Jordan-Wigner transformation](https://en.wikipedia.org/wiki/Jordan%E2%80%93Wigner_transformation), namely
+- `method = :JW` (default): the [Jordan-Wigner transformation](https://en.wikipedia.org/wiki/Jordan%E2%80%93Wigner_transformation), namely
 ```math
 \hat{d}_j = \hat{\sigma}_z^{\otimes j-1} \otimes \hat{\sigma}_{+} \otimes \hat{\mathbb{1}}^{\otimes N-j}
 ```
-- `mode = :BK`: the [Bravyi-Kitaev transformation](https://doi.org/10.1103/PhysRevB.109.115149).
+- `method = :BK`: the Bravyi-Kitaev transformation [OBrien-Strelchuk2024](@cite).
 
 Note that we put ``\hat{\sigma}_{+} = \begin{pmatrix} 0 & 1 \\ 0 & 0 \end{pmatrix}`` here because we consider ``|0\rangle = \begin{pmatrix} 1 \\ 0 \end{pmatrix}`` to be ground (vacant) state, and ``|1\rangle = \begin{pmatrix} 0 \\ 1 \end{pmatrix}`` to be excited (occupied) state.
 
@@ -491,24 +491,24 @@ Note that we put ``\hat{\sigma}_{+} = \begin{pmatrix} 0 & 1 \\ 0 & 0 \end{pmatri
 
 See also [`fcreate`](@ref).
 """
-fdestroy(::Type{T}, N::Union{Int, Val}, j::Int; mode::Union{Symbol, Val} = Val(:JW)) where {T <: FloatOrComplex} =
-    _fermionic_operator(T, N, j, makeVal(mode), Val(:destroy))
+fdestroy(::Type{T}, N::Union{Int, Val}, j::Int; method::Union{Symbol, Val} = Val(:JW)) where {T <: FloatOrComplex} =
+    _fermionic_operator(T, N, j, makeVal(method), Val(:destroy))
 fdestroy(N::Union{Int, Val}, j::Int; kwargs...) = fdestroy(ComplexF64, N, j; kwargs...)
 
 @doc raw"""
-    fcreate([T::Type=ComplexF64,] N::Union{Int,Val}, j::Int; mode::Union{Symbol,Val}=Val(:JW))
+    fcreate([T::Type=ComplexF64,] N::Union{Int,Val}, j::Int; method::Union{Symbol,Val}=Val(:JW))
 
-Construct a fermionic creation operator [with element type `T = ComplexF64` (default)] acting on the `j`-th site, where the fock space has totally `N`-sites.
+Construct a fermionic creation operator [with element type `T = ComplexF64` (default)] acting on the `j`-th site, where the Hilbert space has totally `N`-sites.
 
 The site index `j` should satisfy: `1 ≤ j ≤ N`.
 
-The fermion-to-qubit mapping is selected by the keyword argument `mode`:
+The fermion-to-qubit mapping is selected by the keyword argument `method`:
 
-- `mode = :JW` (default): the [Jordan-Wigner transformation](https://en.wikipedia.org/wiki/Jordan%E2%80%93Wigner_transformation), namely
+- `method = :JW` (default): the [Jordan-Wigner transformation](https://en.wikipedia.org/wiki/Jordan%E2%80%93Wigner_transformation), namely
 ```math
 \hat{d}^\dagger_j = \hat{\sigma}_z^{\otimes j-1} \otimes \hat{\sigma}_{-} \otimes \hat{\mathbb{1}}^{\otimes N-j}
 ```
-- `mode = :BK`: the [Bravyi-Kitaev transformation](https://doi.org/10.1103/PhysRevB.109.115149).
+- `method = :BK`: the Bravyi-Kitaev transformation [OBrien-Strelchuk2024](@cite).
 
 Note that we put ``\hat{\sigma}_{-} = \begin{pmatrix} 0 & 0 \\ 1 & 0 \end{pmatrix}`` here because we consider ``|0\rangle = \begin{pmatrix} 1 \\ 0 \end{pmatrix}`` to be ground (vacant) state, and ``|1\rangle = \begin{pmatrix} 0 \\ 1 \end{pmatrix}`` to be excited (occupied) state.
 
@@ -517,20 +517,18 @@ Note that we put ``\hat{\sigma}_{-} = \begin{pmatrix} 0 & 0 \\ 1 & 0 \end{pmatri
 
 See also [`fdestroy`](@ref).
 """
-fcreate(::Type{T}, N::Union{Int, Val}, j::Int; mode::Union{Symbol, Val} = Val(:JW)) where {T <: FloatOrComplex} =
-    _fermionic_operator(T, N, j, makeVal(mode), Val(:create))
+fcreate(::Type{T}, N::Union{Int, Val}, j::Int; method::Union{Symbol, Val} = Val(:JW)) where {T <: FloatOrComplex} =
+    _fermionic_operator(T, N, j, makeVal(method), Val(:create))
 fcreate(N::Union{Int, Val}, j::Int; kwargs...) = fcreate(ComplexF64, N, j; kwargs...)
 
 _fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{:JW}, ::Val{:destroy}) where {T <: FloatOrComplex} =
     _Jordan_Wigner(T, N, j, sigmap(T))
 _fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{:JW}, ::Val{:create}) where {T <: FloatOrComplex} =
     _Jordan_Wigner(T, N, j, sigmam(T))
-_fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{:BK}, ::Val{:destroy}) where {T <: FloatOrComplex} =
-    _Bravyi_Kitaev(T, N, j, +1)
-_fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{:BK}, ::Val{:create}) where {T <: FloatOrComplex} =
-    _Bravyi_Kitaev(T, N, j, -1)
-_fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{mode}, _) where {T <: FloatOrComplex, mode} =
-    throw(ArgumentError("The fermion-to-qubit mapping `mode` should be either `:JW` or `:BK`, got `:$mode`."))
+_fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{:BK}, dagger::Val) where {T <: FloatOrComplex} =
+    _Bravyi_Kitaev(T, N, j, dagger)
+_fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{method}, _) where {T <: FloatOrComplex, method} =
+    throw(ArgumentError("The fermion-to-qubit mapping `method` should be either `:JW` or `:BK`, got `:$method`."))
 
 _Jordan_Wigner(::Type{T}, N::Int, j::Int, op::QuantumObject{Operator}) where {T <: FloatOrComplex} = _Jordan_Wigner(T, Val(N), j, op)
 
@@ -549,8 +547,8 @@ function _Jordan_Wigner(::Type{T}, ::Val{N}, j::Int, op::QuantumObject{Operator}
 end
 
 # The "update", "parity", and "flip" sets used by the Bravyi-Kitaev transformation,
-# following the convention of [Tranter et al., PhysRevB.109.115149]. All site
-# indices here are 0-based to match the bit-manipulation definitions.
+# following the convention of [OBrien-Strelchuk2024](@cite). All site indices here
+# are 0-based to match the bit-manipulation definitions.
 function _BK_update_set(N::Int, j::Int)
     out = Int[]
     p = j
@@ -581,10 +579,17 @@ function _BK_flip_set(j::Int)
     return out
 end
 
-# `sign = +1` builds the destruction operator, `sign = -1` the creation operator.
-_Bravyi_Kitaev(::Type{T}, N::Int, j::Int, sign::Int) where {T <: FloatOrComplex} = _Bravyi_Kitaev(T, Val(N), j, sign)
+# `Val(:destroy)` gives the +i term (destruction operator), `Val(:create)` the -i term (creation operator)
+_BK_sign(::Val{:destroy}) = 1
+_BK_sign(::Val{:create}) = -1
 
-function _Bravyi_Kitaev(::Type{T}, ::Val{N}, j::Int, sign::Int) where {T <: FloatOrComplex, N}
+# build the Pauli string ⨂ᵢ op over the (0-based) sites in `set`; falls back to the identity when `set` is empty
+_BK_pauli_string(::Type{T}, dims, set, op::QuantumObject) where {T <: FloatOrComplex} =
+    isempty(set) ? qeye(T, prod(dims); dims = dims) : multisite_operator(dims, map(i -> (i + 1) => op, set)...)
+
+_Bravyi_Kitaev(::Type{T}, N::Int, j::Int, dagger::Val) where {T <: FloatOrComplex} = _Bravyi_Kitaev(T, Val(N), j, dagger)
+
+function _Bravyi_Kitaev(::Type{T}, ::Val{N}, j::Int, dagger::Union{Val{:destroy}, Val{:create}}) where {T <: FloatOrComplex, N}
     (N < 1) && throw(ArgumentError("The total number of sites (N) cannot be less than 1"))
     (1 <= j <= N) || throw(ArgumentError("The site index (j) should satisfy: 1 ≤ j ≤ N"))
 
@@ -594,17 +599,20 @@ function _Bravyi_Kitaev(::Type{T}, ::Val{N}, j::Int, sign::Int) where {T <: Floa
     R = setdiff(P, F)
 
     dims = ntuple(i -> 2, Val(N))
-    Id = qeye(T, 2^N; dims = dims)
 
     # the sets are 0-based, so shift by 1 to obtain the 1-based site indices
-    XU = isempty(U) ? Id : multisite_operator(dims, map(i -> (i + 1) => sigmax(T), U)...)
-    ZR = isempty(R) ? Id : multisite_operator(dims, map(i -> (i + 1) => sigmaz(T), R)...)
-    ZP = isempty(P) ? Id : multisite_operator(dims, map(i -> (i + 1) => sigmaz(T), P)...)
+    XU = _BK_pauli_string(T, dims, U, sigmax(T))
+    ZR = _BK_pauli_string(T, dims, R, sigmaz(T))
+    ZP = _BK_pauli_string(T, dims, P, sigmaz(T))
 
     Xj = multisite_operator(dims, j => sigmax(T))
     Yj = multisite_operator(dims, j => sigmay(T))
 
-    return (XU * (Xj * ZP + (sign * 1im) * (Yj * ZR))) / 2
+    op = (XU * (Xj * ZP + T(_BK_sign(dagger) * im) * (Yj * ZR))) / 2
+
+    # `multisite_operator` builds its identity padding with the default (`Float64`) eltype,
+    # so cast back to keep the requested element type `T` (matching the Jordan-Wigner path)
+    return eltype(op) === T ? op : QuantumObject(T.(op.data); type = Operator(), dims = dims)
 end
 
 @doc raw"""

--- a/src/qobj/operators.jl
+++ b/src/qobj/operators.jl
@@ -576,7 +576,7 @@ function _BK_flip_set(α::Int)
     i = 0
     while ((α >> i) & 1) == 1 # while α_i is 1
         β = α & ~(1 << i)     # set i-th bit to 0
-        push!(F_α, β)
+        push!(F, β)
         i += 1
     end
     return F

--- a/src/qobj/operators.jl
+++ b/src/qobj/operators.jl
@@ -492,7 +492,7 @@ Note that we put ``\hat{\sigma}_{+} = \begin{pmatrix} 0 & 1 \\ 0 & 0 \end{pmatri
 See also [`fcreate`](@ref).
 """
 fdestroy(::Type{T}, N::Union{Int, Val}, j::Int; method::Union{Symbol, Val} = Val(:JW)) where {T <: FloatOrComplex} =
-    _fermionic_operator(T, N, j, makeVal(method), Val(:destroy))
+    _fermionic_operator(T, makeVal(N), j, makeVal(method), Val(:destroy))
 fdestroy(N::Union{Int, Val}, j::Int; kwargs...) = fdestroy(ComplexF64, N, j; kwargs...)
 
 @doc raw"""
@@ -518,19 +518,19 @@ Note that we put ``\hat{\sigma}_{-} = \begin{pmatrix} 0 & 0 \\ 1 & 0 \end{pmatri
 See also [`fdestroy`](@ref).
 """
 fcreate(::Type{T}, N::Union{Int, Val}, j::Int; method::Union{Symbol, Val} = Val(:JW)) where {T <: FloatOrComplex} =
-    _fermionic_operator(T, N, j, makeVal(method), Val(:create))
+    _fermionic_operator(T, makeVal(N), j, makeVal(method), Val(:create))
 fcreate(N::Union{Int, Val}, j::Int; kwargs...) = fcreate(ComplexF64, N, j; kwargs...)
 
-_fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{:JW}, ::Val{:destroy}) where {T <: FloatOrComplex} =
+_fermionic_operator(::Type{T}, ::Val{N}, j::Int, ::Val{:JW}, ::Val{:destroy}) where {T <: FloatOrComplex, N} =
     _Jordan_Wigner(T, N, j, sigmap(T))
-_fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{:JW}, ::Val{:create}) where {T <: FloatOrComplex} =
+_fermionic_operator(::Type{T}, ::Val{N}, j::Int, ::Val{:JW}, ::Val{:create}) where {T <: FloatOrComplex, N} =
     _Jordan_Wigner(T, N, j, sigmam(T))
-_fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{:BK}, dagger::Val) where {T <: FloatOrComplex} =
-    _Bravyi_Kitaev(T, N, j, dagger)
-_fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{method}, _) where {T <: FloatOrComplex, method} =
+_fermionic_operator(::Type{T}, ::Val{N}, j::Int, ::Val{:BK}, ::Val{:destroy}) where {T <: FloatOrComplex, N} =
+    _Bravyi_Kitaev(T, N, j, one(T))
+_fermionic_operator(::Type{T}, ::Val{N}, j::Int, ::Val{:BK}, ::Val{:create}) where {T <: FloatOrComplex, N} =
+    _Bravyi_Kitaev(T, N, j, -one(T))
+_fermionic_operator(::Type{T}, :Val{N}, j::Int, ::Val{method}, _) where {T <: FloatOrComplex, N, method} =
     throw(ArgumentError("The fermion-to-qubit mapping `method` should be either `:JW` or `:BK`, got `:$method`."))
-
-_Jordan_Wigner(::Type{T}, N::Int, j::Int, op::QuantumObject{Operator}) where {T <: FloatOrComplex} = _Jordan_Wigner(T, Val(N), j, op)
 
 function _Jordan_Wigner(::Type{T}, ::Val{N}, j::Int, op::QuantumObject{Operator}) where {T <: FloatOrComplex, N}
     (N < 1) && throw(ArgumentError("The total number of sites (N) cannot be less than 1"))
@@ -546,53 +546,53 @@ function _Jordan_Wigner(::Type{T}, ::Val{N}, j::Int, op::QuantumObject{Operator}
     return QuantumObject(kron(Z_tensor, op.data, I_tensor); type = Operator(), dims = ntuple(i -> 2, Val(N)))
 end
 
-# The "update", "parity", and "flip" sets used by the Bravyi-Kitaev transformation,
-# following the convention of [OBrien-Strelchuk2024](@cite). All site indices here
-# are 0-based to match the bit-manipulation definitions.
-function _BK_update_set(N::Int, j::Int)
-    out = Int[]
-    p = j
-    while p < N
-        (p != j) && push!(out, p) # exclude site j itself
-        p = p | (p + 1)
+# These "update", "parity", and "flip" sets are used by the `_Bravyi_Kitaev` transformation [Phys. Rev. B 109, 115149 (2024)]
+## The following functions are optimized using bitwise operations for better performance compared to the pseudo-code in the paper.
+## All site-indices here are 0-based to match the bit-manipulation definitions.
+##
+## Note that we use the variable names as presented in the paper:
+##   - `n`: Number of fermionic modes
+##   - `α`: site index
+function _BK_update_set(n::Int, α::Int)
+    U = Int[]
+    β = α
+    while β < n
+        (β != α) && push!(U, β) # exclude site α itself
+        β = β | (β + 1)
     end
-    return out
+    return U
 end
-
-function _BK_parity_set(j::Int)
-    out = Int[]
-    p = j - 1 # prefix parity = sites with index less than j
-    while p >= 0
-        push!(out, p)
-        p = (p & (p + 1)) - 1 # drop the lowest set block of bits
+function _BK_parity_set(α::Int)
+    P = Int[]
+    β = α - 1 # prefix parity = sites with index less than j
+    while β >= 0
+        push!(P, β)
+        β = (β & (β + 1)) - 1 # drop the lowest set block of bits
     end
-    return out
+    return P
 end
-
-function _BK_flip_set(j::Int)
-    out = Int[]
-    k = 0
-    while ((j >> k) & 1) == 1 # while bit k of j is set
-        push!(out, j & ~(1 << k)) # clear bit k
-        k += 1
+function _BK_flip_set(α::Int)
+    F = Int[]
+    i = 0
+    while ((α >> i) & 1) == 1 # while α_i is 1
+        β = α & ~(1 << i)     # set i-th bit to 0
+        push!(F_α, β)
+        i += 1
     end
-    return out
+    return F
 end
-
-# `Val(:destroy)` gives the +i term (destruction operator), `Val(:create)` the -i term (creation operator)
-_BK_sign(::Val{:destroy}) = 1
-_BK_sign(::Val{:create}) = -1
 
 # build the Pauli string ⨂ᵢ op over the (0-based) sites in `set`; falls back to the identity when `set` is empty
-_BK_pauli_string(::Type{T}, dims, set, op::QuantumObject) where {T <: FloatOrComplex} =
+# the `set` is using 0-based indexing, so shift by 1 to obtain the 1-based site-indices
+_BK_Pauli_string(::Type{T}, dims, set, op::QuantumObject) where {T <: FloatOrComplex} =
     isempty(set) ? qeye(T, prod(dims); dims = dims) : multisite_operator(dims, map(i -> (i + 1) => op, set)...)
 
-_Bravyi_Kitaev(::Type{T}, N::Int, j::Int, dagger::Val) where {T <: FloatOrComplex} = _Bravyi_Kitaev(T, Val(N), j, dagger)
-
-function _Bravyi_Kitaev(::Type{T}, ::Val{N}, j::Int, dagger::Union{Val{:destroy}, Val{:create}}) where {T <: FloatOrComplex, N}
+# the type of `sign` should be same as the first argument (which is specified by `_fermionic_operator`)
+function _Bravyi_Kitaev(::Type{T}, ::Val{N}, j::Int, sign::T) where {T <: FloatOrComplex, N}
     (N < 1) && throw(ArgumentError("The total number of sites (N) cannot be less than 1"))
     (1 <= j <= N) || throw(ArgumentError("The site index (j) should satisfy: 1 ≤ j ≤ N"))
 
+    # use j-1 because these functions consider 0-based indexing, which aligns with the convention of [Phys. Rev. B 109, 115149 (2024)]
     U = _BK_update_set(N, j - 1)
     P = _BK_parity_set(j - 1)
     F = _BK_flip_set(j - 1)
@@ -600,19 +600,14 @@ function _Bravyi_Kitaev(::Type{T}, ::Val{N}, j::Int, dagger::Union{Val{:destroy}
 
     dims = ntuple(i -> 2, Val(N))
 
-    # the sets are 0-based, so shift by 1 to obtain the 1-based site indices
-    XU = _BK_pauli_string(T, dims, U, sigmax(T))
-    ZR = _BK_pauli_string(T, dims, R, sigmaz(T))
-    ZP = _BK_pauli_string(T, dims, P, sigmaz(T))
+    XU = _BK_Pauli_string(T, dims, U, sigmax(T))
+    ZR = _BK_Pauli_string(T, dims, R, sigmaz(T))
+    ZP = _BK_Pauli_string(T, dims, P, sigmaz(T))
 
     Xj = multisite_operator(dims, j => sigmax(T))
     Yj = multisite_operator(dims, j => sigmay(T))
 
-    op = (XU * (Xj * ZP + T(_BK_sign(dagger) * im) * (Yj * ZR))) / 2
-
-    # `multisite_operator` builds its identity padding with the default (`Float64`) eltype,
-    # so cast back to keep the requested element type `T` (matching the Jordan-Wigner path)
-    return eltype(op) === T ? op : QuantumObject(T.(op.data); type = Operator(), dims = dims)
+    return (XU * (Xj * ZP + (sign * im) * (Yj * ZR))) / 2
 end
 
 @doc raw"""

--- a/src/qobj/operators.jl
+++ b/src/qobj/operators.jl
@@ -470,44 +470,67 @@ eye(::Type{T}, N::Int; type = Operator(), dims = nothing) where {T <: Number} = 
 eye(N::Int; type = Operator(), dims = nothing) = eye(ComplexF64, N; type, dims)
 
 @doc raw"""
-    fdestroy([T::Type=ComplexF64,] N::Union{Int,Val}, j::Int)
+    fdestroy([T::Type=ComplexF64,] N::Union{Int,Val}, j::Int; mode::Union{Symbol,Val}=Val(:JW))
 
-Construct a fermionic destruction operator [with element type `T = ComplexF64` (default)] acting on the `j`-th site, where the fock space has totally `N`-sites:
+Construct a fermionic destruction operator [with element type `T = ComplexF64` (default)] acting on the `j`-th site, where the fock space has totally `N`-sites.
 
-Here, we use the [Jordan-Wigner transformation](https://en.wikipedia.org/wiki/Jordan%E2%80%93Wigner_transformation), namely
+The site index `j` should satisfy: `1 ≤ j ≤ N`.
+
+The fermion-to-qubit mapping is selected by the keyword argument `mode`:
+
+- `mode = :JW` (default): the [Jordan-Wigner transformation](https://en.wikipedia.org/wiki/Jordan%E2%80%93Wigner_transformation), namely
 ```math
 \hat{d}_j = \hat{\sigma}_z^{\otimes j-1} \otimes \hat{\sigma}_{+} \otimes \hat{\mathbb{1}}^{\otimes N-j}
 ```
-
-The site index `j` should satisfy: `1 ≤ j ≤ N`.
+- `mode = :BK`: the [Bravyi-Kitaev transformation](https://doi.org/10.1103/PhysRevB.109.115149).
 
 Note that we put ``\hat{\sigma}_{+} = \begin{pmatrix} 0 & 1 \\ 0 & 0 \end{pmatrix}`` here because we consider ``|0\rangle = \begin{pmatrix} 1 \\ 0 \end{pmatrix}`` to be ground (vacant) state, and ``|1\rangle = \begin{pmatrix} 0 \\ 1 \end{pmatrix}`` to be excited (occupied) state.
 
 !!! warning "Beware of type-stability!"
     If you want to keep type stability, it is recommended to use `fdestroy(Val(N), j)` instead of `fdestroy(N, j)`. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
+
+See also [`fcreate`](@ref).
 """
-fdestroy(::Type{T}, N::Union{Int, Val}, j::Int) where {T <: FloatOrComplex} = _Jordan_Wigner(T, N, j, sigmap(T))
-fdestroy(N::Union{Int, Val}, j::Int) = fdestroy(ComplexF64, N, j)
+fdestroy(::Type{T}, N::Union{Int, Val}, j::Int; mode::Union{Symbol, Val} = Val(:JW)) where {T <: FloatOrComplex} =
+    _fermionic_operator(T, N, j, makeVal(mode), Val(:destroy))
+fdestroy(N::Union{Int, Val}, j::Int; kwargs...) = fdestroy(ComplexF64, N, j; kwargs...)
 
 @doc raw"""
-    fcreate([T::Type=ComplexF64,] N::Union{Int,Val}, j::Int)
+    fcreate([T::Type=ComplexF64,] N::Union{Int,Val}, j::Int; mode::Union{Symbol,Val}=Val(:JW))
 
-Construct a fermionic creation operator [with element type `T = ComplexF64` (default)] acting on the `j`-th site, where the fock space has totally `N`-sites:
+Construct a fermionic creation operator [with element type `T = ComplexF64` (default)] acting on the `j`-th site, where the fock space has totally `N`-sites.
 
-Here, we use the [Jordan-Wigner transformation](https://en.wikipedia.org/wiki/Jordan%E2%80%93Wigner_transformation), namely
+The site index `j` should satisfy: `1 ≤ j ≤ N`.
+
+The fermion-to-qubit mapping is selected by the keyword argument `mode`:
+
+- `mode = :JW` (default): the [Jordan-Wigner transformation](https://en.wikipedia.org/wiki/Jordan%E2%80%93Wigner_transformation), namely
 ```math
 \hat{d}^\dagger_j = \hat{\sigma}_z^{\otimes j-1} \otimes \hat{\sigma}_{-} \otimes \hat{\mathbb{1}}^{\otimes N-j}
 ```
-
-The site index `j` should satisfy: `1 ≤ j ≤ N`.
+- `mode = :BK`: the [Bravyi-Kitaev transformation](https://doi.org/10.1103/PhysRevB.109.115149).
 
 Note that we put ``\hat{\sigma}_{-} = \begin{pmatrix} 0 & 0 \\ 1 & 0 \end{pmatrix}`` here because we consider ``|0\rangle = \begin{pmatrix} 1 \\ 0 \end{pmatrix}`` to be ground (vacant) state, and ``|1\rangle = \begin{pmatrix} 0 \\ 1 \end{pmatrix}`` to be excited (occupied) state.
 
 !!! warning "Beware of type-stability!"
     If you want to keep type stability, it is recommended to use `fcreate(Val(N), j)` instead of `fcreate(N, j)`. See [this link](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-value-type) and the [related Section](@ref doc:Type-Stability) about type stability for more details.
+
+See also [`fdestroy`](@ref).
 """
-fcreate(::Type{T}, N::Union{Int, Val}, j::Int) where {T <: FloatOrComplex} = _Jordan_Wigner(T, N, j, sigmam(T))
-fcreate(N::Union{Int, Val}, j::Int) = fcreate(ComplexF64, N, j)
+fcreate(::Type{T}, N::Union{Int, Val}, j::Int; mode::Union{Symbol, Val} = Val(:JW)) where {T <: FloatOrComplex} =
+    _fermionic_operator(T, N, j, makeVal(mode), Val(:create))
+fcreate(N::Union{Int, Val}, j::Int; kwargs...) = fcreate(ComplexF64, N, j; kwargs...)
+
+_fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{:JW}, ::Val{:destroy}) where {T <: FloatOrComplex} =
+    _Jordan_Wigner(T, N, j, sigmap(T))
+_fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{:JW}, ::Val{:create}) where {T <: FloatOrComplex} =
+    _Jordan_Wigner(T, N, j, sigmam(T))
+_fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{:BK}, ::Val{:destroy}) where {T <: FloatOrComplex} =
+    _Bravyi_Kitaev(T, N, j, +1)
+_fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{:BK}, ::Val{:create}) where {T <: FloatOrComplex} =
+    _Bravyi_Kitaev(T, N, j, -1)
+_fermionic_operator(::Type{T}, N::Union{Int, Val}, j::Int, ::Val{mode}, _) where {T <: FloatOrComplex, mode} =
+    throw(ArgumentError("The fermion-to-qubit mapping `mode` should be either `:JW` or `:BK`, got `:$mode`."))
 
 _Jordan_Wigner(::Type{T}, N::Int, j::Int, op::QuantumObject{Operator}) where {T <: FloatOrComplex} = _Jordan_Wigner(T, Val(N), j, op)
 
@@ -523,6 +546,65 @@ function _Jordan_Wigner(::Type{T}, ::Val{N}, j::Int, op::QuantumObject{Operator}
     I_tensor = Eye{T}(2^(N - j))
 
     return QuantumObject(kron(Z_tensor, op.data, I_tensor); type = Operator(), dims = ntuple(i -> 2, Val(N)))
+end
+
+# The "update", "parity", and "flip" sets used by the Bravyi-Kitaev transformation,
+# following the convention of [Tranter et al., PhysRevB.109.115149]. All site
+# indices here are 0-based to match the bit-manipulation definitions.
+function _BK_update_set(N::Int, j::Int)
+    out = Int[]
+    p = j
+    while p < N
+        (p != j) && push!(out, p) # exclude site j itself
+        p = p | (p + 1)
+    end
+    return out
+end
+
+function _BK_parity_set(j::Int)
+    out = Int[]
+    p = j - 1 # prefix parity = sites with index less than j
+    while p >= 0
+        push!(out, p)
+        p = (p & (p + 1)) - 1 # drop the lowest set block of bits
+    end
+    return out
+end
+
+function _BK_flip_set(j::Int)
+    out = Int[]
+    k = 0
+    while ((j >> k) & 1) == 1 # while bit k of j is set
+        push!(out, j & ~(1 << k)) # clear bit k
+        k += 1
+    end
+    return out
+end
+
+# `sign = +1` builds the destruction operator, `sign = -1` the creation operator.
+_Bravyi_Kitaev(::Type{T}, N::Int, j::Int, sign::Int) where {T <: FloatOrComplex} = _Bravyi_Kitaev(T, Val(N), j, sign)
+
+function _Bravyi_Kitaev(::Type{T}, ::Val{N}, j::Int, sign::Int) where {T <: FloatOrComplex, N}
+    (N < 1) && throw(ArgumentError("The total number of sites (N) cannot be less than 1"))
+    (1 <= j <= N) || throw(ArgumentError("The site index (j) should satisfy: 1 ≤ j ≤ N"))
+
+    U = _BK_update_set(N, j - 1)
+    P = _BK_parity_set(j - 1)
+    F = _BK_flip_set(j - 1)
+    R = setdiff(P, F)
+
+    dims = ntuple(i -> 2, Val(N))
+    Id = qeye(T, 2^N; dims = dims)
+
+    # the sets are 0-based, so shift by 1 to obtain the 1-based site indices
+    XU = isempty(U) ? Id : multisite_operator(dims, map(i -> (i + 1) => sigmax(T), U)...)
+    ZR = isempty(R) ? Id : multisite_operator(dims, map(i -> (i + 1) => sigmaz(T), R)...)
+    ZP = isempty(P) ? Id : multisite_operator(dims, map(i -> (i + 1) => sigmaz(T), P)...)
+
+    Xj = multisite_operator(dims, j => sigmax(T))
+    Yj = multisite_operator(dims, j => sigmay(T))
+
+    return (XU * (Xj * ZP + (sign * 1im) * (Yj * ZR))) / 2
 end
 
 @doc raw"""

--- a/test/core-test/states_and_operators.jl
+++ b/test/core-test/states_and_operators.jl
@@ -527,8 +527,10 @@
 
         @inferred eye(20)
 
-        @inferred fdestroy(Val(10), 4)
-        @inferred fcreate(Val(10), 4)
+        @inferred fdestroy(Val(10), 4; method = :JW)
+        @inferred fcreate(Val(10), 4; method = :JW)
+        @inferred fdestroy(Val(10), 4; method = :BK)
+        @inferred fcreate(Val(10), 4; method = :BK)
 
         @inferred projection(20, 5, 3)
 

--- a/test/core-test/states_and_operators.jl
+++ b/test/core-test/states_and_operators.jl
@@ -364,6 +364,47 @@
         @test_throws ArgumentError fdestroy(0, 0)
         @test_throws ArgumentError fdestroy(sites, 0)
         @test_throws ArgumentError fdestroy(sites, sites + 1)
+        @test_throws ArgumentError fdestroy(sites, 1; mode = :unknown)
+        @test_throws ArgumentError fcreate(sites, 1; mode = :unknown)
+
+        # Bravyi-Kitaev fermion-to-qubit mapping
+        @test fdestroy(1, 1; mode = :BK) == fdestroy(1, 1; mode = :JW)
+        @test fcreate(1, 1; mode = :BK) == fcreate(1, 1; mode = :JW)
+
+        N = 7
+        vac_BK = tensor(fill(basis(2, 0), N)...)
+        Cs = map(i -> fdestroy(N, i; mode = :BK), 1:N)
+        for i in 1:N
+            Ci = Cs[i]
+            @test Ci' ≈ fcreate(N, i; mode = :BK)
+            @test (Ci * vac_BK) ≈ zero_ket(ntuple(_ -> 2, N))
+
+            @test commutator(Ci, Ci'; anti = true) ≈ qeye(2^N; dims = ntuple(_ -> 2, N))
+            @test norm(commutator(Ci, Ci; anti = true)) ≈ 0 atol = 1.0e-12
+
+            for j in (i + 1):N
+                Cj = Cs[j]
+                @test norm(commutator(Ci, Cj; anti = true)) ≈ 0 atol = 1.0e-12
+                @test norm(commutator(Ci, Cj'; anti = true)) ≈ 0 atol = 1.0e-12
+            end
+        end
+
+        # explicit Pauli strings for N = 4 (see Tranter et al., PhysRevB.109.115149)
+        X = sigmax()
+        Y = sigmay()
+        Z = sigmaz()
+        Id2 = qeye(2)
+        d_BK = [
+            0.5 * tensor(X, X, Id2, X) + 0.5im * tensor(Y, X, Id2, X),
+            0.5 * tensor(Z, X, Id2, X) + 0.5im * tensor(Id2, Y, Id2, X),
+            0.5 * tensor(Id2, Z, X, X) + 0.5im * tensor(Id2, Z, Y, X),
+            0.5 * tensor(Id2, Z, Z, X) + 0.5im * tensor(Id2, Id2, Id2, Y),
+        ]
+        @test all([fdestroy(4, i; mode = :BK) ≈ d_BK[i] for i in 1:4])
+
+        @test_throws ArgumentError fdestroy(0, 0; mode = :BK)
+        @test_throws ArgumentError fdestroy(sites, 0; mode = :BK)
+        @test_throws ArgumentError fdestroy(sites, sites + 1; mode = :BK)
     end
 
     @testset "identity operator" begin

--- a/test/core-test/states_and_operators.jl
+++ b/test/core-test/states_and_operators.jl
@@ -327,8 +327,11 @@
             (
             exp(-γ / 2) * cos(θ1 / 2) * cos(θ2 / 2) + exp(1im * (ϕ2 - ϕ1) + γ / 2) * sin(θ1 / 2) * sin(θ2 / 2)
         )^(2 * s)
+    end
 
-        # test commutation relations for fermionic creation and annihilation operators
+    @testset "fdestroy and fcreate" begin
+        # Jordan-Wigner transformation
+        ## test commutation relations for fermionic creation and annihilation operators
         sites = 4
         SIZE = 2^sites
         dims = ntuple(i -> 2, Val(sites))
@@ -361,11 +364,6 @@
         @test d1' * d2' * vac == tensor(basis(2, 1), basis(2, 1))
         @test d1' * d1' * d2' * vac == zero
         @test d2' * d1' * d2' * vac == zero
-        @test_throws ArgumentError fdestroy(0, 0)
-        @test_throws ArgumentError fdestroy(sites, 0)
-        @test_throws ArgumentError fdestroy(sites, sites + 1)
-        @test_throws ArgumentError fdestroy(sites, 1; method = :unknown)
-        @test_throws ArgumentError fcreate(sites, 1; method = :unknown)
 
         # Bravyi-Kitaev fermion-to-qubit mapping
         @test fdestroy(1, 1; method = :BK) == fdestroy(1, 1; method = :JW)
@@ -389,7 +387,7 @@
             end
         end
 
-        # explicit Pauli strings for N = 4 [see O'Brien and Strelchuk, Phys. Rev. B 109, 115149 (2024)]
+        ## explicit Pauli strings for N = 4 [see O'Brien and Strelchuk, Phys. Rev. B 109, 115149 (2024)]
         X = sigmax()
         Y = sigmay()
         Z = sigmaz()
@@ -402,9 +400,15 @@
         ]
         @test all([fdestroy(4, i; method = :BK) ≈ d_BK[i] for i in 1:4])
 
+        # Errors
+        @test_throws ArgumentError fdestroy(0, 0; method = :JW)
+        @test_throws ArgumentError fdestroy(sites, 0; method = :JW)
+        @test_throws ArgumentError fdestroy(sites, sites + 1; method = :JW)
         @test_throws ArgumentError fdestroy(0, 0; method = :BK)
         @test_throws ArgumentError fdestroy(sites, 0; method = :BK)
         @test_throws ArgumentError fdestroy(sites, sites + 1; method = :BK)
+        @test_throws ArgumentError fdestroy(sites, 1; method = :unknown)
+        @test_throws ArgumentError fcreate(sites, 1; method = :unknown)
     end
 
     @testset "identity operator" begin

--- a/test/core-test/states_and_operators.jl
+++ b/test/core-test/states_and_operators.jl
@@ -527,10 +527,10 @@
 
         @inferred eye(20)
 
-        @inferred fdestroy(Val(10), 4; method = :JW)
-        @inferred fcreate(Val(10), 4; method = :JW)
-        @inferred fdestroy(Val(10), 4; method = :BK)
-        @inferred fcreate(Val(10), 4; method = :BK)
+        @inferred fdestroy(Val(10), 4; method = Val(:JW))
+        @inferred fcreate(Val(10), 4; method = Val(:JW))
+        @inferred fdestroy(Val(10), 4; method = Val(:BK))
+        @inferred fcreate(Val(10), 4; method = Val(:BK))
 
         @inferred projection(20, 5, 3)
 

--- a/test/core-test/states_and_operators.jl
+++ b/test/core-test/states_and_operators.jl
@@ -364,19 +364,19 @@
         @test_throws ArgumentError fdestroy(0, 0)
         @test_throws ArgumentError fdestroy(sites, 0)
         @test_throws ArgumentError fdestroy(sites, sites + 1)
-        @test_throws ArgumentError fdestroy(sites, 1; mode = :unknown)
-        @test_throws ArgumentError fcreate(sites, 1; mode = :unknown)
+        @test_throws ArgumentError fdestroy(sites, 1; method = :unknown)
+        @test_throws ArgumentError fcreate(sites, 1; method = :unknown)
 
         # Bravyi-Kitaev fermion-to-qubit mapping
-        @test fdestroy(1, 1; mode = :BK) == fdestroy(1, 1; mode = :JW)
-        @test fcreate(1, 1; mode = :BK) == fcreate(1, 1; mode = :JW)
+        @test fdestroy(1, 1; method = :BK) == fdestroy(1, 1; method = :JW)
+        @test fcreate(1, 1; method = :BK) == fcreate(1, 1; method = :JW)
 
         N = 7
         vac_BK = tensor(fill(basis(2, 0), N)...)
-        Cs = map(i -> fdestroy(N, i; mode = :BK), 1:N)
+        Cs = map(i -> fdestroy(N, i; method = :BK), 1:N)
         for i in 1:N
             Ci = Cs[i]
-            @test Ci' ≈ fcreate(N, i; mode = :BK)
+            @test Ci' ≈ fcreate(N, i; method = :BK)
             @test (Ci * vac_BK) ≈ zero_ket(ntuple(_ -> 2, N))
 
             @test commutator(Ci, Ci'; anti = true) ≈ qeye(2^N; dims = ntuple(_ -> 2, N))
@@ -389,7 +389,7 @@
             end
         end
 
-        # explicit Pauli strings for N = 4 (see Tranter et al., PhysRevB.109.115149)
+        # explicit Pauli strings for N = 4 [see O'Brien and Strelchuk, Phys. Rev. B 109, 115149 (2024)]
         X = sigmax()
         Y = sigmay()
         Z = sigmaz()
@@ -400,11 +400,11 @@
             0.5 * tensor(Id2, Z, X, X) + 0.5im * tensor(Id2, Z, Y, X),
             0.5 * tensor(Id2, Z, Z, X) + 0.5im * tensor(Id2, Id2, Id2, Y),
         ]
-        @test all([fdestroy(4, i; mode = :BK) ≈ d_BK[i] for i in 1:4])
+        @test all([fdestroy(4, i; method = :BK) ≈ d_BK[i] for i in 1:4])
 
-        @test_throws ArgumentError fdestroy(0, 0; mode = :BK)
-        @test_throws ArgumentError fdestroy(sites, 0; mode = :BK)
-        @test_throws ArgumentError fdestroy(sites, sites + 1; mode = :BK)
+        @test_throws ArgumentError fdestroy(0, 0; method = :BK)
+        @test_throws ArgumentError fdestroy(sites, 0; method = :BK)
+        @test_throws ArgumentError fdestroy(sites, sites + 1; method = :BK)
     end
 
     @testset "identity operator" begin
@@ -592,6 +592,8 @@
             @test CT == eltype(momentum(CT, N))
             @test CT == eltype(fdestroy(CT, N, 1))
             @test CT == eltype(fcreate(CT, N, 1))
+            @test CT == eltype(fdestroy(CT, N, 1; method = :BK))
+            @test CT == eltype(fcreate(CT, N, 1; method = :BK))
             @test CT == eltype(tunneling(CT, N))
             @test CT == eltype(qft(CT, N))
         end


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Implement Bravyi-Kitaev mapping for fermionic operators