### PR TITLE
Fix wrong ordering of filtered kronecker product in `liouvillian_dressed_nonsecular`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Improve the documentation and docstring.
 - Efficient Jordan Wigner transformation for `fdestroy` and `fcreate`. ([#723])
 - Fix `mcsolve` error when both keyword arguments `e_ops` and `save_end=false` are specified. ([#728])
+- Fix wrong order in filtered kronecker product in `liouvillian_dressed_nonsecular`. ([#729])
 
 ## [v0.47.0]
 Release date: 2026-05-19
@@ -528,3 +529,4 @@ Release date: 2024-11-13
 [#725]: https://github.com/qutip/QuantumToolbox.jl/issues/725
 [#727]: https://github.com/qutip/QuantumToolbox.jl/issues/727
 [#728]: https://github.com/qutip/QuantumToolbox.jl/issues/728
+[#729]: https://github.com/qutip/QuantumToolbox.jl/issues/729

--- a/src/time_evolution/liouvillian_dressed_nonsecular.jl
+++ b/src/time_evolution/liouvillian_dressed_nonsecular.jl
@@ -159,14 +159,14 @@ function _filtered_kron(A, B, E, σ, tol)
         jA = J_A[idxA]
         vA = V_A[idxA]
         for idxB in eachindex(V_B)
-            iT = I_B[idxB]
-            jT = J_B[idxB]
+            iB = I_B[idxB]
+            jB = J_B[idxB]
             vB = V_B[idxB]
-            Ωdiff = (E[iA] - E[jA]) - (E[iT] - E[jT])
+            Ωdiff = (E[iA] - E[jA]) - (E[iB] - E[jB])
             v = vA * vB * gaussian(Ωdiff, 0, σ)
             if abs(v) > tol
-                push!(I_out, iA + (iT - 1) * N)
-                push!(J_out, jA + (jT - 1) * N)
+                push!(I_out, iB + (iA - 1) * N)
+                push!(J_out, jB + (jA - 1) * N)
                 push!(V_out, v)
             end
         end

--- a/test/core-test/liouvillian_dressed_nonsecular.jl
+++ b/test/core-test/liouvillian_dressed_nonsecular.jl
@@ -35,9 +35,9 @@
     sx = sm + sp
     sz = sp * sm - sm * sp
 
-    H = 1 * a' * a + 1 * sz / 2 + 0.5 * (a + a') * sx
+    H = 1 * a' * a + 1 * sz / 2 + 0.5 * im * (a - a') * sx
 
-    fields = [sqrt(0.01) * (a + a'), sqrt(0.01) * sx]
+    fields = [sqrt(0.01) * im * (a - a'), sqrt(0.01) * sx]
     Tlist = [0, 0.0]
 
     E, U, L1 = liouvillian_dressed_nonsecular(H, fields, Tlist, N_trunc = N_trunc, tol = tol)
@@ -58,6 +58,11 @@
     L_gme_0 = liouvillian_dressed_nonsecular(H, fields, Tlist, tol = tol, σ_filter = 1.0e-14)[3]
     L_dr = dressed_liouvillian(H, fields, tol = tol)
     @test norm(L_gme_0.data - L_dr.data) / size(L_gme_0.data, 1) < 1.0e-8
+
+    # Test that the σ = ∞ and σ >> 1 limits give the same result
+    L1 = liouvillian_dressed_nonsecular(H, fields, Tlist, N_trunc = N_trunc, tol = tol, σ_filter = 1.0e5)[3]
+    L2 = liouvillian_dressed_nonsecular(H, fields, Tlist, N_trunc = N_trunc, tol = tol, σ_filter = Inf)[3]
+    @test norm(L1.data - L2.data) / size(L1.data, 1) < 1.0e-7
 
     H = 1 * a' * a + 1 * sz / 2 + 1.0e-5 * (a * sp + a' * sm)
 
@@ -87,7 +92,7 @@
 
             H = 1 * a' * a + 1 * sz / 2 + 0.5 * (a + a') * sx
 
-            fields = [sqrt(0.01) * (a + a'), sqrt(0.01) * sx]
+            fields = [sqrt(0.01) * im * (a - a'), sqrt(0.01) * sx]
             Tlist = [0, 0.01]
 
             @inferred liouvillian_dressed_nonsecular(H, fields, Tlist, N_trunc = N_trunc, tol = tol)


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
The `liouvillian_dressed_nonsecular` function is using a filtered method for `spre`, `spost` and `sprepost`. The previous methods were swapping the arguments order.

We didn't notice this so far because the eigenvalues of the Hamiltonian were real-valued. Here I have fixed it.