### PR TITLE
Fix `multisite_operator` type inference issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
-- Improvement for `multisite_operator` ([#722], [#725]):
+- Improvement for `multisite_operator` ([#722], [#725], [#727]):
   - Add a convenient method when the Hilbert space dimension of all sites are equal.
   - Improve the documentation and docstring.
 - Efficient Jordan Wigner transformation for `fdestroy` and `fcreate`. ([#723])
@@ -525,3 +525,4 @@ Release date: 2024-11-13
 [#722]: https://github.com/qutip/QuantumToolbox.jl/issues/722
 [#723]: https://github.com/qutip/QuantumToolbox.jl/issues/723
 [#725]: https://github.com/qutip/QuantumToolbox.jl/issues/725
+[#727]: https://github.com/qutip/QuantumToolbox.jl/issues/727

--- a/src/qobj/functions.jl
+++ b/src/qobj/functions.jl
@@ -295,12 +295,12 @@ function multisite_operator(dims::AbstractVecOrTuple{T}, pairs::Pair{<:Integer, 
     isempty(pairs) && throw(ArgumentError("At least one Pair of `site-index => operator` must be provided."))
 
     N = length(dims) # total number of sites
-    sites_unsorted = collect(getfield.(pairs, :first))
+    sites_unsorted = [first(p) for p in pairs]
     all(i -> 1 <= i <= N, sites_unsorted) || throw(ArgumentError("There are totally $N-sites, so site indices must satisfy 1 ≤ i ≤ $N."))
 
     idxs = sortperm(sites_unsorted)
     _sites = sites_unsorted[idxs]
-    _ops = collect(getfield.(pairs, :second))[idxs]
+    _ops = [last(p) for p in pairs][idxs]
     _dims = collect(dims) # Use this instead of a Tuple, to avoid type instability when indexing on a slice
 
     sites, ops, ElType = _get_unique_sites_ops_type(_sites, _ops)
@@ -324,7 +324,7 @@ function multisite_operator(N::Union{Integer, Val}, pairs::Pair{<:Integer, <:Qua
     return multisite_operator(dims, pairs...)
 end
 
-function _get_unique_sites_ops_type(sites, ops)
+function _get_unique_sites_ops_type(sites::AbstractVector{<:Integer}, ops::AbstractVector{<:QuantumObject{Operator}})
     unique_sites = unique(sites)
     unique_ops = map(i -> prod(ops[findall(==(i), sites)]), unique_sites)
     T = mapreduce(eltype, promote_type, unique_ops)

--- a/test/core-test/quantum_objects.jl
+++ b/test/core-test/quantum_objects.jl
@@ -525,9 +525,10 @@
     end
 
     @testset "multisite operator" begin
+        dims = (3, 5, 4, 2)
         a = destroy(5)
         σy = sigmay()
-        M = multisite_operator((3, 5, 4, 2), 2 => a, 4 => σy)
+        M = multisite_operator(dims, 2 => a, 4 => σy)
         @test M == tensor(qeye(3), a, qeye(4), σy)
         @test eltype(M) == ComplexF64 # since promote_type(a, σy) == ComplexF64
 
@@ -549,12 +550,16 @@
         @test eltype(IAI) == Float16
         @test eltype(IAB) == eltype(AIB) == eltype(ABI) == Float32
 
-        dims = (3, 2, 4, 2)
         @test_throws ArgumentError multisite_operator(dims) # at least one Pair must be provided
         @test_throws ArgumentError multisite_operator(dims, 0 => sigmax()) # site index out of range
         @test_throws ArgumentError multisite_operator(dims, 5 => sigmax()) # site index out of range
         @test_throws ArgumentError multisite_operator(dims, 1 => Qobj(rand(2, 2))) # dims mismatch
         @test_throws ArgumentError multisite_operator(dims, 2 => Qobj(rand(2, 3))) # not endomorphic
+
+        @testset "Type Inference (multisite_operator)" begin
+            @inferred multisite_operator(Val(3), 2 => a)
+            @inferred multisite_operator(dims, 2 => a, 4 => σy)
+        end
     end
 
     @testset "expectation value" begin


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
This is a follow-up work for PR #722 and #725. This fixes the type-inference issue for `multisite_operator`.