### PR TITLE
Fix `mcsolve` error when both keyword arguments `e_ops` and `save_end=false` are specified.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add a convenient method when the Hilbert space dimension of all sites are equal.
   - Improve the documentation and docstring.
 - Efficient Jordan Wigner transformation for `fdestroy` and `fcreate`. ([#723])
+- Fix `mcsolve` error when both keyword arguments `e_ops` and `save_end=false` are specified. ([#728])
 
 ## [v0.47.0]
 Release date: 2026-05-19
@@ -525,3 +526,4 @@ Release date: 2024-11-13
 [#722]: https://github.com/qutip/QuantumToolbox.jl/issues/722
 [#723]: https://github.com/qutip/QuantumToolbox.jl/issues/723
 [#725]: https://github.com/qutip/QuantumToolbox.jl/issues/725
+[#728]: https://github.com/qutip/QuantumToolbox.jl/issues/728

--- a/src/time_evolution/time_evolution.jl
+++ b/src/time_evolution/time_evolution.jl
@@ -289,8 +289,10 @@ average_states(sol::TimeEvolutionMultiTrajSol{<:Vector{<:QuantumObject}}) = sol.
 
 # TODO: Check if broadcasting division ./ size(states, 1) is type stable
 _average_traj_states(states::Matrix{<:QuantumObject{Ket}}) =
+    size(states, 2) == 0 ? Vector{Base.promote_op(ket2dm, eltype(states))}() :
     map(x -> x / size(states, 1), dropdims(sum(ket2dm, states, dims = 1), dims = 1))
 _average_traj_states(states::Matrix{<:QuantumObject{ObjType}}) where {ObjType <: Union{Operator, OperatorKet}} =
+    size(states, 2) == 0 ? Vector{eltype(states)}() :
     map(x -> x / size(states, 1), dropdims(sum(states, dims = 1), dims = 1))
 
 @doc raw"""

--- a/test/core-test/time_evolution.jl
+++ b/test/core-test/time_evolution.jl
@@ -479,6 +479,13 @@ end
         "abstol = $(sol_mc_states.abstol)\n" *
         "reltol = $(sol_mc_states.reltol)\n"
 
+    # check that save_end = false works as expected
+    # the states at the end of each trajectory are not saved, but expectation values are still saved
+    sol_mc_save_end_false =
+        mcsolve(H, ψ0, tlist, c_ops, e_ops = e_ops, save_end = false, progress_bar = Val(false), ntraj = 5)
+    @test length(sol_mc_save_end_false.states) == length(sol_mc_save_end_false.times_states) == 0
+    @test size(sol_mc_save_end_false.expect) == (length(e_ops), length(tlist))
+
     @test_throws ArgumentError mcsolve(H, ψ0, TESetup.tlist1, c_ops, progress_bar = Val(false))
     @test_throws ArgumentError mcsolve(H, ψ0, TESetup.tlist2, c_ops, progress_bar = Val(false))
     @test_throws ArgumentError mcsolve(H, ψ0, TESetup.tlist3, c_ops, progress_bar = Val(false))


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
Fix `mcsolve` error when both keyword arguments `e_ops` and `save_end=false` are specified.

This PR should also fix the issue presented in PR #726.