### PR TITLE
Only force `tstops = tlist` in `ssesolve`/`smesolve` when storing measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -555,4 +555,3 @@ Release date: 2024-11-13
 [#745]: https://github.com/qutip/QuantumToolbox.jl/issues/745
 [#747]: https://github.com/qutip/QuantumToolbox.jl/issues/747
 [#748]: https://github.com/qutip/QuantumToolbox.jl/issues/748
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add documentation about arbitrary precision computations. ([#745])
 - Fix `e_ops` expectation values being always stored as `ComplexF64` in `sesolve`, `mesolve`, `mcsolve`, `ssesolve`, and `smesolve`. They now follow the element type of the problem, so that arbitrary precision solutions return `sol.expect` with the requested precision instead of silently narrowing it to double precision. ([#745])
 - Fix `sesolve_map` and `mesolve_map` sharing mutable e_ops-saving callback state across trajectories when a custom `prob_func` is supplied, which could throw a `BoundsError` or produce incorrect results. Both now accept a `safetycopy` keyword (smart-defaulting to `true` for a custom `prob_func`, `false` otherwise) mirroring `SciMLBase.EnsembleProblem`. ([#645], [#747])
+- Fix the number of solver steps in `ssesolve` and `smesolve` scaling with `length(tlist)` whenever `e_ops` or a progress bar was given. `tstops = tlist` was being forced for every callback, but it is only required by `store_measurement = true` (to reconstruct `dW/dt`); expectation values are recorded by interpolation, as in `mesolve`. Solves with `e_ops` are now up to several times faster and their cost no longer depends on the output resolution. ([#748])
 
 ## [v0.47.2]
 Release date: 2026-06-21
@@ -553,4 +554,5 @@ Release date: 2024-11-13
 [#736]: https://github.com/qutip/QuantumToolbox.jl/issues/736
 [#745]: https://github.com/qutip/QuantumToolbox.jl/issues/745
 [#747]: https://github.com/qutip/QuantumToolbox.jl/issues/747
+[#748]: https://github.com/qutip/QuantumToolbox.jl/issues/748
 

--- a/src/time_evolution/callback_helpers/callback_helpers.jl
+++ b/src/time_evolution/callback_helpers/callback_helpers.jl
@@ -6,8 +6,8 @@ This file contains helper functions for callbacks. The affect! function are defi
 
 abstract type AbstractSaveFunc end
 
-function _merge_tstops(kwargs, prob_is_const::Bool, tlist)
-    if prob_is_const
+function _merge_tstops(kwargs, skip_tstops::Bool, tlist)
+    if skip_tstops
         return kwargs
     else
         tstops = haskey(kwargs, :tstops) ? unique!(sort!(vcat(tlist, kwargs.tstops))) : tlist
@@ -37,7 +37,7 @@ function _generate_stochastic_kwargs(
 
     # Ensure that the noise is stored in tlist. # TODO: Fix this directly in DiffEqNoiseProcess.jl
     # See https://github.com/SciML/DiffEqNoiseProcess.jl/issues/214 for example
-    kwargs2 = _merge_tstops(kwargs, false, tlist) # set 'prob_is_const = false' to force add 'tstops = tlist'
+    kwargs2 = _merge_tstops(kwargs, !getVal(store_measurement), tlist)
 
     if SF === SaveFuncSSESolve
         cb_normalize = _ssesolve_generate_normalize_cb()

--- a/src/time_evolution/smesolve.jl
+++ b/src/time_evolution/smesolve.jl
@@ -56,14 +56,14 @@ Above, ``\hat{C}_i`` represent the collapse operators related to pure dissipatio
 - `params`: `NullParameters` of parameters to pass to the solver.
 - `rng`: Random number generator for reproducibility.
 - `progress_bar`: Whether to show the progress bar. Using non-`Val` types might lead to type instabilities.
-- `store_measurement`: Whether to store the measurement expectation values. Default is `Val(false)`.
+- `store_measurement`: Whether to store the measurement expectation values. Default is `Val(false)`. Note that setting this to `Val(true)` forces the solver to stop at every time point in `tlist`, which can make the solve slower, with a cost growing with `length(tlist)`.
 - `kwargs`: The keyword arguments for the ODEProblem.
 
 # Notes
 
 - The states will be saved depend on the keyword argument `saveat` in `kwargs`.
 - If `e_ops` is empty, the default value of `saveat=tlist` (saving the states corresponding to `tlist`), otherwise, `saveat=[tlist[end]]` (only save the final state). You can also specify `e_ops` and `saveat` separately.
-- The default tolerances in `kwargs` are given as `reltol=1e-2` and `abstol=1e-2`.
+- The default tolerances in `kwargs` are given as `reltol=2e-3` and `abstol=1e-3`.
 - For more details about `kwargs` please refer to [`DifferentialEquations.jl` (Keyword Arguments)](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
 
 !!! tip "Performance Tip"
@@ -198,14 +198,14 @@ Above, ``\hat{C}_i`` represent the collapse operators related to pure dissipatio
 - `prob_func`: Function to use for generating the SDEProblem.
 - `output_func`: a `Tuple` containing the `Function` to use for generating the output of a single trajectory, the (optional) `Progress` object, and the (optional) `RemoteChannel` object.
 - `progress_bar`: Whether to show the progress bar. Using non-`Val` types might lead to type instabilities.
-- `store_measurement`: Whether to store the measurement expectation values. Default is `Val(false)`.
+- `store_measurement`: Whether to store the measurement expectation values. Default is `Val(false)`. Note that setting this to `Val(true)` forces the solver to stop at every time point in `tlist`, which can make the solve slower, with a cost growing with `length(tlist)`.
 - `kwargs`: The keyword arguments for the ODEProblem.
 
 # Notes
 
 - The states will be saved depend on the keyword argument `saveat` in `kwargs`.
 - If `e_ops` is empty, the default value of `saveat=tlist` (saving the states corresponding to `tlist`), otherwise, `saveat=[tlist[end]]` (only save the final state). You can also specify `e_ops` and `saveat` separately.
-- The default tolerances in `kwargs` are given as `reltol=1e-2` and `abstol=1e-2`.
+- The default tolerances in `kwargs` are given as `reltol=2e-3` and `abstol=1e-3`.
 - For more details about `kwargs` please refer to [`DifferentialEquations.jl` (Keyword Arguments)](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
 
 !!! tip "Performance Tip"
@@ -333,14 +333,14 @@ Above, ``\hat{C}_i`` represent the collapse operators related to pure dissipatio
 - `output_func`: a `Tuple` containing the `Function` to use for generating the output of a single trajectory, the (optional) `Progress` object, and the (optional) `RemoteChannel` object.
 - `progress_bar`: Whether to show the progress bar. Using non-`Val` types might lead to type instabilities.
 - `keep_runs_results`: Whether to save the results of each trajectory. Default to `Val(false)`.
-- `store_measurement`: Whether to store the measurement expectation values. Default is `Val(false)`.
+- `store_measurement`: Whether to store the measurement expectation values. Default is `Val(false)`. Note that setting this to `Val(true)` forces the solver to stop at every time point in `tlist`, which can make the solve slower, with a cost growing with `length(tlist)`.
 - `kwargs`: The keyword arguments for the ODEProblem.
 
 # Notes
 
 - The states will be saved depend on the keyword argument `saveat` in `kwargs`.
 - If `e_ops` is empty, the default value of `saveat=tlist` (saving the states corresponding to `tlist`), otherwise, `saveat=[tlist[end]]` (only save the final state). You can also specify `e_ops` and `saveat` separately.
-- The default tolerances in `kwargs` are given as `reltol=1e-2` and `abstol=1e-2`.
+- The default tolerances in `kwargs` are given as `reltol=2e-3` and `abstol=1e-3`.
 - For more details about `kwargs` please refer to [`DifferentialEquations.jl` (Keyword Arguments)](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
 
 !!! tip "Performance Tip"

--- a/src/time_evolution/ssesolve.jl
+++ b/src/time_evolution/ssesolve.jl
@@ -57,14 +57,14 @@ Above, ``\hat{S}_n`` are the stochastic collapse operators and ``dW_n(t)`` is th
 - `params`: `NullParameters` of parameters to pass to the solver.
 - `rng`: Random number generator for reproducibility.
 - `progress_bar`: Whether to show the progress bar. Using non-`Val` types might lead to type instabilities.
-- `store_measurement`: Whether to store the measurement results. Default is `Val(false)`.
+- `store_measurement`: Whether to store the measurement results. Default is `Val(false)`. Note that setting this to `Val(true)` forces the solver to stop at every time point in `tlist`, which can make the solve slower, with a cost growing with `length(tlist)`.
 - `kwargs`: The keyword arguments for the ODEProblem.
 
 # Notes
 
 - The states will be saved depend on the keyword argument `saveat` in `kwargs`.
 - If `e_ops` is empty, the default value of `saveat=tlist` (saving the states corresponding to `tlist`), otherwise, `saveat=[tlist[end]]` (only save the final state). You can also specify `e_ops` and `saveat` separately.
-- The default tolerances in `kwargs` are given as `reltol=1e-2` and `abstol=1e-2`.
+- The default tolerances in `kwargs` are given as `reltol=2e-3` and `abstol=1e-3`.
 - For more details about `kwargs` please refer to [`DifferentialEquations.jl` (Keyword Arguments)](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
 
 !!! tip "Performance Tip"
@@ -200,14 +200,14 @@ Above, ``\hat{S}_n`` are the stochastic collapse operators and  ``dW_n(t)`` is t
 - `prob_func`: Function to use for generating the SDEProblem.
 - `output_func`: a `Tuple` containing the `Function` to use for generating the output of a single trajectory, the (optional) `Progress` object, and the (optional) `RemoteChannel` object.
 - `progress_bar`: Whether to show the progress bar. Using non-`Val` types might lead to type instabilities.
-- `store_measurement`: Whether to store the measurement results. Default is `Val(false)`.
+- `store_measurement`: Whether to store the measurement results. Default is `Val(false)`. Note that setting this to `Val(true)` forces the solver to stop at every time point in `tlist`, which can make the solve slower, with a cost growing with `length(tlist)`.
 - `kwargs`: The keyword arguments for the ODEProblem.
 
 # Notes
 
 - The states will be saved depend on the keyword argument `saveat` in `kwargs`.
 - If `e_ops` is empty, the default value of `saveat=tlist` (saving the states corresponding to `tlist`), otherwise, `saveat=[tlist[end]]` (only save the final state). You can also specify `e_ops` and `saveat` separately.
-- The default tolerances in `kwargs` are given as `reltol=1e-2` and `abstol=1e-2`.
+- The default tolerances in `kwargs` are given as `reltol=2e-3` and `abstol=1e-3`.
 - For more details about `kwargs` please refer to [`DifferentialEquations.jl` (Keyword Arguments)](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
 
 !!! tip "Performance Tip"
@@ -335,14 +335,14 @@ Above, ``\hat{S}_n`` are the stochastic collapse operators and ``dW_n(t)`` is th
 - `output_func`: a `Tuple` containing the `Function` to use for generating the output of a single trajectory, the (optional) `Progress` object, and the (optional) `RemoteChannel` object.
 - `progress_bar`: Whether to show the progress bar. Using non-`Val` types might lead to type instabilities.
 - `keep_runs_results`: Whether to save the results of each trajectory. Default to `Val(false)`.
-- `store_measurement`: Whether to store the measurement results. Default is `Val(false)`.
+- `store_measurement`: Whether to store the measurement results. Default is `Val(false)`. Note that setting this to `Val(true)` forces the solver to stop at every time point in `tlist`, which can make the solve slower, with a cost growing with `length(tlist)`.
 - `kwargs`: The keyword arguments for the ODEProblem.
 
 # Notes
 
 - The states will be saved depend on the keyword argument `saveat` in `kwargs`.
 - If `e_ops` is empty, the default value of `saveat=tlist` (saving the states corresponding to `tlist`), otherwise, `saveat=[tlist[end]]` (only save the final state). You can also specify `e_ops` and `saveat` separately.
-- The default tolerances in `kwargs` are given as `reltol=1e-2` and `abstol=1e-2`.
+- The default tolerances in `kwargs` are given as `reltol=2e-3` and `abstol=1e-3`.
 - For more details about `alg` please refer to [`DifferentialEquations.jl` (SDE Solvers)](https://docs.sciml.ai/DiffEqDocs/stable/solvers/sde_solve/)
 - For more details about `kwargs` please refer to [`DifferentialEquations.jl` (Keyword Arguments)](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
 


### PR DESCRIPTION
### Problem

The number of solver steps in `ssesolve`/`smesolve` scaled with `length(tlist)` whenever `e_ops` (or a progress bar) was given — 5.5x more steps at 501 output points than at 100, for identical physics. `mesolve` was unaffected.

### Cause

`_generate_stochastic_kwargs` forced `tstops = tlist` for *every* callback. Those tstops exist only for `_homodyne_dWdt!`, which assumes the noise process has a sample at each `tlist` point — i.e. only when `store_measurement = true`. Expectation values are recorded by the interpolating `FunctionCallingCallback`, exactly as in `mesolve`, and never needed them.

Dense tstops are expensive for an adaptive SDE solver: tstop clipping destroys the proposed `dt`, and `SRIW1` needs ~9 steps per interval to grow it back. This reproduces upstream with no QuantumToolbox involved — a plain linear `SDEProblem` goes from 349 to 4469 steps purely from `tstops = range(0, 10, 501)`.

### Fix

Gate the forced tstops on `store_measurement`. `_merge_tstops`'s `prob_is_const` argument is renamed to `skip_tstops`, since it now carries two meanings; the four `isconstant(...)` call sites are unchanged. Time-dependent Hamiltonians still get `tstops = tlist` as before.

Also corrects the documented default SDE tolerances (`reltol=1e-2`/`abstol=1e-2` → the actual `2e-3`/`1e-3`).

### Result

Steps for the reporter's MWE (N=50), median over 10 trajectories:

| npoints | before | after |
|---|---|---|
| 100 | 979 | 820 |
| 251 | 2244 | 746 |
| 501 | 4341 | 779 |

Accuracy is unchanged: against the exact `mesolve` solution over 800 trajectories, the max deviation is 0.060 / 0.065 / 0.069 at 101 / 251 / 501 points (peak ⟨n⟩ = 9.5) — flat, so the interpolated recording introduces no resolution-dependent bias. `store_measurement = true` keeps its tstops and its results are unchanged.

Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)