### PR TITLE
Default `ContinuousLindbladJumpCallback` to `interp_points = 0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
 - [lib] Introduce `QuantumToolboxCore` library. ([#686])
+- Speed up `mcsolve` by changing the default of `ContinuousLindbladJumpCallback` from `interp_points = 10` to `interp_points = 0`. Since `mcsolve` propagates the unnormalized state under the non-Hermitian effective Hamiltonian, `d⟨ψ|ψ⟩/dt = -Σₙ⟨ψ|Ĉₙ†Ĉₙ|ψ⟩ ≤ 0`, so the norm decreases monotonically between jumps and the jump condition can change sign at most once per solver step. Checking only the step endpoints is therefore exact, whereas the previous default also evaluated the ODE interpolant at 9 interior points on every accepted step. Trajectories are bit-for-bit unchanged; the driven Jaynes-Cummings benchmark gets `1.2x` to `1.6x` faster, with the largest gains at small Hilbert space dimensions. Pass `interp_points > 0` to restore the old behaviour, which is only needed if a deliberately non-Hermitian `H` breaks the monotonicity of the norm.
 
 ## [v0.47.3]
 Release date: 2026-07-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [lib] Introduce `QuantumToolboxCore` library. ([#686], [#753])
 - [lib] Move more basic functionalities to `QuantumToolboxCore` library. ([#751])
 - Add support for matrix form `liouvillian`, `liouvillian_dressed_nonsecular` and `mesolve` time evolution. By setting `matrix_form = Val(true)`, the density matrix is not vectorized, which improves the memory efficiency for large systems. The superoperators are now stored through SciMLOperators.jl objects. ([#707])
-- Speed up `mcsolve` by changing the default of `ContinuousLindbladJumpCallback` from `interp_points = 10` to `interp_points = 0`. Since `mcsolve` propagates the unnormalized state under the non-Hermitian effective Hamiltonian, `d⟨ψ|ψ⟩/dt = -Σₙ⟨ψ|Ĉₙ†Ĉₙ|ψ⟩ ≤ 0`, so the norm decreases monotonically between jumps and the jump condition can change sign at most once per solver step. Checking only the step endpoints is therefore exact, whereas the previous default also evaluated the ODE interpolant at 9 interior points on every accepted step. Trajectories are bit-for-bit unchanged; the driven Jaynes-Cummings benchmark gets `1.2x` to `1.6x` faster, with the largest gains at small Hilbert space dimensions. Pass `interp_points > 0` to restore the old behaviour, which is only needed if a deliberately non-Hermitian `H` breaks the monotonicity of the norm.
+- Speed up `mcsolve` by changing the default of `ContinuousLindbladJumpCallback` from `interp_points = 10` to `interp_points = 0`. Since `mcsolve` propagates the unnormalized state under the non-Hermitian effective Hamiltonian, `d⟨ψ|ψ⟩/dt = -Σₙ⟨ψ|Ĉₙ†Ĉₙ|ψ⟩ ≤ 0`, so the norm decreases monotonically between jumps and the jump condition can change sign at most once per solver step. Checking only the step endpoints is therefore exact, whereas the previous default also evaluated the ODE interpolant at 9 interior points on every accepted step. Trajectories are bit-for-bit unchanged; the driven Jaynes-Cummings benchmark gets `1.2x` to `1.6x` faster, with the largest gains at small Hilbert space dimensions. Pass `interp_points > 0` to restore the old behaviour, which is only needed if a deliberately non-Hermitian `H` breaks the monotonicity of the norm. ([#752])
 
 ## [v0.47.3]
 Release date: 2026-07-28
@@ -567,4 +567,5 @@ Release date: 2024-11-13
 [#747]: https://github.com/qutip/QuantumToolbox.jl/issues/747
 [#748]: https://github.com/qutip/QuantumToolbox.jl/issues/748
 [#751]: https://github.com/qutip/QuantumToolbox.jl/issues/751
+[#752]: https://github.com/qutip/QuantumToolbox.jl/issues/752
 [#753]: https://github.com/qutip/QuantumToolbox.jl/issues/753

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [lib] Introduce `QuantumToolboxCore` library. ([#686], [#753])
 - [lib] Move more basic functionalities to `QuantumToolboxCore` library. ([#751])
 - Add support for matrix form `liouvillian`, `liouvillian_dressed_nonsecular` and `mesolve` time evolution. By setting `matrix_form = Val(true)`, the density matrix is not vectorized, which improves the memory efficiency for large systems. The superoperators are now stored through SciMLOperators.jl objects. ([#707])
+- Speed up `mcsolve` by changing the default of `ContinuousLindbladJumpCallback` from `interp_points = 10` to `interp_points = 0`. Since `mcsolve` propagates the unnormalized state under the non-Hermitian effective Hamiltonian, `d⟨ψ|ψ⟩/dt = -Σₙ⟨ψ|Ĉₙ†Ĉₙ|ψ⟩ ≤ 0`, so the norm decreases monotonically between jumps and the jump condition can change sign at most once per solver step. Checking only the step endpoints is therefore exact, whereas the previous default also evaluated the ODE interpolant at 9 interior points on every accepted step. Trajectories are bit-for-bit unchanged; the driven Jaynes-Cummings benchmark gets `1.2x` to `1.6x` faster, with the largest gains at small Hilbert space dimensions. Pass `interp_points > 0` to restore the old behaviour, which is only needed if a deliberately non-Hermitian `H` breaks the monotonicity of the norm.
 
 ## [v0.47.3]
 Release date: 2026-07-28

--- a/docs/src/resources/api.md
+++ b/docs/src/resources/api.md
@@ -236,6 +236,8 @@ TimeEvolutionProblem
 TimeEvolutionSol
 TimeEvolutionMCSol
 TimeEvolutionStochasticSol
+ContinuousLindbladJumpCallback
+DiscreteLindbladJumpCallback
 average_states
 average_expect
 std_expect

--- a/docs/src/resources/api.md
+++ b/docs/src/resources/api.md
@@ -263,6 +263,8 @@ TimeEvolutionProblem
 TimeEvolutionSol
 TimeEvolutionMCSol
 TimeEvolutionStochasticSol
+ContinuousLindbladJumpCallback
+DiscreteLindbladJumpCallback
 average_states
 average_expect
 std_expect

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -90,7 +90,7 @@ If the environmental measurements register a quantum jump, the wave function und
 - `e_ops`: List of operators for which to calculate expectation values. It can be either a `Vector` or a `Tuple`.
 - `params`: Parameters to pass to the solver. This argument is usually expressed as a `NamedTuple` or `AbstractVector` of parameters. For more advanced usage, any custom struct can be used.
 - `rng`: Random number generator for reproducibility.
-- `jump_callback`: The Jump Callback type: Discrete or Continuous. The default is `ContinuousLindbladJumpCallback()`, which is more precise.
+- `jump_callback`: The Jump Callback type: [`ContinuousLindbladJumpCallback`](@ref) or [`DiscreteLindbladJumpCallback`](@ref). The default is `ContinuousLindbladJumpCallback()`, which is more precise.
 - `kwargs`: The keyword arguments for the ODEProblem.
 
 # Notes
@@ -198,7 +198,7 @@ If the environmental measurements register a quantum jump, the wave function und
 - `rng`: Random number generator for reproducibility.
 - `ntraj`: Number of trajectories to use.
 - `ensemblealg`: Ensemble algorithm to use. Default to `EnsembleThreads()`.
-- `jump_callback`: The Jump Callback type: Discrete or Continuous. The default is `ContinuousLindbladJumpCallback()`, which is more precise.
+- `jump_callback`: The Jump Callback type: [`ContinuousLindbladJumpCallback`](@ref) or [`DiscreteLindbladJumpCallback`](@ref). The default is `ContinuousLindbladJumpCallback()`, which is more precise.
 - `progress_bar`: Whether to show the progress bar. Using non-`Val` types might lead to type instabilities.
 - `prob_func`: Function to use for generating the ODEProblem.
 - `output_func`: a `Tuple` containing the `Function` to use for generating the output of a single trajectory, the (optional) `Progress` object, and the (optional) `RemoteChannel` object.
@@ -332,7 +332,7 @@ If the environmental measurements register a quantum jump, the wave function und
 - `rng`: Random number generator for reproducibility.
 - `ntraj`: Number of trajectories to use.
 - `ensemblealg`: Ensemble algorithm to use. Default to `EnsembleThreads()`.
-- `jump_callback`: The Jump Callback type: Discrete or Continuous. The default is `ContinuousLindbladJumpCallback()`, which is more precise.
+- `jump_callback`: The Jump Callback type: [`ContinuousLindbladJumpCallback`](@ref) or [`DiscreteLindbladJumpCallback`](@ref). The default is `ContinuousLindbladJumpCallback()`, which is more precise.
 - `progress_bar`: Whether to show the progress bar. Using non-`Val` types might lead to type instabilities.
 - `prob_func`: Function to use for generating the ODEProblem.
 - `output_func`: a `Tuple` containing the `Function` to use for generating the output of a single trajectory, the (optional) `Progress` object, and the (optional) `RemoteChannel` object.

--- a/src/time_evolution/time_evolution.jl
+++ b/src/time_evolution/time_evolution.jl
@@ -344,13 +344,57 @@ std_expect(::TimeEvolutionMultiTrajSol{TS, Nothing}) where {TS} = nothing
 
 abstract type LindbladJumpCallbackType end
 
+@doc raw"""
+    ContinuousLindbladJumpCallback(; interp_points::Int = 0)
+
+Quantum jump detection for [`mcsolve`](@ref) based on root-finding. The jump time is located by a
+`ContinuousCallback`, which brackets the step in which the norm ``\langle \psi | \psi \rangle``
+crosses below its randomly drawn target and then bisects to find the crossing.
+
+# Arguments
+
+- `interp_points`: Number of interior interpolation points checked per solver step when looking for the crossing. The default `0` checks only the two step endpoints.
+
+# Notes
+
+The default `interp_points = 0` is exact, not an approximation. Since ``|\psi(t)\rangle`` is
+propagated under the non-Hermitian effective Hamiltonian
+``\hat{H}_{\textrm{eff}} = \hat{H} - \frac{i}{2} \sum_n \hat{C}_n^\dagger \hat{C}_n``, its norm obeys
+
+```math
+\frac{d}{dt} \langle \psi | \psi \rangle = - \sum_n \langle \psi | \hat{C}_n^\dagger \hat{C}_n | \psi \rangle \leq 0 ,
+```
+
+so the norm decreases monotonically between jumps and can cross the target at most once per step.
+The crossing is therefore always visible from the sign of the condition at the two step endpoints,
+and the interior points added by `interp_points > 0` are redundant work repeated on every accepted
+step.
+
+Set `interp_points > 0` only if that monotonicity is broken, which requires supplying a
+deliberately non-Hermitian ``\hat{H}`` that makes the norm increase.
+
+See also [`DiscreteLindbladJumpCallback`](@ref) and [`mcsolve`](@ref).
+"""
 struct ContinuousLindbladJumpCallback <: LindbladJumpCallbackType
     interp_points::Int
 end
 
+@doc raw"""
+    DiscreteLindbladJumpCallback()
+
+Quantum jump detection for [`mcsolve`](@ref) based on a `DiscreteCallback`. The jump is applied at
+the end of the first solver step in which the norm ``\langle \psi | \psi \rangle`` is found to be
+below its randomly drawn target, without root-finding.
+
+This is cheaper per step than [`ContinuousLindbladJumpCallback`](@ref), but less precise: the
+recorded jump time is the step boundary rather than the actual crossing, so its accuracy is limited
+by the solver step size.
+
+See also [`ContinuousLindbladJumpCallback`](@ref) and [`mcsolve`](@ref).
+"""
 struct DiscreteLindbladJumpCallback <: LindbladJumpCallbackType end
 
-ContinuousLindbladJumpCallback(; interp_points::Int = 10) = ContinuousLindbladJumpCallback(interp_points)
+ContinuousLindbladJumpCallback(; interp_points::Int = 0) = ContinuousLindbladJumpCallback(interp_points)
 
 function _check_tlist(tlist, T::Type)
     tlist2 = convert(Vector{T}, tlist) # Convert it to support GPUs and avoid type instabilities for OrdinaryDiffEq.jl

--- a/src/time_evolution/time_evolution.jl
+++ b/src/time_evolution/time_evolution.jl
@@ -355,9 +355,7 @@ abstract type LindbladJumpCallbackType end
 @doc raw"""
     ContinuousLindbladJumpCallback(; interp_points::Int = 0)
 
-Quantum jump detection for [`mcsolve`](@ref) based on root-finding. The jump time is located by a
-`ContinuousCallback`, which brackets the step in which the norm ``\langle \psi | \psi \rangle``
-crosses below its randomly drawn target and then bisects to find the crossing.
+Quantum jump detection for [`mcsolve`](@ref) based on root-finding. The jump time is located by a `ContinuousCallback`, which brackets the step in which the norm ``\langle \psi | \psi \rangle`` crosses below its randomly drawn target and then bisects to find the crossing.
 
 # Arguments
 
@@ -365,21 +363,15 @@ crosses below its randomly drawn target and then bisects to find the crossing.
 
 # Notes
 
-The default `interp_points = 0` is exact, not an approximation. Since ``|\psi(t)\rangle`` is
-propagated under the non-Hermitian effective Hamiltonian
-``\hat{H}_{\textrm{eff}} = \hat{H} - \frac{i}{2} \sum_n \hat{C}_n^\dagger \hat{C}_n``, its norm obeys
+The default `interp_points = 0` is exact, not an approximation. Since ``|\psi(t)\rangle`` is propagated under the non-Hermitian effective Hamiltonian ``\hat{H}_{\textrm{eff}} = \hat{H} - \frac{i}{2} \sum_n \hat{C}_n^\dagger \hat{C}_n``, its norm obeys
 
 ```math
 \frac{d}{dt} \langle \psi | \psi \rangle = - \sum_n \langle \psi | \hat{C}_n^\dagger \hat{C}_n | \psi \rangle \leq 0 ,
 ```
 
-so the norm decreases monotonically between jumps and can cross the target at most once per step.
-The crossing is therefore always visible from the sign of the condition at the two step endpoints,
-and the interior points added by `interp_points > 0` are redundant work repeated on every accepted
-step.
+so the norm decreases monotonically between jumps and can cross the target at most once per step. The crossing is therefore always visible from the sign of the condition at the two step endpoints, and the interior points added by `interp_points > 0` are redundant work repeated on every accepted step.
 
-Set `interp_points > 0` only if that monotonicity is broken, which requires supplying a
-deliberately non-Hermitian ``\hat{H}`` that makes the norm increase.
+Set `interp_points > 0` only if that monotonicity is broken, which requires supplying a deliberately non-Hermitian ``\hat{H}`` that makes the norm increase.
 
 See also [`DiscreteLindbladJumpCallback`](@ref) and [`mcsolve`](@ref).
 """
@@ -390,13 +382,9 @@ end
 @doc raw"""
     DiscreteLindbladJumpCallback()
 
-Quantum jump detection for [`mcsolve`](@ref) based on a `DiscreteCallback`. The jump is applied at
-the end of the first solver step in which the norm ``\langle \psi | \psi \rangle`` is found to be
-below its randomly drawn target, without root-finding.
+Quantum jump detection for [`mcsolve`](@ref) based on a `DiscreteCallback`. The jump is applied at the end of the first solver step in which the norm ``\langle \psi | \psi \rangle`` is found to be below its randomly drawn target, without root-finding.
 
-This is cheaper per step than [`ContinuousLindbladJumpCallback`](@ref), but less precise: the
-recorded jump time is the step boundary rather than the actual crossing, so its accuracy is limited
-by the solver step size.
+This is cheaper per step than [`ContinuousLindbladJumpCallback`](@ref), but less precise: the recorded jump time is the step boundary rather than the actual crossing, so its accuracy is limited by the solver step size.
 
 See also [`ContinuousLindbladJumpCallback`](@ref) and [`mcsolve`](@ref).
 """

--- a/src/time_evolution/time_evolution.jl
+++ b/src/time_evolution/time_evolution.jl
@@ -383,8 +383,8 @@ deliberately non-Hermitian ``\hat{H}`` that makes the norm increase.
 
 See also [`DiscreteLindbladJumpCallback`](@ref) and [`mcsolve`](@ref).
 """
-struct ContinuousLindbladJumpCallback <: LindbladJumpCallbackType
-    interp_points::Int
+Base.@kwdef struct ContinuousLindbladJumpCallback <: LindbladJumpCallbackType
+    interp_points::Int = 0
 end
 
 @doc raw"""
@@ -401,8 +401,6 @@ by the solver step size.
 See also [`ContinuousLindbladJumpCallback`](@ref) and [`mcsolve`](@ref).
 """
 struct DiscreteLindbladJumpCallback <: LindbladJumpCallbackType end
-
-ContinuousLindbladJumpCallback(; interp_points::Int = 0) = ContinuousLindbladJumpCallback(interp_points)
 
 function _check_tlist(tlist, T::Type)
     tlist2 = convert(Vector{T}, tlist) # Convert it to support GPUs and avoid type instabilities for OrdinaryDiffEq.jl

--- a/src/time_evolution/time_evolution.jl
+++ b/src/time_evolution/time_evolution.jl
@@ -352,13 +352,57 @@ std_expect(::TimeEvolutionMultiTrajSol{TS, Nothing}) where {TS} = nothing
 
 abstract type LindbladJumpCallbackType end
 
+@doc raw"""
+    ContinuousLindbladJumpCallback(; interp_points::Int = 0)
+
+Quantum jump detection for [`mcsolve`](@ref) based on root-finding. The jump time is located by a
+`ContinuousCallback`, which brackets the step in which the norm ``\langle \psi | \psi \rangle``
+crosses below its randomly drawn target and then bisects to find the crossing.
+
+# Arguments
+
+- `interp_points`: Number of interior interpolation points checked per solver step when looking for the crossing. The default `0` checks only the two step endpoints.
+
+# Notes
+
+The default `interp_points = 0` is exact, not an approximation. Since ``|\psi(t)\rangle`` is
+propagated under the non-Hermitian effective Hamiltonian
+``\hat{H}_{\textrm{eff}} = \hat{H} - \frac{i}{2} \sum_n \hat{C}_n^\dagger \hat{C}_n``, its norm obeys
+
+```math
+\frac{d}{dt} \langle \psi | \psi \rangle = - \sum_n \langle \psi | \hat{C}_n^\dagger \hat{C}_n | \psi \rangle \leq 0 ,
+```
+
+so the norm decreases monotonically between jumps and can cross the target at most once per step.
+The crossing is therefore always visible from the sign of the condition at the two step endpoints,
+and the interior points added by `interp_points > 0` are redundant work repeated on every accepted
+step.
+
+Set `interp_points > 0` only if that monotonicity is broken, which requires supplying a
+deliberately non-Hermitian ``\hat{H}`` that makes the norm increase.
+
+See also [`DiscreteLindbladJumpCallback`](@ref) and [`mcsolve`](@ref).
+"""
 struct ContinuousLindbladJumpCallback <: LindbladJumpCallbackType
     interp_points::Int
 end
 
+@doc raw"""
+    DiscreteLindbladJumpCallback()
+
+Quantum jump detection for [`mcsolve`](@ref) based on a `DiscreteCallback`. The jump is applied at
+the end of the first solver step in which the norm ``\langle \psi | \psi \rangle`` is found to be
+below its randomly drawn target, without root-finding.
+
+This is cheaper per step than [`ContinuousLindbladJumpCallback`](@ref), but less precise: the
+recorded jump time is the step boundary rather than the actual crossing, so its accuracy is limited
+by the solver step size.
+
+See also [`ContinuousLindbladJumpCallback`](@ref) and [`mcsolve`](@ref).
+"""
 struct DiscreteLindbladJumpCallback <: LindbladJumpCallbackType end
 
-ContinuousLindbladJumpCallback(; interp_points::Int = 10) = ContinuousLindbladJumpCallback(interp_points)
+ContinuousLindbladJumpCallback(; interp_points::Int = 0) = ContinuousLindbladJumpCallback(interp_points)
 
 function _check_tlist(tlist, T::Type)
     tlist2 = convert(Vector{T}, tlist) # Convert it to support GPUs and avoid type instabilities for OrdinaryDiffEq.jl


### PR DESCRIPTION
## Checklist

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [ ] Appropriate tests were added and tested locally by running: `make test`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

## Description

Changes the default of `ContinuousLindbladJumpCallback` from `interp_points = 10` to `interp_points = 0`, which makes `mcsolve` **1.2x to 1.6x** faster while producing bit-for-bit identical trajectories.

`mcsolve` propagates the *unnormalized* state under the non-Hermitian effective Hamiltonian $\hat{H}_{\textrm{eff}} = \hat{H} - \frac{i}{2}\sum_n \hat{C}_n^\dagger \hat{C}_n$, so the norm obeys, exactly,

$$\frac{d}{dt}\langle\psi|\psi\rangle = i\langle\psi|(\hat{H}_{\textrm{eff}}^\dagger - \hat{H}_{\textrm{eff}})|\psi\rangle = -\sum_n \langle\psi|\hat{C}_n^\dagger \hat{C}_n|\psi\rangle \leq 0 .$$

The norm is therefore **monotonically decreasing between jumps**, so the jump condition `random_n[] - real(dot(u, u))` is monotonically non-decreasing and can change sign at most once per solver step. A crossing is always visible from the sign of the condition at the two step endpoints.

`interp_points = 10` made `DiffEqBase` run

```julia
ts = range(integrator.tprev, stop = integrator.t, length = callback.interp_points)
for i in 2:length(ts)   # 9 interpolant evaluations + 9 dot(u, u)
```

on essentially every accepted step, searching for a sign change that provably cannot hide between the endpoints. Setting `interp_points = 0` skips that scan entirely; the root-finding that locates the exact jump time is unaffected.

This holds for time-dependent `H` and time-dependent `c_ops` too, since all three `_mcsolve_make_Heff_QobjEvo` branches put exactly $-\frac{i}{2}\sum_n \hat{C}_n^\dagger \hat{C}_n$ into the anti-Hermitian part.

### Benchmarks

Driven Jaynes-Cummings model (the system already used in `benchmarks/timeevolution.jl`: cavity + qubit, 3 collapse operators, `e_ops = [a' * a, σz]`), 100 trajectories, `EnsembleSerial`, identical `rng` seed. Julia 1.10, 4-core Xeon @ 2.80GHz:

| Hilbert dimension | `interp_points = 10` (old) | `interp_points = 0` (new) | speedup |
| ----------------- | -------------------------- | ------------------------- | ------- |
| 10                | 0.0623 s                   | 0.0397 s                  | 1.57x   |
| 40                | 0.1870 s                   | 0.1236 s                  | 1.51x   |
| 100               | 0.3244 s                   | 0.2691 s                  | 1.21x   |

The gain shrinks as the Hilbert space grows, as expected: an interpolant evaluation is $O(N)$ while the matrix-vector products that dominate a step grow faster, so the fixed per-step scanning overhead is progressively better amortized. Allocation counts are unchanged (the scan uses a preallocated cache).

### Equivalence

Same system, same seed, 10 trajectories, **336 jumps** total:

- identical number of jumps per trajectory
- identical `col_which` (same collapse operator selected every time)
- `max |Δt|` between `col_times` = **0.0** — the recorded jump times are bit-for-bit identical

This is stronger than strictly required. The two settings bracket the root over different intervals before bisecting, so agreement only to the root-finder tolerance would have been acceptable; in practice both bisections converge to the same floating-point value.

## Related issues or PRs

None.

## Additional context

**Why no new tests.** The change is a default-value change whose entire justification is that the output is unchanged, and that is verified above at the strongest level available (bit-for-bit identical jump times and collapse choices). The existing suite already covers both code paths: `test/core-test/time_evolution.jl` exercises `DiscreteLindbladJumpCallback` explicitly and the continuous default everywhere else.

**The escape hatch is retained.** `interp_points > 0` still works and is documented. The only way to break the monotonicity argument is to supply a deliberately non-Hermitian `H` whose anti-Hermitian part makes the norm grow, which is outside the documented contract of `mcsolve` but is cheap to keep supported.

**Why the continuous callback stays the default.** `interp_points = 0` does *not* reduce `ContinuousLindbladJumpCallback` to `DiscreteLindbladJumpCallback`. The continuous callback still brackets `[tprev, t]`, bisects on the ODE interpolant to find the exact crossing time `t*`, rewinds the integrator to `t*` (`LeftRootFind`) and applies the collapse to `ψ(t*)`. The discrete callback does none of that: it fires at the step endpoint at which the norm is first *found* to be below target. Measured on a damped cavity with an identical seed, discrete jump times are late by `0.23` on average (max `0.39`) and the delay is never negative, and across 8 independent 500-trajectory ensembles the discrete unravelling is further from the `mesolve` reference in 8/8 cases (mean error `0.0146` vs `0.0118`). It is ~19% cheaper per run, which is the tradeoff it already offered before this PR.

**Drive-by:** added docstrings for `ContinuousLindbladJumpCallback` and `DiscreteLindbladJumpCallback`, which were exported but undocumented, and registered them in `docs/src/resources/api.md`.

**Not fixed here:** `src/time_evolution/ssesolve.jl:199` documents a `jump_callback` argument that `ssesolve` does not accept — a pre-existing copy-paste leftover, left alone to keep this PR focused.

---
_Generated by [Claude Code](https://claude.ai/code)_