### PR TITLE
[Fix] code coverage and setup `codecov.yml`

### DIFF
--- a/.buildkite/CUDA_Ext.yml
+++ b/.buildkite/CUDA_Ext.yml
@@ -10,7 +10,6 @@ steps:
           dirs:
             - src
             - lib
-            - ext
     agents:
       queue: "cuda"
     commands: |
@@ -48,7 +47,6 @@ steps:
           dirs:
             - src
             - lib
-            - ext
     agents:
       queue: "cuda"
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,11 +15,12 @@ steps:
     plugins:
       - staticfloat/forerunner: # CUDA.jl tests
           watch:
-            - "codecov.yml"
             - ".buildkite/pipeline.yml"
             - ".buildkite/CUDA_Ext.yml"
             - "src/**"
             - "lib/QuantumToolboxCore/**"
             - "test/runtests.jl"
             - "test/ext-test/gpu/**"
+            - 'Project.toml'
+            - 'codecov.yml'
           target: ".buildkite/CUDA_Ext.yml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,6 +15,7 @@ steps:
     plugins:
       - staticfloat/forerunner: # CUDA.jl tests
           watch:
+            - "codecov.yml"
             - ".buildkite/pipeline.yml"
             - ".buildkite/CUDA_Ext.yml"
             - "src/**"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,7 @@ on:
       - 'test/main-test/**'
       - 'test/ext-test/cpu/**'
       - 'Project.toml'
+      - 'codecov.yml'
   pull_request:
     branches:
       - 'main'
@@ -25,6 +26,7 @@ on:
       - 'test/main-test/**'
       - 'test/ext-test/cpu/**'
       - 'Project.toml'
+      - 'codecov.yml'
     types:
       - opened
       - reopened
@@ -111,11 +113,7 @@ jobs:
           JULIA_NUM_THREADS: auto
       - uses: julia-actions/julia-processcoverage@v1
         with:
-          directories: |-
-            src,
-            ext,
-            lib/QuantumToolboxCore/src,
-            lib/QuantumToolboxCore/ext
+          directories: src,ext,lib
       - uses: codecov/codecov-action@v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -113,7 +113,7 @@ jobs:
           JULIA_NUM_THREADS: auto
       - uses: julia-actions/julia-processcoverage@v1
         with:
-          directories: src,ext,lib
+          directories: src,lib,ext
       - uses: codecov/codecov-action@v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -111,7 +111,11 @@ jobs:
           JULIA_NUM_THREADS: auto
       - uses: julia-actions/julia-processcoverage@v1
         with:
-          directories: src,ext
+          directories: |-
+            src,
+            ext,
+            lib/QuantumToolboxCore/src,
+            lib/QuantumToolboxCore/ext
       - uses: codecov/codecov-action@v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - "docs/**"
+  - "benchmarks/**"
+  - "**/test/**"


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] Any code changes were done in a way that does not break public API.
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [x] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
The current codecov does not cover the source files located in `Core` library.

In this PR, we make sure the CI pipelines include all `*.jl` files under `src`, `ext`, and `lib`. However, we setup `codecov.yml` to ignore coverage for files in `**/test/**`.
