### PR TITLE
Add support to time-dependent collapse operators in `mcsolve`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
-
+- Add support for time-dependent collapse operators (`QobjEvo`) in `mcsolve`. ([#733])
 
 ## [v0.47.1]
 Release date: 2026-06-11
@@ -539,3 +539,4 @@ Release date: 2024-11-13
 [#727]: https://github.com/qutip/QuantumToolbox.jl/issues/727
 [#728]: https://github.com/qutip/QuantumToolbox.jl/issues/728
 [#729]: https://github.com/qutip/QuantumToolbox.jl/issues/729
+[#733]: https://github.com/qutip/QuantumToolbox.jl/issues/733

--- a/src/time_evolution/callback_helpers/mcsolve_callback_helpers.jl
+++ b/src/time_evolution/callback_helpers/mcsolve_callback_helpers.jl
@@ -15,7 +15,6 @@ _get_save_callback_idx(cb, ::Type{SaveFuncMCSolve}) = _mcsolve_has_continuous_ju
 ##
 struct LindbladJump{
         T1,
-        T2,
         RNGType <: AbstractRNG,
         RandT,
         CT <: AbstractVector,
@@ -25,7 +24,6 @@ struct LindbladJump{
         JTWIT,
     }
     c_ops::T1
-    c_ops_herm::T2
     traj_rng::RNGType
     random_n::RandT
     cache_mc::CT
@@ -39,7 +37,6 @@ end
 (f::LindbladJump)(integrator) = _lindblad_jump_affect!(
     integrator,
     f.c_ops,
-    f.c_ops_herm,
     f.traj_rng,
     f.random_n,
     f.cache_mc,
@@ -67,10 +64,10 @@ function _save_func_mcsolve(u, integrator, e_ops, iter, expvals)
 end
 
 function _generate_mcsolve_kwargs(ψ0, T, e_ops, tlist, c_ops, jump_callback, rng, kwargs)
-    c_ops_data = get_data.(c_ops)
-    c_ops_herm_data = map(op -> op' * op, c_ops_data)
-
     cache_mc = similar(ψ0.data, T)
+
+    c_ops_data = map(op -> get_data(cache_operator(QobjEvo(op), cache_mc)), c_ops)
+
     weights_mc = Vector{Float64}(undef, length(c_ops))
     cumsum_weights_mc = similar(weights_mc)
 
@@ -82,7 +79,6 @@ function _generate_mcsolve_kwargs(ψ0, T, e_ops, tlist, c_ops, jump_callback, rn
 
     _affect! = LindbladJump(
         c_ops_data,
-        c_ops_herm_data,
         rng,
         random_n,
         cache_mc,
@@ -121,7 +117,6 @@ end
 function _lindblad_jump_affect!(
         integrator,
         c_ops,
-        c_ops_herm,
         traj_rng,
         random_n,
         cache_mc,
@@ -132,14 +127,17 @@ function _lindblad_jump_affect!(
         col_times_which_idx,
     )
     ψ = integrator.u
+    p = integrator.p
+    t = integrator.t
 
     @inbounds for i in eachindex(weights_mc)
-        weights_mc[i] = real(dot(ψ, c_ops_herm[i], ψ))
+        c_ops[i](cache_mc, ψ, nothing, p, t)
+        weights_mc[i] = real(dot(cache_mc, cache_mc))
     end
     cumsum!(cumsum_weights_mc, weights_mc)
     r = rand(traj_rng) * sum(weights_mc)
     collapse_idx = getindex(1:length(weights_mc), findfirst(>(r), cumsum_weights_mc))
-    mul!(cache_mc, c_ops[collapse_idx], ψ)
+    c_ops[collapse_idx](cache_mc, ψ, nothing, p, t)
     normalize!(cache_mc)
     copyto!(integrator.u, cache_mc)
 
@@ -182,7 +180,7 @@ _mc_get_jump_callback(cb::DiscreteCallback) = cb
 ##
 
 #=
-    With this function we extract the c_ops and c_ops_herm from the LindbladJump `affect!` function of the callback of the integrator.
+    With this function we extract the c_ops from the LindbladJump `affect!` function of the callback of the integrator.
     This callback can be a DiscreteLindbladJumpCallback or a ContinuousLindbladJumpCallback.
 =#
 function _mcsolve_get_c_ops(integrator::AbstractODEIntegrator)
@@ -190,7 +188,7 @@ function _mcsolve_get_c_ops(integrator::AbstractODEIntegrator)
     if cb isa Nothing
         return nothing
     else
-        return cb.affect!.c_ops, cb.affect!.c_ops_herm
+        return cb.affect!.c_ops
     end
 end
 
@@ -258,9 +256,10 @@ function _similar_affect!(affect::LindbladJump, traj_rng)
     col_which = similar(affect.col_which)
     col_times_which_idx = Ref(1)
 
+    c_ops = map(op -> isconstant(op) ? op : deepcopy(op), affect.c_ops)
+
     return LindbladJump(
-        affect.c_ops,
-        affect.c_ops_herm,
+        c_ops,
         traj_rng,
         random_n,
         cache_mc,

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -86,7 +86,7 @@ If the environmental measurements register a quantum jump, the wave function und
 - `H`: Hamiltonian of the system ``\hat{H}``. It can be either a [`QuantumObject`](@ref), a [`QuantumObjectEvolution`](@ref), or a `Tuple` of operator-function pairs.
 - `ψ0`: Initial state of the system ``|\psi(0)\rangle``.
 - `tlist`: List of time points at which to save either the state or the expectation values of the system.
-- `c_ops`: List of collapse operators ``\{\hat{C}_n\}_n``. It can be either a `Vector` or a `Tuple`.
+- `c_ops`: List of collapse operators ``\{\hat{C}_n\}_n``. It can be either a `Vector` or a `Tuple`. Each element can be a [`QuantumObject`](@ref) or a [`QuantumObjectEvolution`](@ref) (for time-dependent collapse operators).
 - `e_ops`: List of operators for which to calculate expectation values. It can be either a `Vector` or a `Tuple`.
 - `params`: Parameters to pass to the solver. This argument is usually expressed as a `NamedTuple` or `AbstractVector` of parameters. For more advanced usage, any custom struct can be used.
 - `rng`: Random number generator for reproducibility.
@@ -192,7 +192,7 @@ If the environmental measurements register a quantum jump, the wave function und
 - `H`: Hamiltonian of the system ``\hat{H}``. It can be either a [`QuantumObject`](@ref), a [`QuantumObjectEvolution`](@ref), or a `Tuple` of operator-function pairs.
 - `ψ0`: Initial state of the system ``|\psi(0)\rangle``.
 - `tlist`: List of time points at which to save either the state or the expectation values of the system.
-- `c_ops`: List of collapse operators ``\{\hat{C}_n\}_n``. It can be either a `Vector` or a `Tuple`.
+- `c_ops`: List of collapse operators ``\{\hat{C}_n\}_n``. It can be either a `Vector` or a `Tuple`. Each element can be a [`QuantumObject`](@ref) or a [`QuantumObjectEvolution`](@ref) (for time-dependent collapse operators).
 - `e_ops`: List of operators for which to calculate expectation values. It can be either a `Vector` or a `Tuple`.
 - `params`: Parameters to pass to the solver. This argument is usually expressed as a `NamedTuple` or `AbstractVector` of parameters. For more advanced usage, any custom struct can be used.
 - `rng`: Random number generator for reproducibility.
@@ -325,7 +325,7 @@ If the environmental measurements register a quantum jump, the wave function und
 - `H`: Hamiltonian of the system ``\hat{H}``. It can be either a [`QuantumObject`](@ref), a [`QuantumObjectEvolution`](@ref), or a `Tuple` of operator-function pairs.
 - `ψ0`: Initial state of the system ``|\psi(0)\rangle``.
 - `tlist`: List of time points at which to save either the state or the expectation values of the system.
-- `c_ops`: List of collapse operators ``\{\hat{C}_n\}_n``. It can be either a `Vector` or a `Tuple`.
+- `c_ops`: List of collapse operators ``\{\hat{C}_n\}_n``. It can be either a `Vector` or a `Tuple`. Each element can be a [`QuantumObject`](@ref) or a [`QuantumObjectEvolution`](@ref) (for time-dependent collapse operators).
 - `alg`: The algorithm to use for the ODE solver. Default to `DP5()`.
 - `e_ops`: List of operators for which to calculate expectation values. It can be either a `Vector` or a `Tuple`.
 - `params`: Parameters to pass to the solver. This argument is usually expressed as a `NamedTuple` or `AbstractVector` of parameters. For more advanced usage, any custom struct can be used.

--- a/src/time_evolution/time_evolution_dynamical.jl
+++ b/src/time_evolution/time_evolution_dynamical.jl
@@ -528,7 +528,7 @@ function _DSF_mcsolve_Affect!(integrator)
     # c_ops0 = params.c_ops
 
     e_ops0 = _get_e_ops(integrator, SaveFuncMCSolve)
-    c_ops0, c_ops0_herm = _mcsolve_get_c_ops(integrator)
+    c_ops0 = _mcsolve_get_c_ops(integrator)
 
     copyto!(ψt, integrator.u)
     normalize!(ψt)
@@ -571,13 +571,17 @@ function _DSF_mcsolve_Affect!(integrator)
 
     ## By copying the data, we are assuming that the variables are Vectors and not Tuple
     @. e_ops0 = get_data(e_ops2)
-    @. c_ops0 = get_data(c_ops2)
-    c_ops0_herm .= map(op -> op' * op, c_ops0)
+    # The stored collapse operators are (constant) `MatrixOperator`s. We rebuild them with
+    # the shifted data instead of `copyto!`-ing into them, since the sparsity pattern of the
+    # shifted operators may differ from the original ones.
+    @inbounds for i in eachindex(c_ops0)
+        c_ops0[i] = MatrixOperator(get_data(c_ops2[i]))
+    end
 
-    H_nh = convert(eltype(ψt), 0.5im) * sum(c_ops0_herm)
+    H_nh = convert(eltype(ψt), 0.5im) * mapreduce(op -> (d = get_data(op); d' * d), +, c_ops2)
     # By doing this, we are assuming that the system is time-independent and f is a ScaledOperator
     # of the form -1im * (H - H_nh)
-    copyto!(integrator.f.f.L, H(op_l2, dsf_params).data - H_nh)
+    copyto!(integrator.f.f.L, get_data(H(op_l2, dsf_params)) - H_nh)
     return derivative_discontinuity!(integrator, true)
 end
 

--- a/test/core-test/time_evolution.jl
+++ b/test/core-test/time_evolution.jl
@@ -1065,6 +1065,93 @@ end
     @test sol_me.expect ≈ sol_me_td3.expect atol = 1.0e-6 * length(tlist)
 end
 
+@testitem "Time-dependent collapse operators" setup = [TESetup] begin
+    rng = TESetup.rng
+
+    # ---- Analytic benchmark: a single qubit with a time-dependent decay rate ----
+    # For C(t) = √γ(t) σ⁻, the excited-state population obeys dP/dt = -γ(t) P, hence
+    # P(t) = exp(-∫₀ᵗ γ(t')dt'). With γ(t) = γ₀(1 + ½cos(ωt)) (strictly positive),
+    # ∫₀ᵗ γ = γ₀(t + ½ sin(ωt)/ω).
+    σ = sigmam()
+    pq = (γ0 = 0.4, ω = 0.5)
+    fq(p, t) = sqrt(p.γ0 * (1 + 0.5 * cos(p.ω * t)))
+    c_op_q = QobjEvo(σ, fq)
+    Hq = 0 * qeye(2)
+    ψe = basis(2, 0)  # excited state
+    Pe = σ' * σ       # excited-state projector
+    tlist_q = range(0, 10, 100)
+    analytic = @. exp(-pq.γ0 * (tlist_q + 0.5 * sin(pq.ω * tlist_q) / pq.ω))
+
+    sol_me_q = mesolve(Hq, ψe, tlist_q, (c_op_q,), e_ops = (Pe,), params = pq, progress_bar = Val(false))
+    @test real.(sol_me_q.expect[1, :]) ≈ analytic atol = 1.0e-4 # mesolve is essentially exact here
+
+    sol_mc_q =
+        mcsolve(Hq, ψe, tlist_q, (c_op_q,), e_ops = (Pe,), params = pq, ntraj = 1000, rng = rng, progress_bar = Val(false))
+    @test real.(sol_mc_q.expect[1, :]) ≈ analytic atol = 1.0e-2 * length(tlist_q)
+
+    # ---- mesolve ↔ mcsolve consistency on a richer system (decay + heating) ----
+    N = TESetup.N
+    a = TESetup.a
+    σm = TESetup.σm
+    H = TESetup.H
+    e_ops = TESetup.e_ops
+    γ = TESetup.γ
+    nth = TESetup.nth
+
+    ψ0 = kron(fock(N, 1), fock(2, 1)) # start with excitation so the dynamics are nontrivial
+    tlist = range(0, 10 / γ, 100)
+
+    # Time-dependent decay (`f_dn`) and heating (`f_up`) rates; `p` is passed as `params`.
+    # The heating channels keep the total jump rate strictly positive (no dark state),
+    # mirroring the constant `c_ops` of the test setup.
+    p = (γ = γ, nth = nth, ω = 0.5)
+    f_dn(p, t) = sqrt(p.γ * (1 + p.nth) * (1 + 0.5 * sin(p.ω * t)^2))
+    f_up(p, t) = sqrt(p.γ * p.nth * (1 + 0.5 * sin(p.ω * t)^2))
+    c_ops_td = (QobjEvo(a, f_dn), QobjEvo(a', f_up), QobjEvo(σm, f_dn), QobjEvo(σm', f_up))
+
+    sol_me = mesolve(H, ψ0, tlist, c_ops_td, e_ops = e_ops, params = p, progress_bar = Val(false))
+    sol_mc = mcsolve(H, ψ0, tlist, c_ops_td, e_ops = e_ops, params = p, ntraj = 500, rng = rng, progress_bar = Val(false))
+    @test sol_me.expect ≈ sol_mc.expect atol = 1.0e-2 * length(tlist)
+
+    # A mix of constant and time-dependent collapse operators must also work
+    c_ops_mixed = (QobjEvo(a, f_dn), sqrt(γ * nth) * a', sqrt(γ * (1 + nth)) * σm, sqrt(γ * nth) * σm')
+    sol_me_mix = mesolve(H, ψ0, tlist, c_ops_mixed, e_ops = e_ops, params = p, progress_bar = Val(false))
+    sol_mc_mix =
+        mcsolve(H, ψ0, tlist, c_ops_mixed, e_ops = e_ops, params = p, ntraj = 500, rng = rng, progress_bar = Val(false))
+    @test sol_me_mix.expect ≈ sol_mc_mix.expect atol = 1.0e-2 * length(tlist)
+
+    @testset "Type Inference (mesolve)" begin
+        @inferred mesolveProblem(Hq, ψe, tlist_q, (c_op_q,), e_ops = (Pe,), params = pq, progress_bar = Val(false))
+        @inferred mesolve(Hq, ψe, tlist_q, (c_op_q,), e_ops = (Pe,), params = pq, progress_bar = Val(false))
+        @inferred mesolve(H, ψ0, tlist, c_ops_td, e_ops = e_ops, params = p, progress_bar = Val(false))
+    end
+
+    @testset "Type Inference (mcsolve)" begin
+        @inferred mcsolveEnsembleProblem(
+            H,
+            ψ0,
+            tlist,
+            c_ops_td,
+            ntraj = 5,
+            e_ops = e_ops,
+            params = p,
+            progress_bar = Val(false),
+            rng = rng,
+        )
+        @inferred mcsolve(
+            H,
+            ψ0,
+            tlist,
+            c_ops_td,
+            ntraj = 5,
+            e_ops = e_ops,
+            params = p,
+            progress_bar = Val(false),
+            rng = rng,
+        )
+    end
+end
+
 @testitem "mcsolve, ssesolve and smesolve reproducibility" setup = [TESetup] begin
     using Random
 


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
This PR adds the support to time-dependent collapse operators in `mcsolve`.
