### PR TITLE
Add `save_states` keyword to `mcsolve` to avoid saving states at final time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add a convenient method when the Hilbert space dimension of all sites are equal.
   - Improve the documentation and docstring.
 - Efficient Jordan Wigner transformation for `fdestroy` and `fcreate`. ([#723])
+- Add `save_states` keyword argument to `mcsolve` to skip the (potentially expensive) post-processing assembly and trajectory-averaging of states when only expectation values are needed. ([#726])
 
 ## [v0.47.0]
 Release date: 2026-05-19
@@ -525,3 +526,4 @@ Release date: 2024-11-13
 [#722]: https://github.com/qutip/QuantumToolbox.jl/issues/722
 [#723]: https://github.com/qutip/QuantumToolbox.jl/issues/723
 [#725]: https://github.com/qutip/QuantumToolbox.jl/issues/725
+[#726]: https://github.com/qutip/QuantumToolbox.jl/issues/726

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -23,14 +23,17 @@ end
 
 # Assemble (and, when `keep_runs_results = Val(false)`, trajectory-average) the states.
 # With `save_states = Val(false)` this is skipped entirely to avoid the (potentially expensive)
-# state normalization and `ket2dm` averaging when only expectation values are needed.
+# state normalization and `ket2dm` averaging when only expectation values are needed. In that case
+# an empty container is returned whose number of dimensions matches the `keep_runs_results` layout
+# (a per-trajectory matrix when `Val(true)`, an averaged vector when `Val(false)`).
 function _mcsolve_states(sol, dimensions, normalize_states, keep_runs_results, ::Val{true})
     # stack to transform Vector{Vector{QuantumObject}} -> Matrix{QuantumObject}
     states_all =
         stack(map(i -> _normalize_state!.(sol.u[i].u, Ref(dimensions), normalize_states), eachindex(sol.u)), dims = 1)
     return _store_multitraj_states(states_all, keep_runs_results)
 end
-_mcsolve_states(sol, dimensions, normalize_states, keep_runs_results, ::Val{false}) = QuantumObject[]
+_mcsolve_states(sol, dimensions, normalize_states, ::Val{false}, ::Val{false}) = QuantumObject[]
+_mcsolve_states(sol, dimensions, normalize_states, ::Val{true}, ::Val{false}) = Matrix{QuantumObject}(undef, 0, 0)
 
 function _mcsolve_make_Heff_QobjEvo(H::QuantumObject, c_ops)
     c_ops isa Nothing && return QuantumObjectEvolution(H)
@@ -350,7 +353,7 @@ If the environmental measurements register a quantum jump, the wave function und
 - `output_func`: a `Tuple` containing the `Function` to use for generating the output of a single trajectory, the (optional) `Progress` object, and the (optional) `RemoteChannel` object.
 - `keep_runs_results`: Whether to save the results of each trajectory. Default to `Val(false)`.
 - `normalize_states`: Whether to normalize the states. Default to `Val(true)`.
-- `save_states`: Whether to assemble and store the trajectory states in the returned solution. Default to `Val(true)`. Set it to `Val(false)` (together with `e_ops`) to skip the (potentially expensive) state assembly and averaging when only expectation values are needed; in that case `sol.states` is empty.
+- `save_states`: Whether to assemble and store the trajectory states in the returned solution. Default to `Val(true)`. Set it to `Val(false)` to skip the (potentially expensive) state assembly and averaging when only expectation values are needed; in that case `sol.states` is empty. This is functional on its own, but for best performance it is recommended to also pass `e_ops` so that the solver stores fewer states during integration (see the Notes below).
 - `kwargs`: The keyword arguments for the ODEProblem.
 
 # Notes

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -21,6 +21,17 @@ function _normalize_state!(u, dims, normalize_states)
     return QuantumObject(u, Ket(), dims)
 end
 
+# Assemble (and, when `keep_runs_results = Val(false)`, trajectory-average) the states.
+# With `save_states = Val(false)` this is skipped entirely to avoid the (potentially expensive)
+# state normalization and `ket2dm` averaging when only expectation values are needed.
+function _mcsolve_states(sol, dimensions, normalize_states, keep_runs_results, ::Val{true})
+    # stack to transform Vector{Vector{QuantumObject}} -> Matrix{QuantumObject}
+    states_all =
+        stack(map(i -> _normalize_state!.(sol.u[i].u, Ref(dimensions), normalize_states), eachindex(sol.u)), dims = 1)
+    return _store_multitraj_states(states_all, keep_runs_results)
+end
+_mcsolve_states(sol, dimensions, normalize_states, keep_runs_results, ::Val{false}) = QuantumObject[]
+
 function _mcsolve_make_Heff_QobjEvo(H::QuantumObject, c_ops)
     c_ops isa Nothing && return QuantumObjectEvolution(H)
     return QuantumObjectEvolution(H - 1im * mapreduce(op -> op' * op, +, c_ops) / 2)
@@ -283,6 +294,7 @@ end
         output_func::Union{Tuple,Nothing} = nothing,
         keep_runs_results::Union{Val,Bool} = Val(false),
         normalize_states::Union{Val,Bool} = Val(true),
+        save_states::Union{Val,Bool} = Val(true),
         kwargs...,
     )
 
@@ -338,6 +350,7 @@ If the environmental measurements register a quantum jump, the wave function und
 - `output_func`: a `Tuple` containing the `Function` to use for generating the output of a single trajectory, the (optional) `Progress` object, and the (optional) `RemoteChannel` object.
 - `keep_runs_results`: Whether to save the results of each trajectory. Default to `Val(false)`.
 - `normalize_states`: Whether to normalize the states. Default to `Val(true)`.
+- `save_states`: Whether to assemble and store the trajectory states in the returned solution. Default to `Val(true)`. Set it to `Val(false)` (together with `e_ops`) to skip the (potentially expensive) state assembly and averaging when only expectation values are needed; in that case `sol.states` is empty.
 - `kwargs`: The keyword arguments for the ODEProblem.
 
 # Notes
@@ -345,6 +358,7 @@ If the environmental measurements register a quantum jump, the wave function und
 - `ensemblealg` can be one of `EnsembleThreads()`, `EnsembleSerial()`, `EnsembleDistributed()`
 - The states will be saved depend on the keyword argument `saveat` in `kwargs`.
 - If `e_ops` is empty, the default value of `saveat=tlist` (saving the states corresponding to `tlist`), otherwise, `saveat=[tlist[end]]` (only save the final state). You can also specify `e_ops` and `saveat` separately.
+- `save_states=Val(false)` only skips the post-processing of the states (assembly and trajectory-averaging); it does not change how many states the ODE solver stores during integration (that is controlled by `saveat`). For maximum performance when only expectation values are needed, combine `save_states=Val(false)` with `e_ops` (so that `saveat=[tlist[end]]`).
 - The default tolerances in `kwargs` are given as `reltol=1e-6` and `abstol=1e-8`.
 - For more details about `alg` please refer to [`DifferentialEquations.jl` (ODE Solvers)](https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/)
 - For more details about `kwargs` please refer to [`DifferentialEquations.jl` (Keyword Arguments)](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
@@ -370,6 +384,7 @@ function mcsolve(
         output_func::Union{Tuple, Nothing} = nothing,
         keep_runs_results::Union{Val, Bool} = Val(false),
         normalize_states::Union{Val, Bool} = Val(true),
+        save_states::Union{Val, Bool} = Val(true),
         kwargs...,
     ) where {TJC <: LindbladJumpCallbackType}
     ens_prob_mc = mcsolveEnsembleProblem(
@@ -390,7 +405,15 @@ function mcsolve(
         kwargs...,
     )
 
-    return mcsolve(ens_prob_mc, alg, ntraj, ensemblealg, makeVal(keep_runs_results), normalize_states)
+    return mcsolve(
+        ens_prob_mc,
+        alg,
+        ntraj,
+        ensemblealg,
+        makeVal(keep_runs_results),
+        normalize_states,
+        makeVal(save_states),
+    )
 end
 
 function mcsolve(
@@ -400,6 +423,7 @@ function mcsolve(
         ensemblealg::EnsembleAlgorithm = EnsembleThreads(),
         keep_runs_results = Val(false),
         normalize_states = Val(true),
+        save_states = Val(true),
     )
     sol = _ensemble_dispatch_solve(ens_prob_mc, alg, ensemblealg, ntraj; rng = ens_prob_mc.kwargs.rng)
 
@@ -411,8 +435,7 @@ function mcsolve(
         _expvals_sol_1 isa Nothing ? nothing : map(i -> _get_expvals(sol.u[i], SaveFuncMCSolve), eachindex(sol.u))
     expvals_all = _expvals_all isa Nothing ? nothing : stack(_expvals_all, dims = 2) # Stack on dimension 2 to align with QuTiP
 
-    # stack to transform Vector{Vector{QuantumObject}} -> Matrix{QuantumObject}
-    states_all = stack(map(i -> _normalize_state!.(sol.u[i].u, Ref(dimensions), normalize_states), eachindex(sol.u)), dims = 1)
+    states = _mcsolve_states(sol, dimensions, normalize_states, keep_runs_results, makeVal(save_states))
 
     col_times = map(i -> _mc_get_jump_callback(sol.u[i]).affect!.col_times, eachindex(sol.u))
     col_which = map(i -> _mc_get_jump_callback(sol.u[i]).affect!.col_which, eachindex(sol.u))
@@ -423,7 +446,7 @@ function mcsolve(
         ntraj,
         ens_prob_mc.times,
         _sol_1.t,
-        _store_multitraj_states(states_all, keep_runs_results),
+        states,
         _store_multitraj_expect(expvals_all, keep_runs_results),
         col_times,
         col_which,

--- a/test/core-test/time_evolution.jl
+++ b/test/core-test/time_evolution.jl
@@ -481,7 +481,8 @@ end
         "reltol = $(sol_mc_states.reltol)\n"
 
     # save_states = Val(false) skips state assembly/averaging but keeps expectation values.
-    # Using the same seeded rng, the expectation values must be identical to a save_states = Val(true) run.
+    # Using the same seeded rng and EnsembleSerial (for deterministic trajectory/RNG order), the
+    # expectation values must be identical to a save_states = Val(true) run.
     sol_mc_with_states = mcsolve(
         H,
         ψ0,
@@ -489,6 +490,7 @@ end
         c_ops,
         e_ops = e_ops,
         progress_bar = Val(false),
+        ensemblealg = QuantumToolbox.EnsembleSerial(),
         rng = MersenneTwister(1234),
     )
     sol_mc_no_states = mcsolve(
@@ -498,6 +500,7 @@ end
         c_ops,
         e_ops = e_ops,
         progress_bar = Val(false),
+        ensemblealg = QuantumToolbox.EnsembleSerial(),
         save_states = Val(false),
         rng = MersenneTwister(1234),
     )
@@ -506,6 +509,22 @@ end
     @test isempty(average_states(sol_mc_no_states))
     sol_mc_no_states_string = sprint((t, s) -> show(t, "text/plain", s), sol_mc_no_states)
     @test occursin("num_states = 0", sol_mc_no_states_string)
+
+    # save_states = Val(false) with keep_runs_results = Val(true) returns an empty per-trajectory
+    # (matrix-shaped) container, consistent with the saved-states layout.
+    sol_mc_no_states_runs = mcsolve(
+        H,
+        ψ0,
+        tlist,
+        c_ops,
+        e_ops = e_ops,
+        progress_bar = Val(false),
+        ensemblealg = QuantumToolbox.EnsembleSerial(),
+        save_states = Val(false),
+        keep_runs_results = Val(true),
+    )
+    @test isempty(sol_mc_no_states_runs.states)
+    @test ndims(sol_mc_no_states_runs.states) == 2
 
     @test_throws ArgumentError mcsolve(H, ψ0, TESetup.tlist1, c_ops, progress_bar = Val(false))
     @test_throws ArgumentError mcsolve(H, ψ0, TESetup.tlist2, c_ops, progress_bar = Val(false))

--- a/test/core-test/time_evolution.jl
+++ b/test/core-test/time_evolution.jl
@@ -392,6 +392,7 @@ end
 end
 
 @testitem "mcsolve" setup = [TESetup] begin
+    using Random
     using SciMLOperators
     import SciMLOperators: ScaledOperator
     using Statistics
@@ -478,6 +479,33 @@ end
         "ODE alg.: $(sol_mc_states.alg)\n" *
         "abstol = $(sol_mc_states.abstol)\n" *
         "reltol = $(sol_mc_states.reltol)\n"
+
+    # save_states = Val(false) skips state assembly/averaging but keeps expectation values.
+    # Using the same seeded rng, the expectation values must be identical to a save_states = Val(true) run.
+    sol_mc_with_states = mcsolve(
+        H,
+        ψ0,
+        tlist,
+        c_ops,
+        e_ops = e_ops,
+        progress_bar = Val(false),
+        rng = MersenneTwister(1234),
+    )
+    sol_mc_no_states = mcsolve(
+        H,
+        ψ0,
+        tlist,
+        c_ops,
+        e_ops = e_ops,
+        progress_bar = Val(false),
+        save_states = Val(false),
+        rng = MersenneTwister(1234),
+    )
+    @test sol_mc_no_states.expect == sol_mc_with_states.expect
+    @test isempty(sol_mc_no_states.states)
+    @test isempty(average_states(sol_mc_no_states))
+    sol_mc_no_states_string = sprint((t, s) -> show(t, "text/plain", s), sol_mc_no_states)
+    @test occursin("num_states = 0", sol_mc_no_states_string)
 
     @test_throws ArgumentError mcsolve(H, ψ0, TESetup.tlist1, c_ops, progress_bar = Val(false))
     @test_throws ArgumentError mcsolve(H, ψ0, TESetup.tlist2, c_ops, progress_bar = Val(false))


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [ ] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [ ] Any code changes were done in a way that does not break public API.
- [ ] Appropriate tests were added and tested locally by running: `make test`.
- [ ] Any code changes should be `julia` formatted by running: `make format`.
- [ ] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [ ] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
`mcsolve` always assembled and (when `keep_runs_results = Val(false)`) trajectory-averaged the per-trajectory states after the trajectories finished. The averaging converts every saved ket to a density matrix via `ket2dm` (an O(dim^2) outer product) for all `ntraj * ntimes` states on a single thread, which can dominate the post-progress-bar finalization time even when the caller only wants expectation values.

Add a `save_states::Union{Val,Bool} = Val(true)` keyword that, when set to `Val(false)`, skips the state assembly/averaging entirely (`sol.states` is left empty). Expectation values are unaffected since they are computed by a separate saving callback. Dispatch is done through a `Val` so the path stays type stable.