### PR TITLE
Support `lastindex` for quantum objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
-
+- Support `Base.lastindex` (`end`) for quantum objects. ([#736])
 
 ## [v0.47.1]
 Release date: 2026-06-11
@@ -539,3 +539,4 @@ Release date: 2024-11-13
 [#727]: https://github.com/qutip/QuantumToolbox.jl/issues/727
 [#728]: https://github.com/qutip/QuantumToolbox.jl/issues/728
 [#729]: https://github.com/qutip/QuantumToolbox.jl/issues/729
+[#736]: https://github.com/qutip/QuantumToolbox.jl/issues/736

--- a/src/qobj/quantum_object_base.jl
+++ b/src/qobj/quantum_object_base.jl
@@ -98,6 +98,9 @@ Base.copy(A::AbstractQuantumObject) = get_typename_wrapper(A)(copy(A.data), A.ty
 Base.getindex(A::AbstractQuantumObject, inds...) = getindex(A.data, inds...)
 Base.setindex!(A::AbstractQuantumObject, val, inds...) = setindex!(A.data, val, inds...)
 
+Base.lastindex(A::AbstractQuantumObject) = lastindex(A.data)
+Base.lastindex(A::AbstractQuantumObject, d::Int) = lastindex(A.data, d)
+
 @doc raw"""
     eltype(A::AbstractQuantumObject)
 

--- a/test/core-test/quantum_objects.jl
+++ b/test/core-test/quantum_objects.jl
@@ -258,6 +258,15 @@
         @test issymmetric(Y) == false
         @test issymmetric(Z) == true
 
+        # indexing
+        ψ = rand_ket(N)
+        ρ = rand_dm(N)
+        @test ψ[end] == ψ.data[end]
+        @test ρ[end] == ρ[N^2] == ρ.data[end]
+        @test ρ[end, 1] == ρ[N, 1] == ρ.data[N, 1]
+        @test ρ[1, end] == ρ[1, N] == ρ.data[1, N]
+        @test ρ[end, end] == ρ[N, N] == ρ.data[N, N]
+
         # diag
         @test diag(a, 1) ≈ [sqrt(i) for i in 1:(N - 1)]
         @test diag(a_d, -1) == [sqrt(i) for i in 1:(N - 1)]


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
This PR extend the methods of `Base.lastindex` for quantum objects, in order to support `end`-index access.