### PR TITLE
[lib] Use `tensor` and `⊗` defined in `TensorCore.jl`.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,7 +18,7 @@ steps:
             - ".buildkite/pipeline.yml"
             - ".buildkite/CUDA_Ext.yml"
             - "src/**"
-            - "lib/QuantumToolboxCore"
+            - "lib/QuantumToolboxCore/**"
             - "test/runtests.jl"
             - "test/ext-test/gpu/**"
           target: ".buildkite/CUDA_Ext.yml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [lib] Introduce `QuantumToolboxCore` library. ([#686], [#753])
 - [lib] Move more basic functionalities to `QuantumToolboxCore` library. ([#751])
+- [lib] Use `tensor` and `⊗` defined in `TensorCore.jl`. ([#764], [#765])
 
 ## [v0.47.3]
 Release date: 2026-07-28
@@ -565,3 +566,5 @@ Release date: 2024-11-13
 [#748]: https://github.com/qutip/QuantumToolbox.jl/issues/748
 [#751]: https://github.com/qutip/QuantumToolbox.jl/issues/751
 [#753]: https://github.com/qutip/QuantumToolbox.jl/issues/753
+[#764]: https://github.com/qutip/QuantumToolbox.jl/issues/764
+[#765]: https://github.com/qutip/QuantumToolbox.jl/issues/765

--- a/lib/QuantumToolboxCore/Project.toml
+++ b/lib/QuantumToolboxCore/Project.toml
@@ -10,6 +10,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+TensorCore = "62fd8b95-f654-4bbd-a8a5-9c27f68ccd50"
 
 [weakdeps]
 CUDACore = "bd0ed864-bdfe-4181-a5ed-ce625a5fdea2"
@@ -32,4 +33,5 @@ Random = "1"
 SciMLOperators = "1.12"
 SparseArrays = "1"
 StaticArraysCore = "1"
+TensorCore = "0.1.1"
 julia = "1.10"

--- a/lib/QuantumToolboxCore/src/QuantumToolboxCore.jl
+++ b/lib/QuantumToolboxCore/src/QuantumToolboxCore.jl
@@ -5,12 +5,16 @@ using SparseArrays
 using LinearAlgebra
 import LinearAlgebra: checksquare
 
+# JuliaMath libraries
+import TensorCore: TensorCore, tensor, ⊗
+
 # other dependencies (in alphabetical order)
 import Base: AbstractVecOrTuple
 import FillArrays: Eye
 import Random: AbstractRNG, default_rng
 import StaticArraysCore: SVector, MVector
 
+# SciML
 import SciMLOperators:
     SciMLOperators,
     cache_operator,
@@ -32,6 +36,9 @@ export ishermitian, issymmetric, isposdef, dot, tr, svdvals, norm, normalize, no
 
 ## SparseArrays
 export permute
+
+## TensorCore
+export tensor, ⊗
 
 ## SciMLOperators
 export cache_operator, iscached, isconstant

--- a/lib/QuantumToolboxCore/src/qobj/functions.jl
+++ b/lib/QuantumToolboxCore/src/qobj/functions.jl
@@ -142,8 +142,8 @@ to_sparse_if_needed(::Val{needed}, A::Union{QuantumObject, AbstractArray}, tol::
 
 @doc raw"""
     kron(A::AbstractQuantumObject, B::AbstractQuantumObject, ...)
-    tensor(A::AbstractQuantumObject, B::AbstractQuantumObject, ...)
-    ⊗(A::AbstractQuantumObject, B::AbstractQuantumObject, ...)
+    TensorCore.tensor(A::AbstractQuantumObject, B::AbstractQuantumObject, ...)
+    TensorCore.⊗(A::AbstractQuantumObject, B::AbstractQuantumObject, ...)
     A ⊗ B
 
 Returns the [Kronecker product](https://en.wikipedia.org/wiki/Kronecker_product) ``\hat{A} \otimes \hat{B} \otimes \cdots``.
@@ -173,6 +173,8 @@ julia> a.dims, O.dims
 (([20], [20]), ([20, 20], [20, 20]))
 ```
 """
+Base.kron, TensorCore.tensor # add the same docstring to both methods
+
 Base.kron(A::AbstractQuantumObject) = A
 
 # kron for two quantum objects A and B
@@ -204,6 +206,13 @@ function Base.kron(A::Vector{<:AbstractQuantumObject})
     @warn "`tensor(A)` or `kron(A)` with `A` is a `Vector` can hurt performance. Try to use `tensor(A...)` or `kron(A...)` instead."
     return kron(A...)
 end
+
+# Add methods to TensorCore.jl
+# Note that
+#   const ⊗ = tensor
+# is defined in TensorCore.jl already, so we only need to overload tensor for AbstractQuantumObject here
+TensorCore.tensor(A::AbstractQuantumObject...) = kron(A...)
+TensorCore.tensor(A::Vector{<:AbstractQuantumObject}) = kron(A)
 
 @doc raw"""
     multisite_operator(dims::Union{AbstractVecOrTuple,Integer,Val}, pairs::Pair{Integer,QuantumObject{Operator}}...)

--- a/lib/QuantumToolboxCore/src/qobj/synonyms.jl
+++ b/lib/QuantumToolboxCore/src/qobj/synonyms.jl
@@ -5,7 +5,6 @@ Synonyms of the functions for QuantumObject
 export Qobj, QobjEvo, shape, isherm
 export trans, dag, matrix_element, unit
 export basis
-export tensor, ⊗
 export qeye, qeye_like, qzero_like
 export vector_to_operator, operator_to_vector
 export sqrtm, logm, expm, sinm, cosm
@@ -50,9 +49,6 @@ Supports the following inputs:
 matrix_element(i, A, j) = dot(i, A, j)
 
 const unit = normalize
-
-const tensor = kron
-const ⊗ = kron
 
 const qeye = eye
 

--- a/lib/QuantumToolboxCore/test/quantum_objects.jl
+++ b/lib/QuantumToolboxCore/test/quantum_objects.jl
@@ -468,15 +468,27 @@
     end
 
     @testset "tensor" begin
+        # the following functions acts the same:
+        #   - Base.kron
+        #   - TensorCore.tensor
+        #   - TensorCore.⊗
         σx = sigmax()
-        X3 = kron(σx, σx, σx)
-        @test tensor(σx) == kron(σx)
-        @test tensor(fill(σx, 3)...) == X3
-        X_warn = @test_logs (
+        X_tuple = (σx, σx, σx)
+        X_full = kron(X_tuple...)
+        @test kron(σx) == tensor(σx) == ⊗(σx)
+        @test X_full == tensor(X_tuple...) == σx ⊗ σx ⊗ σx == ⊗(X_tuple...)
+
+        # warnings
+        X_vector = [σx, σx, σx]
+        X_warn_kron = @test_logs (
             :warn,
             "`tensor(A)` or `kron(A)` with `A` is a `Vector` can hurt performance. Try to use `tensor(A...)` or `kron(A...)` instead.",
-        ) tensor(fill(σx, 3))
-        @test X_warn == X3
+        ) kron(X_vector)
+        X_warn_tensor = @test_logs (
+            :warn,
+            "`tensor(A)` or `kron(A)` with `A` is a `Vector` can hurt performance. Try to use `tensor(A...)` or `kron(A...)` instead.",
+        ) tensor(X_vector)
+        @test X_warn_kron == X_warn_tensor == X_full
     end
 
     @testset "projection" begin


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
As the discussions in issue #764 and https://github.com/qojulia/SecondQuantizedAlgebra.jl/issues/238 .

I think we can use `JuliaMath/TensorCore.jl` as dependency since it's a very stable and light-weighted package.

## Related issues or PRs
fix #764