### PR TITLE
Show extension information in `versioninfo`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,7 +18,7 @@ steps:
             - ".buildkite/pipeline.yml"
             - ".buildkite/CUDA_Ext.yml"
             - "src/**"
-            - "lib/QuantumToolboxCore"
+            - "lib/QuantumToolboxCore/**"
             - "test/runtests.jl"
             - "test/ext-test/gpu/**"
           target: ".buildkite/CUDA_Ext.yml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [lib] Introduce `QuantumToolboxCore` library. ([#686], [#753])
 - [lib] Move more basic functionalities to `QuantumToolboxCore` library. ([#751])
 - Add support for matrix form `liouvillian`, `liouvillian_dressed_nonsecular` and `mesolve` time evolution. By setting `matrix_form = Val(true)`, the density matrix is not vectorized, which improves the memory efficiency for large systems. The superoperators are now stored through SciMLOperators.jl objects. ([#707])
+- Show extension information in `versioninfo`. ([#767])
 
 ## [v0.47.3]
 Release date: 2026-07-28
@@ -567,3 +568,4 @@ Release date: 2024-11-13
 [#748]: https://github.com/qutip/QuantumToolbox.jl/issues/748
 [#751]: https://github.com/qutip/QuantumToolbox.jl/issues/751
 [#753]: https://github.com/qutip/QuantumToolbox.jl/issues/753
+[#767]: https://github.com/qutip/QuantumToolbox.jl/issues/767

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [lib] Introduce `QuantumToolboxCore` library. ([#686], [#753])
 - [lib] Move more basic functionalities to `QuantumToolboxCore` library. ([#751])
-- Add support for matrix form `liouvillian`, `liouvillian_dressed_nonsecular` and `mesolve` time evolution. By setting `matrix_form = Val(true)`, the density matrix is not vectorized, which improves the memory efficiency for large systems. The superoperators are now stored through SciMLOperators.jl objects. ([#707])
 - Show extension information in `versioninfo`. ([#767])
+- Add support for matrix form `liouvillian`, `liouvillian_dressed_nonsecular` and `mesolve` time evolution. By setting `matrix_form = Val(true)`, the density matrix is not vectorized, which improves the memory efficiency for large systems. The superoperators are now stored through SciMLOperators.jl objects. ([#707])
 
 ## [v0.47.3]
 Release date: 2026-07-28

--- a/lib/QuantumToolboxCore/ext/QuantumToolboxCoreCUDAExt.jl
+++ b/lib/QuantumToolboxCore/ext/QuantumToolboxCoreCUDAExt.jl
@@ -106,4 +106,12 @@ end
 QuantumToolboxCore._sparse_similar(A::CuSparseMatrixCSC, args...) = sparse(args..., fmt = :csc)
 QuantumToolboxCore._sparse_similar(A::CuSparseMatrixCSR, args...) = sparse(args..., fmt = :csr)
 
+function __init__()
+    # register to QuantumToolboxCore.EXT_PKGS
+    (CUDACore ∉ QuantumToolboxCore.EXT_PKGS) && push!(QuantumToolboxCore.EXT_PKGS, CUDACore)
+    (cuSPARSE ∉ QuantumToolboxCore.EXT_PKGS) && push!(QuantumToolboxCore.EXT_PKGS, cuSPARSE)
+
+    return nothing
+end
+
 end

--- a/lib/QuantumToolboxCore/ext/QuantumToolboxCoreGPUArraysExt.jl
+++ b/lib/QuantumToolboxCore/ext/QuantumToolboxCoreGPUArraysExt.jl
@@ -2,9 +2,8 @@ module QuantumToolboxCoreGPUArraysExt
 
 using QuantumToolboxCore
 
-import GPUArrays: AbstractGPUArray, AbstractGPUSparseArray, dense_array_type
-import KernelAbstractions
-import KernelAbstractions: @kernel, @Const, @index, get_backend, synchronize
+import GPUArrays: GPUArrays, AbstractGPUArray, AbstractGPUSparseArray, dense_array_type
+import KernelAbstractions: KernelAbstractions, @kernel, @Const, @index, get_backend, synchronize
 
 QuantumToolboxCore.to_dense(::Type{T1}, A::AbstractGPUArray{T2}) where {T1 <: Number, T2 <: Number} = T1.(A)
 QuantumToolboxCore.to_dense(A::AbstractGPUSparseArray) = dense_array_type(typeof(A))(A)
@@ -32,6 +31,14 @@ function QuantumToolboxCore._map_trace(A::AbstractGPUArray{T, 4}) where {T}
     KernelAbstractions.synchronize(backend)
 
     return B
+end
+
+function __init__()
+    # register to QuantumToolboxCore.EXT_PKGS
+    (GPUArrays ∉ QuantumToolboxCore.EXT_PKGS) && push!(QuantumToolboxCore.EXT_PKGS, GPUArrays)
+    (KernelAbstractions ∉ QuantumToolboxCore.EXT_PKGS) && push!(QuantumToolboxCore.EXT_PKGS, KernelAbstractions)
+
+    return nothing
 end
 
 end

--- a/lib/QuantumToolboxCore/src/versioninfo.jl
+++ b/lib/QuantumToolboxCore/src/versioninfo.jl
@@ -46,7 +46,7 @@ function pkginfo(io::IO = stdout)
 
     # dependencies
     if !isempty(DEP_PKGS)
-        println(io, SINGLE_SEPARATION_LINE, "dependencies:")
+        println(io, SINGLE_SEPARATION_LINE, "Dependencies:")
         for pkg in DEP_PKGS
             println(io, rpad(pkg, maxLen, " "), " Ver. ", all_pkgs_ver[idx])
             idx += 1
@@ -55,7 +55,7 @@ function pkginfo(io::IO = stdout)
 
     # triggered extensions
     if !isempty(EXT_PKGS)
-        println(io, SINGLE_SEPARATION_LINE, "triggered extensions for:")
+        println(io, SINGLE_SEPARATION_LINE, "Triggered extensions:")
         for pkg in EXT_PKGS
             println(io, rpad(pkg, maxLen, " "), " Ver. ", all_pkgs_ver[idx])
             idx += 1

--- a/lib/QuantumToolboxCore/src/versioninfo.jl
+++ b/lib/QuantumToolboxCore/src/versioninfo.jl
@@ -5,6 +5,7 @@ Reusable version information helpers for QuantumToolbox libraries.
 # Registry of all loaded QuantumToolbox libraries, populated via __init__ in each library.
 const QT_LIBRARIES = Module[]
 const DEP_PKGS = Module[]
+const EXT_PKGS = Module[]
 
 # separation lines
 const SEPARATION_LINE_LENGTH = 36
@@ -12,16 +13,21 @@ const SINGLE_SEPARATION_LINE = repeat("-", SEPARATION_LINE_LENGTH) * "\n"
 const DOUBLE_SEPARATION_LINE = repeat("=", SEPARATION_LINE_LENGTH) * "\n"
 
 raw"""
-    QuantumToolboxCore.pkginfo(io::IO=stdout; pkgs::Vector{Module} = Module[])
+    QuantumToolboxCore.pkginfo(io::IO=stdout)
 
-Command line output of version numbers for given vector of packages: `pkgs`.
+Command line output of version numbers for:
+
+- QuantumToolbox libraries
+- Dependencies
+- Triggered extensions
 """
-function pkginfo(io::IO = stdout; pkgs::Vector{Module} = Module[], split_after::Union{Nothing, Int} = nothing)
-    pkg_ver_list = map(pkgversion, pkgs)
+function pkginfo(io::IO = stdout)
+
+    all_pkgs = vcat(QT_LIBRARIES, DEP_PKGS, EXT_PKGS)
+    all_pkgs_ver = map(pkgversion, all_pkgs)
 
     # maximum string length of package names (5 refer to "Julia")
-    pkgs_is_empty = isempty(pkgs)
-    maxLen = pkgs_is_empty ? 5 : max(5, maximum(length ∘ string, pkgs))
+    maxLen = max(5, maximum(length ∘ string, all_pkgs))
 
     print(
         io,
@@ -29,11 +35,33 @@ function pkginfo(io::IO = stdout; pkgs::Vector{Module} = Module[], split_after::
         DOUBLE_SEPARATION_LINE,
     )
     println(io, rpad("Julia", maxLen, " "), " Ver. ", VERSION) # print Julia version first
-    pkgs_is_empty || print(io, SINGLE_SEPARATION_LINE)
-    for (idx, (pkg, pkg_ver)) in enumerate(zip(pkgs, pkg_ver_list))
-        println(io, rpad(pkg, maxLen, " "), " Ver. ", pkg_ver)
-        !isnothing(split_after) && (idx == split_after) && (idx < length(pkgs)) && print(io, SINGLE_SEPARATION_LINE)
+
+    idx = 1  # index for all_pkgs_ver iteration
+
+    # QuantumToolbox libraries
+    for pkg in QT_LIBRARIES
+        println(io, rpad(pkg, maxLen, " "), " Ver. ", all_pkgs_ver[idx])
+        idx += 1
     end
+
+    # dependencies
+    if !isempty(DEP_PKGS)
+        println(io, SINGLE_SEPARATION_LINE, "dependencies:")
+        for pkg in DEP_PKGS
+            println(io, rpad(pkg, maxLen, " "), " Ver. ", all_pkgs_ver[idx])
+            idx += 1
+        end
+    end
+
+    # triggered extensions
+    if !isempty(EXT_PKGS)
+        println(io, SINGLE_SEPARATION_LINE, "triggered extensions for:")
+        for pkg in EXT_PKGS
+            println(io, rpad(pkg, maxLen, " "), " Ver. ", all_pkgs_ver[idx])
+            idx += 1
+        end
+    end
+
     print(io, "\n")
     return nothing
 end
@@ -75,7 +103,7 @@ function _print_versioninfo(io::IO = stdout)
         "    Alberto Mercurio and Yi-Te Huang\n",
     )
 
-    pkginfo(io; pkgs = vcat(QT_LIBRARIES, DEP_PKGS), split_after = length(QT_LIBRARIES))
+    pkginfo(io)
     sysinfo(io)
 
     println(


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
This PR add `QuantumToolboxCore.EXT_PKGS` to register triggered extensions. And print those information in `versioninfo`.

The current output of `versioninfo` with triggered extension looks like:

```julia
using QuantumToolbox, CUDA
QuantumToolbox.versioninfo()
```
```
 QuantumToolbox.jl: Quantum Toolbox in Julia
≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
Copyright © QuTiP team 2022 and later.
Current admin team:
    Alberto Mercurio and Yi-Te Huang

Package information:
====================================
Julia              Ver. 1.12.6
QuantumToolbox     Ver. 0.47.3
QuantumToolboxCore Ver. 0.1.0
------------------------------------
Dependencies:
SciMLOperators     Ver. 1.30.0
SciMLBase          Ver. 3.50.2
OrdinaryDiffEqCore Ver. 4.16.0
LinearSolve        Ver. 5.15.1
------------------------------------
Triggered extensions:
GPUArrays          Ver. 11.5.6
KernelAbstractions Ver. 0.9.41
CUDACore           Ver. 6.1.1
cuSPARSE           Ver. 6.1.0
```